### PR TITLE
fix: CI環境でのPanda CSSテストエラーを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Generate Panda CSS
+        run: pnpm prepare
+
       - name: Run linter
         run: pnpm lint
 

--- a/src/components/common/MetaInfo.tsx
+++ b/src/components/common/MetaInfo.tsx
@@ -15,10 +15,8 @@ export const MetaInfo = ({ createdAt, author, variant = 'card' }: MetaInfoProps)
       alignItems: 'center',
       justifyContent: 'space-between',
       gap: '16px',
-      ...(variant === 'card' && {
-        marginTop: '16px',
-        paddingTop: '16px'
-      })
+      marginTop: variant === 'card' ? '16px' : '0',
+      paddingTop: variant === 'card' ? '16px' : '0'
     })}>
       <div className={css({
         display: 'flex',


### PR DESCRIPTION
## Summary
- CI環境でMetaInfo.test.tsxのテストが失敗する問題を修正
- Panda CSSの条件付きスタイル生成に関する環境差異を解消

## 変更内容
1. **CI workflowの改善** (`.github/workflows/ci.yml`)
   - テスト実行前に`pnpm prepare`ステップを追加
   - styled-systemディレクトリが確実に生成されるように修正

2. **MetaInfoコンポーネントの修正** (`src/components/common/MetaInfo.tsx`)
   - スプレッド演算子による条件付きスタイルを三項演算子に変更
   - CI環境でのPanda CSS静的解析をより安定化

## 問題の詳細
CI環境で以下のエラーが発生していました：
```
expected 'd_flex ai_center jc_space-between gap…' to contain 'mt_16px'
Expected: "mt_16px"
Received: "d_flex ai_center jc_space-between gap_16px mt_0"
```

これは、Panda CSSがスプレッド演算子による条件付きスタイルを静的解析時に正しく処理できていなかったためです。

## Test plan
- [x] ローカル環境でのテスト実行確認
- [x] 全テストスイートの実行確認
- [ ] CI環境でのテスト成功確認

🤖 Generated with [Claude Code](https://claude.ai/code)