### PR TITLE
chore: プロジェクトのブランディングと設定を更新

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd /home/amkkr/repos/lazy-note && pnpm test:run && pnpm lint && pnpm prepare"
+            "command": "cd $HOME/repos/lazy-note && pnpm test:run && pnpm lint && pnpm type-check && pnpm prepare"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,4 @@
+
 {
   "permissions": {
     "allow": [
@@ -15,28 +16,7 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit",
-        "path_pattern": ".*\\.(ts|tsx)$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "cd /home/amkkr/repos/lazy-note && pnpm test:run && pnpm lint && pnpm prepare"
-          }
-        ]
-      },
-      {
-        "matcher": "Write",
-        "path_pattern": ".*\\.(ts|tsx)$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "cd /home/amkkr/repos/lazy-note && pnpm test:run && pnpm lint && pnpm prepare"
-          }
-        ]
-      },
-      {
-        "matcher": "MultiEdit",
-        "path_pattern": ".*\\.(ts|tsx)$",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,49 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)",
+      "Bash(git pull:*)",
+      "Bash(git commit:*)",
+      "WebFetch(domain:docs.anthropic.com)",
+      "Bash(ls:*)"
+    ],
+    "deny": []
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit",
+        "path_pattern": ".*\\.(ts|tsx)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd /home/amkkr/repos/lazy-note && pnpm test:run && pnpm lint && pnpm prepare"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "path_pattern": ".*\\.(ts|tsx)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd /home/amkkr/repos/lazy-note && pnpm test:run && pnpm lint && pnpm prepare"
+          }
+        ]
+      },
+      {
+        "matcher": "MultiEdit",
+        "path_pattern": ".*\\.(ts|tsx)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd /home/amkkr/repos/lazy-note && pnpm test:run && pnpm lint && pnpm prepare"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Lazy Note</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -5,13 +5,15 @@
   "type": "module",
   "scripts": {
     "dev": "panda --watch & vite",
-    "build": "pnpm run lint && pnpm run test:run && panda && tsc && vite build",
+    "build": "pnpm run lint && pnpm run test:run && pnpm run type-check && panda && tsc && vite build",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
     "test:ui": "vitest --ui",
     "fmt": "biome check --write --unsafe ./src",
     "lint": "biome lint  ./src",
+    "type-check": "tsc --noEmit",
+    "type-check:test": "tsc --noEmit --project tsconfig.test.json",
     "prepare": "panda codegen",
     "new-post": "node scripts/newPost.ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sample-vite-react",
+  "name": "lazy-note",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/components/common/BrandName.tsx
+++ b/src/components/common/BrandName.tsx
@@ -17,7 +17,7 @@ export const BrandName = ({ variant = 'header', showIcon = true }: BrandNameProp
         marginBottom: '4px'
       })
     })}>
-      {showIcon && '✨ '}Creative Blog
+      {showIcon && '✨ '}Lazy Note
     </div>
   );
 };

--- a/src/components/common/__tests__/BrandName.test.tsx
+++ b/src/components/common/__tests__/BrandName.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BrandName } from "../BrandName";
+
+describe("BrandName", () => {
+  it("ヘッダーバリアントで正しく表示される", () => {
+    render(<BrandName variant="header" />);
+    
+    const brandName = screen.getByText("✨ Lazy Note");
+    expect(brandName).toBeInTheDocument();
+    // Panda CSSはfs_20pxのようなクラス名を生成する
+    expect(brandName.className).toContain("fs_20px");
+  });
+
+  it("フッターバリアントで正しく表示される", () => {
+    render(<BrandName variant="footer" />);
+    
+    const brandName = screen.getByText("✨ Lazy Note");
+    expect(brandName).toBeInTheDocument();
+    // Panda CSSはfs_14pxのようなクラス名を生成する
+    expect(brandName.className).toContain("fs_14px");
+  });
+
+  it("デフォルトでヘッダーバリアントが使用される", () => {
+    render(<BrandName />);
+    
+    const brandName = screen.getByText("✨ Lazy Note");
+    expect(brandName).toBeInTheDocument();
+  });
+
+  it("showIcon=falseの時、アイコンが表示されない", () => {
+    render(<BrandName showIcon={false} />);
+    
+    const brandName = screen.getByText("Lazy Note");
+    expect(brandName).toBeInTheDocument();
+    expect(brandName.textContent).not.toContain("✨");
+  });
+
+  it("showIcon=trueの時、アイコンが表示される", () => {
+    render(<BrandName showIcon={true} />);
+    
+    const brandName = screen.getByText("✨ Lazy Note");
+    expect(brandName).toBeInTheDocument();
+    expect(brandName.textContent).toContain("✨");
+  });
+});

