### PR TITLE
chore: ナビゲーションリンクをLazy Noteに統一

### DIFF
--- a/src/pages/posts/[timestamp].tsx
+++ b/src/pages/posts/[timestamp].tsx
@@ -60,7 +60,7 @@ const PostDetail = () => {
               },
             })}
           >
-            ← Creative Blog に戻る
+            ← Lazy Note に戻る
           </Link>
         </nav>
 


### PR DESCRIPTION
## Summary
- 記事詳細ページの戻るリンクテキストを「Creative Blog」から「Lazy Note」に変更
- UIのテキストをプロジェクト名に合わせて統一

## Test plan
- [ ] 記事詳細ページでナビゲーションリンクが正しく表示されることを確認
- [ ] リンクのクリック動作が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)