### PR TITLE
fix: MetaInfoのborder-radiusを削除し、セクション間の分割方法を変更

### DIFF
--- a/src/components/common/MetaInfo.tsx
+++ b/src/components/common/MetaInfo.tsx
@@ -16,8 +16,7 @@ export const MetaInfo = ({ createdAt, author, variant = 'card' }: MetaInfoProps)
       justifyContent: 'space-between',
       gap: '16px',
       ...(variant === 'card' && {
-        marginTop: '16px',
-        paddingTop: '16px'
+        marginTop: '0'
       })
     })}>
       <div className={css({
@@ -28,8 +27,7 @@ export const MetaInfo = ({ createdAt, author, variant = 'card' }: MetaInfoProps)
         color: isHeader ? 'white' : '#6b7280',
         ...(isHeader && {
           background: 'rgba(255, 255, 255, 0.2)',
-          padding: '8px 16px',
-          borderRadius: '20px'
+          padding: '8px 16px'
         })
       })}>
         <span>📅</span>
@@ -43,8 +41,7 @@ export const MetaInfo = ({ createdAt, author, variant = 'card' }: MetaInfoProps)
         color: isHeader ? 'white' : '#6b7280',
         ...(isHeader && {
           background: 'rgba(255, 255, 255, 0.2)',
-          padding: '8px 16px',
-          borderRadius: '20px'
+          padding: '8px 16px'
         })
       })}>
         <span>✍️</span>

--- a/src/components/common/__tests__/MetaInfo.test.tsx
+++ b/src/components/common/__tests__/MetaInfo.test.tsx
@@ -36,10 +36,10 @@ describe("MetaInfo", () => {
   it("cardバリアントがデフォルトで適用される", () => {
     const { container } = render(<MetaInfo createdAt="2024-01-01" author="山田太郎" />);
     
-    // cardバリアントの場合、marginTopとpaddingTopが適用される
+    // cardバリアントの場合、marginとpaddingが0に設定される
     const metaInfo = container.firstChild as HTMLElement;
-    expect(metaInfo.className).toContain("mt_16px");
-    expect(metaInfo.className).toContain("pt_16px");
+    expect(metaInfo.className).toContain("mt_0");
+    expect(metaInfo.className).toContain("pt_0");
   });
 
   it("headerバリアントが正しく適用される", () => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -51,8 +51,10 @@ const Index = () => {
                 >
                   <div className={css({ 
                     padding: 'card',
-                    paddingBottom: '12px',
-                    paddingX: '12px'
+                    paddingBottom: '16px',
+                    paddingX: '12px',
+                    borderBottom: '1px solid',
+                    borderColor: 'surface.200'
                   })}>
                     <MetaInfo
                       createdAt={post.createdAt}

--- a/src/pages/posts/[timestamp].tsx
+++ b/src/pages/posts/[timestamp].tsx
@@ -107,6 +107,12 @@ const PostDetail = () => {
               />
             </header>
 
+            {/* Divider */}
+            <div className={css({
+              height: "1px",
+              background: "surface.200"
+            })} />
+
             {/* Article Content */}
             <main
               className={css({


### PR DESCRIPTION
## 概要
MetaInfoコンポーネントのborder-radiusを削除し、日付・筆者セクションと本文セクションの分割方法を変更しました。

## 変更内容

- MetaInfoコンポーネントからborder-radiusを削除
  - headerバリアントで使用されていたborder-radius: 20pxを削除
  
- セクション間の分割方法を変更
  - 記事一覧ページ: MetaInfoセクションと本文セクションの間に1pxのborderを追加
  - 記事詳細ページ: ヘッダーとメインコンテンツの間に1pxの区切り線を追加
  - MetaInfoのcardバリアントのpaddingTopを削除し、よりシンプルなレイアウトに変更

## 備考
より明確な視覚的階層を作り、コンテンツ間の分離を改善しました。

🤖 Generated with [Claude Code](https://claude.ai/code)