--- a/src/components/common/__tests__/EmptyState.test.tsx
+++ b/src/components/common/__tests__/EmptyState.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EmptyState } from "../EmptyState";
+
+interface MockLinkProps {
+  children: React.ReactNode;
+  to: string;
+  [key: string]: unknown;
+}
+
+// React Routerのモック
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    Link: ({ children, to, ...props }: MockLinkProps) => (
+      <a href={to} {...props}>{children}</a>
+    ),
+  };
+});
+
+describe("EmptyState", () => {
+  const defaultProps = {
+    icon: "📝",
+    title: "まだ記事がありません",
+    description: "最初の記事を作成してみましょう",
+  };
+
+  it("アイコン、タイトル、説明文が正しく表示される", () => {
+    render(<EmptyState {...defaultProps} />);
+    
+    expect(screen.getByText("📝")).toBeInTheDocument();
+    expect(screen.getByText("まだ記事がありません")).toBeInTheDocument();
+    expect(screen.getByText("最初の記事を作成してみましょう")).toBeInTheDocument();
+  });
+
+  it("アクションボタンが設定されている場合、正しく表示される", () => {
+    const action = {
+      label: "記事を作成",
+      href: "/posts/new",
+    };
+    
+    render(<EmptyState {...defaultProps} action={action} />);
+    
+    const actionLink = screen.getByText("記事を作成");
+    expect(actionLink).toBeInTheDocument();
+    expect(actionLink).toHaveAttribute("href", "/posts/new");
+  });
+
+  it("アクションボタンが設定されていない場合、表示されない", () => {
+    render(<EmptyState {...defaultProps} />);
+    
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("異なるアイコンが正しく表示される", () => {
+    render(<EmptyState {...defaultProps} icon="🔍" />);
+    
+    expect(screen.getByText("🔍")).toBeInTheDocument();
+    expect(screen.queryByText("📝")).not.toBeInTheDocument();
+  });
+
+  it("長いテキストでも正しくレイアウトされる", () => {
+    const longProps = {
+      icon: "📚",
+      title: "これは非常に長いタイトルのテストです。レイアウトが崩れないことを確認します。",
+      description: "これは非常に長い説明文のテストです。複数行にわたる長い文章でも、適切にレイアウトされることを確認します。テキストが折り返され、読みやすい形で表示されることを検証します。",
+    };
+    
+    render(<EmptyState {...longProps} />);
+    
+    expect(screen.getByText(longProps.title)).toBeInTheDocument();
+    expect(screen.getByText(longProps.description)).toBeInTheDocument();
+  });
+});

--- a/src/components/common/__tests__/GradientBox.test.tsx
+++ b/src/components/common/__tests__/GradientBox.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GradientBox } from "../GradientBox";
+
+describe("GradientBox", () => {
+  it("子要素が正しくレンダリングされる", () => {
+    render(
+      <GradientBox>
+        <div>テストコンテンツ</div>
+      </GradientBox>
+    );
+    
+    expect(screen.getByText("テストコンテンツ")).toBeInTheDocument();
+  });
+
+  it("primaryバリアントがデフォルトで適用される", () => {
+    const { container } = render(
+      <GradientBox>
+        <div>コンテンツ</div>
+      </GradientBox>
+    );
+    
+    const gradientBox = container.firstChild as HTMLElement;
+    // Panda CSSで生成されたスタイルの確認
+    expect(gradientBox).toBeInTheDocument();
+    expect(gradientBox.className).toContain("pos_relative");
+  });
+
+  it("accentバリアントが正しく適用される", () => {
+    const { container } = render(
+      <GradientBox variant="accent">
+        <div>コンテンツ</div>
+      </GradientBox>
+    );
+    
+    const gradientBox = container.firstChild as HTMLElement;
+    // バリアントの違いを確認するため、要素の存在を確認
+    expect(gradientBox).toBeInTheDocument();
+  });
+
+  it("showPattern=trueの時、パターンオーバーレイが表示される", () => {
+    const { container } = render(
+      <GradientBox showPattern={true}>
+        <div>コンテンツ</div>
+      </GradientBox>
+    );
+    
+    // パターンオーバーレイは2番目の子要素として追加される
+    const gradientBox = container.firstChild as HTMLElement;
+    const patternOverlay = gradientBox.firstChild;
+    expect(patternOverlay).toBeInTheDocument();
+    // position: absoluteクラスを確認
+    expect(patternOverlay).toHaveClass(/pos_absolute/);
+  });
+
+  it("showPattern=falseの時、パターンオーバーレイが表示されない", () => {
+    const { container } = render(
+      <GradientBox showPattern={false}>
+        <div>コンテンツ</div>
+      </GradientBox>
+    );
+    
+    // パターンオーバーレイのdivが存在しないことを確認
+    const patternOverlay = container.querySelector('[class*="position"][class*="absolute"]');
+    expect(patternOverlay).not.toBeInTheDocument();
+  });
+
+  it("カスタムclassNameが適用される", () => {
+    const { container } = render(
+      <GradientBox className="custom-class">
+        <div>コンテンツ</div>
+      </GradientBox>
+    );
+    
+    const gradientBox = container.firstChild as HTMLElement;
+    expect(gradientBox.className).toContain("custom-class");
+  });
+
+  it("複数の子要素を含むことができる", () => {
+    render(
+      <GradientBox>
+        <h1>タイトル</h1>
+        <p>説明文</p>
+        <button type="button">ボタン</button>
+      </GradientBox>
+    );
+    
+    expect(screen.getByText("タイトル")).toBeInTheDocument();
+    expect(screen.getByText("説明文")).toBeInTheDocument();
+    expect(screen.getByText("ボタン")).toBeInTheDocument();
+  });
+});

--- a/src/components/common/__tests__/LoadingSpinner.test.tsx
+++ b/src/components/common/__tests__/LoadingSpinner.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LoadingSpinner } from "../LoadingSpinner";
+
+describe("LoadingSpinner", () => {
+  it("デフォルトのメッセージが表示される", () => {
+    render(<LoadingSpinner />);
+    
+    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
+  });
+
+  it("カスタムメッセージが表示される", () => {
+    render(<LoadingSpinner message="データを取得しています" />);
+    
+    expect(screen.getByText("データを取得しています")).toBeInTheDocument();
+    expect(screen.queryByText("読み込み中...")).not.toBeInTheDocument();
+  });
+
+  it("スピナー要素が存在する", () => {
+    const { container } = render(<LoadingSpinner />);
+    
+    // LoadingSpinnerコンポーネントがレンダリングされていることを確認
+    expect(container.firstChild).toBeInTheDocument();
+    // メッセージと一緒にスピナーも描画される
+    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
+  });
+
+  it("空のメッセージを渡してもレンダリングされる", () => {
+    render(<LoadingSpinner message="" />);
+    
+    // 空のメッセージの場合、p要素は存在するが中身は空
+    const messageElement = screen.getByText((content, element) => {
+      return element?.tagName === 'P' && content === '';
+    });
+    expect(messageElement).toBeInTheDocument();
+  });
+
+  it("長いメッセージでも正しく表示される", () => {
+    const longMessage = "これは非常に長いローディングメッセージです。複数行にわたる可能性があります。";
+    render(<LoadingSpinner message={longMessage} />);
+    
+    expect(screen.getByText(longMessage)).toBeInTheDocument();
+  });
+
+  it("複数のLoadingSpinnerを同時にレンダリングできる", () => {
+    render(
+      <>
+        <LoadingSpinner message="ローディング1" />
+        <LoadingSpinner message="ローディング2" />
+      </>
+    );
+    
+    expect(screen.getByText("ローディング1")).toBeInTheDocument();
+    expect(screen.getByText("ローディング2")).toBeInTheDocument();
+  });
+});

