### PR TITLE
chore: PRテンプレート使用ルールをCLAUDE.mdに追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ Panda CSSを使用しているため、スタイルは以下のパターンで�
 6. **直接マージ禁止**: 開発ブランチを直接masterにマージしてはならない
 7. **Pull Request必須**: マージは必ずGithubにpushして、Pull Requestを通して行うこと
 8. **rebase禁止**: `git rebase`コマンドは使用しない。コンフリクト解決時は`git merge`を使用すること
+9. **PRテンプレート使用**: Pull Requestの内容は`.github/pull_request_template.md`を元に作成すること
 
 ### ブランチ名の例
 


### PR DESCRIPTION
## 概要
CLAUDE.mdのGitブランチ運用ルールに、PRテンプレート使用に関するルールを追加しました。

## 変更内容

- CLAUDE.mdに9番目のルールとして「PRテンプレート使用: Pull Requestの内容は`.github/pull_request_template.md`を元に作成すること」を追加

## 備考
今後のPR作成時には、このテンプレートを使用することで統一されたフォーマットでの情報提供が可能になります。

🤖 Generated with [Claude Code](https://claude.ai/code)