### PR TITLE
fix: TypeScriptの型エラーを修正

### DIFF
--- a/src/api/__tests__/posts.test.ts
+++ b/src/api/__tests__/posts.test.ts
@@ -35,9 +35,8 @@ describe("createPostsMiddleware", () => {
   describe("投稿一覧の取得", () => {
     it("GET /api/posts で投稿一覧を返す", () => {
       const mockFiles = ["20250101.md", "20250102.md", "test.txt"];
-      vi.mocked(fs.readdirSync).mockReturnValue(
-        mockFiles as unknown as fs.Dirent[],
-      );
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+      vi.mocked(fs.readdirSync).mockReturnValue(mockFiles as any);
 
       middleware(req as IncomingMessage, res as ServerResponse, next);
 
@@ -56,9 +55,8 @@ describe("createPostsMiddleware", () => {
 
     it("Markdown ファイルのみをフィルタリングする", () => {
       const mockFiles = ["post.md", "image.png", "data.json", "note.md"];
-      vi.mocked(fs.readdirSync).mockReturnValue(
-        mockFiles as unknown as fs.Dirent[],
-      );
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+      vi.mocked(fs.readdirSync).mockReturnValue(mockFiles as any);
 
       middleware(req as IncomingMessage, res as ServerResponse, next);
 


### PR DESCRIPTION
## 概要
`src/api/__tests__/posts.test.ts`で発生していたTypeScriptの型エラーを修正しました。

## 変更内容
- `fs.readdirSync`のモックで`any`型を使用するように変更
- Biomeのエラーを回避するためのアノテーションコメントを追加

## 背景
`fs.readdirSync`のモック時に、`string[]`を`fs.Dirent[]`として扱おうとしていたため型エラーが発生していました。
テストファイルでのモックであることを考慮し、`any`型の使用を許可することで解決しました。

## 確認項目
- [x] TypeScriptの型チェック（`pnpm exec tsc --noEmit`）が成功
- [x] テスト（`pnpm test:run`）がすべてパス  
- [x] Lintチェック（`pnpm lint`）が成功

🤖 Generated with Claude Code