--- a/src/components/common/__tests__/MetaInfo.test.tsx
+++ b/src/components/common/__tests__/MetaInfo.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MetaInfo } from "../MetaInfo";
+
+describe("MetaInfo", () => {
+  it("作成日と著者が正しく表示される", () => {
+    render(<MetaInfo createdAt="2024-01-01" author="山田太郎" />);
+    
+    expect(screen.getByText("2024-01-01")).toBeInTheDocument();
+    expect(screen.getByText("山田太郎")).toBeInTheDocument();
+    expect(screen.getByText("📅")).toBeInTheDocument();
+    expect(screen.getByText("✍️")).toBeInTheDocument();
+  });
+
+  it("作成日が未設定の場合、デフォルトテキストが表示される", () => {
+    render(<MetaInfo author="山田太郎" />);
+    
+    expect(screen.getByText("日付未設定")).toBeInTheDocument();
+    expect(screen.getByText("山田太郎")).toBeInTheDocument();
+  });
+
+  it("著者が未設定の場合、デフォルトテキストが表示される", () => {
+    render(<MetaInfo createdAt="2024-01-01" />);
+    
+    expect(screen.getByText("2024-01-01")).toBeInTheDocument();
+    expect(screen.getByText("匿名")).toBeInTheDocument();
+  });
+
+  it("両方未設定の場合、両方のデフォルトテキストが表示される", () => {
+    render(<MetaInfo />);
+    
+    expect(screen.getByText("日付未設定")).toBeInTheDocument();
+    expect(screen.getByText("匿名")).toBeInTheDocument();
+  });
+
+  it("cardバリアントがデフォルトで適用される", () => {
+    const { container } = render(<MetaInfo createdAt="2024-01-01" author="山田太郎" />);
+    
+    // cardバリアントの場合、marginTopとpaddingTopが適用される
+    const metaInfo = container.firstChild as HTMLElement;
+    expect(metaInfo.className).toContain("mt_16px");
+    expect(metaInfo.className).toContain("pt_16px");
+  });
+
+  it("headerバリアントが正しく適用される", () => {
+    const { container } = render(
+      <MetaInfo createdAt="2024-01-01" author="山田太郎" variant="header" />
+    );
+    
+    // headerバリアントの場合、子要素に背景が適用される
+    const metaInfo = container.firstChild as HTMLElement;
+    const dateElement = metaInfo.querySelector('[class*="bg_"]');
+    expect(dateElement).toBeInTheDocument();
+  });
+
+  it("空文字列を渡した場合、デフォルトテキストが表示される", () => {
+    render(<MetaInfo createdAt="" author="" />);
+    
+    expect(screen.getByText("日付未設定")).toBeInTheDocument();
+    expect(screen.getByText("匿名")).toBeInTheDocument();
+  });
+
+  it("長いテキストでも正しくレイアウトされる", () => {
+    render(
+      <MetaInfo 
+        createdAt="2024年12月31日 23時59分59秒" 
+        author="非常に長い名前を持つ著者の名前です" 
+      />
+    );
+    
+    expect(screen.getByText("2024年12月31日 23時59分59秒")).toBeInTheDocument();
+    expect(screen.getByText("非常に長い名前を持つ著者の名前です")).toBeInTheDocument();
+  });
+});

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="vite/client" />
+/// <reference types="vitest/globals" />
 /// <reference types="@testing-library/jest-dom" />

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,5 +7,5 @@
     "allowSyntheticDefaultImports": true,
     "strict": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "panda.config.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
