### PR TITLE
fix: React RouterにベースURLを設定してプレビュー環境で正しく動作するように修正

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,7 +23,7 @@ if (rootElement === null) {
 }
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <App />
     </BrowserRouter>
   </React.StrictMode>,


### PR DESCRIPTION
## 概要
React RouterのBrowserRouterにbasename属性を追加し、プロダクションビルド環境（`/lazy-note/`パス）でアプリケーションが正しく動作するように修正しました。

## 問題
- `pnpm preview`実行時、`http://localhost:4173/lazy-note/`でアクセスしても白い画面が表示される
- React Routerがベースパスを認識していないため、ルーティングが正しく機能しない

## 解決策
- `BrowserRouter`に`basename={import.meta.env.BASE_URL}`を設定
- Viteの`base`設定と連動してReact Routerが正しいパスを認識

## 変更内容
- `src/main.tsx`: BrowserRouterコンポーネントにbasename属性を追加

## テスト
- [x] `pnpm build`でビルドが成功することを確認
- [x] `pnpm preview`で`http://localhost:4173/lazy-note/`にアクセスして正常に表示されることを確認
- [x] 開発環境（`pnpm dev`）で引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)