### PR TITLE
fix: Markdownコンテンツが正しくレンダリングされない問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",
+    "dompurify": "^3.2.6",
     "marked": "^16.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@headlessui/react':
         specifier: ^2.2.4
         version: 2.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      dompurify:
+        specifier: ^3.2.6
+        version: 3.2.6
       marked:
         specifier: ^16.0.0
         version: 16.0.0
@@ -744,6 +747,9 @@ packages:
   '@types/react@19.1.8':
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@vitejs/plugin-react@4.6.0':
     resolution: {integrity: sha512-5Kgff+m8e2PB+9j51eGHEpn5kUzRKH2Ry0qGoe8ItJg7pqnkPrYPkDQZGgGmTa0EGarHrkjLvOdU3b1fzI8otQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -973,6 +979,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.2.6:
+    resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
 
   electron-to-chromium@1.5.178:
     resolution: {integrity: sha512-wObbz/ar3Bc6e4X5vf0iO8xTN8YAjN/tgiAOJLr7yjYFtP9wAjq8Mb5h0yn6kResir+VYx2DXBj9NNobs0ETSA==}
@@ -2512,6 +2521,9 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@vitejs/plugin-react@4.6.0(vite@6.3.5(lightningcss@1.25.1)(yaml@2.8.0))':
     dependencies:
       '@babel/core': 7.27.7
@@ -2748,6 +2760,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.2.6:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   electron-to-chromium@1.5.178: {}
 

--- a/src/pages/posts/[timestamp].tsx
+++ b/src/pages/posts/[timestamp].tsx
@@ -1,3 +1,4 @@
+import DOMPurify from "dompurify";
 import { Link, useParams } from "react-router-dom";
 import { css } from "../../../styled-system/css";
 import { Layout } from "../../components/Layout";
@@ -163,7 +164,12 @@ const PostDetail = () => {
                 },
               })}
             >
-              <div>{post.content}</div>
+              <div
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: MarkdownをHTMLとして表示するために必要。DOMPurifyでサニタイズ済み
+                dangerouslySetInnerHTML={{
+                  __html: DOMPurify.sanitize(post.content),
+                }}
+              />
             </main>
           </article>
         </div>


### PR DESCRIPTION
## 概要
投稿詳細ページ（`/posts/[timestamp]`）でMarkdownコンテンツのHTMLタグが文字列として表示される問題を修正しました。

## 変更内容

- `dangerouslySetInnerHTML`を使用してMarkdownから変換されたHTMLを適切にレンダリング
- XSS対策として`DOMPurify`ライブラリを追加し、HTMLコンテンツをサニタイズ
- Biomeのセキュリティ警告に対して、意図的な使用であることを示すコメントを追加

## 備考

- DOMPurifyによりXSS攻撃を防ぎながら、安全にHTMLコンテンツを表示できます

🤖 Generated with [Claude Code](https://claude.ai/code)