-  "exclude": ["**/__tests__/**/*"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "types": ["vitest/globals", "@testing-library/jest-dom"],
+  "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client"],
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": [
+    "src/**/*",
+    "src/**/__tests__/**/*"
+  ],
+  "exclude": []
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,5 +60,10 @@ export default defineConfig({
       'src/**/__tests__/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'
     ],
+    typecheck: {
+      checker: 'tsc',
+      include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      tsconfig: './tsconfig.test.json'
+    }
   }
 })


### PR DESCRIPTION
## Summary
プロジェクトのブランディングを統一し、開発環境の設定を改善しました。

## Changes

### 🎨 ブランディングの統一
- HTMLタイトルを「Lazy Note」に変更
- BrandNameコンポーネントを「Lazy Note」に統一
- 関連するテストコードを更新

### ⚙️ TypeScript設定の改善
- `tsconfig.node.json` → `tsconfig.build.json`にリネーム（用途を明確化）
- テスト用の`tsconfig.test.json`を追加
- 型チェックコマンドを追加 (`type-check`, `type-check:test`)

### 🧪 テストコードの追加
- `src/components/common`配下の全コンポーネントにテストを追加
  - BrandName, EmptyState, GradientBox, LoadingSpinner, MetaInfo
- @testing-library/jest-domの型定義問題を解決

### 🔧 品質管理の強化
- Claudeのhooksに型チェックを追加（test → lint → type-check → prepare）
- Vitestの設定を改善（型定義対応）

## Test Results
- ✅ **テスト**: 9ファイル、53テスト、すべて成功
- ✅ **リント**: 26ファイル、エラーなし
- ✅ **型チェック**: エラーなし

🤖 Generated with [Claude Code](https://claude.ai/code)