### PR TITLE
chore: Dependabotの実行時刻を朝6:30に変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-      time: "09:00"
+      time: "06:30"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
     assignees:


### PR DESCRIPTION
## 概要
Dependabotの実行時刻を土曜日朝9:00から6:30に変更します。

## 変更内容
- 毎週土曜日の実行時刻を09:00から06:30に変更

## 理由
より早い時間に依存関係の更新を確認できるようにするため

## テスト
- [ ] `.github/dependabot.yml`の構文が正しいことを確認
- [ ] GitHub上でDependabot設定が正しく認識されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)