### PR TITLE
chore: pnpm approve-buildsした

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+ignoredBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
## 概要

`pnpm i` したところ以下の内容のwarningが出た
これの修正

```bash
╭ Warning ───────────────────────────────────────────────────────────────────────────────────╮
│                                                                                            │
│   Ignored build scripts: esbuild.                                                          │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.   │
│                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
```

参考:https://github.com/orgs/pnpm/discussions/9322


## 変更内容

- メッセージにある`pnpm approve-builds`をたたいてその差分を反映

## 備考
