### PR TITLE
fix: Headerコンポーネントのpadding設定を個別プロパティに分割

### DIFF
--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -33,7 +33,8 @@ export const Header = ({ postCount }: HeaderProps) => {
           className={css({
             background: "bg.2",
             color: "fg.1",
-            padding: "sm",
+            paddingY: "sm",
+            paddingX: "md",
             borderRadius: "20px",
             fontSize: "sm",
             fontWeight: "bold",


### PR DESCRIPTION
## 概要
Headerコンポーネントの投稿数表示部分のスタイリングを改善しました。

## 変更内容

- `src/components/layouts/Header.tsx`の投稿数表示部分のpadding設定を`paddingY`と`paddingX`に分割
- 垂直方向は`sm`サイズを維持し、水平方向に`md`サイズの余白を追加

## 備考
この変更により、投稿数表示部分のレイアウトがより見やすくなります。

🤖 Generated with [Claude Code](https://claude.ai/code)