### PR TITLE
fix: PostDetailPageのpadding設定を個別プロパティに分割

### DIFF
--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -92,7 +92,9 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
             {/* Article Content */}
             <main
               className={css({
-                padding: "section",
+                paddingRight: "section",
+                paddingLeft: "section",
+                paddingBottom: "section",
                 lineHeight: "body",
                 fontSize: "base",
                 color: "fg.1",


### PR DESCRIPTION
## 概要
PostDetailPageコンポーネントのpadding設定を個別プロパティに分割し、記事コンテンツ上部の余白を削除しました。

## 変更内容
- `padding: "section"` を以下に分割：
  - `paddingRight: "section"`
  - `paddingLeft: "section"`
  - `paddingBottom: "section"`
- 上部のpaddingを削除することで、ヘッダーと記事コンテンツの間の余白を調整

## テスト
- [x] ビルドが成功することを確認
- [x] テストがパスすることを確認
- [x] プレビューでレイアウトが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)