### PR TITLE
chore: dependabotの設定から不要なパラメータを削除

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,8 @@ updates:
       time: "09:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
-    reviewers:
-      - "amkkr"
     assignees:
       - "amkkr"
     commit-message:
       prefix: "deps"
       include: "scope"
-    labels:
-      - "dependencies"


### PR DESCRIPTION
## 概要
dependabot.ymlから不要なパラメータを削除しました。

## 変更内容
- `reviewers`パラメータを削除（assigneesで十分なため）
- `labels`パラメータを削除（デフォルトの動作で問題ないため）

## 理由
- reviewersとassigneesの両方を設定する必要はなく、assigneesのみで十分です
- labelsは特に必要ない場合は省略可能です

## 関連Issue
なし

## チェックリスト
- [x] コードがプロジェクトのコーディング規約に従っている
- [x] 必要なテストを追加/更新した
- [x] ドキュメントを更新した（必要な場合）

🤖 Generated with [Claude Code](https://claude.ai/code)