### PR TITLE
fix: 本番環境でのMarkdownファイル表示対応

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,8 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { registerApiMiddlewares } from "./src/api";
+import fs from "node:fs";
+import path from "node:path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -9,10 +11,28 @@ export default defineConfig({
   plugins: [
     react(),
     {
-      name: "datasources-watcher",
+      name: "datasources-plugin",
       configureServer(server) {
         // APIミドルウェアを登録
         registerApiMiddlewares(server);
+      },
+      generateBundle() {
+        // ビルド時にdatasourcesフォルダをdistにコピー
+        const datasourcesPath = path.resolve("datasources");
+        const outputPath = path.resolve("dist", "datasources");
+
+        if (fs.existsSync(datasourcesPath)) {
+          fs.mkdirSync(outputPath, { recursive: true });
+          const files = fs.readdirSync(datasourcesPath);
+          
+          for (const file of files) {
+            if (file.endsWith(".md")) {
+              const sourcePath = path.join(datasourcesPath, file);
+              const destPath = path.join(outputPath, file);
+              fs.copyFileSync(sourcePath, destPath);
+            }
+          }
+        }
       },
     },
   ],


### PR DESCRIPTION
## Summary
- 本番ビルド時にMarkdownファイルが表示されない問題を修正
- 開発環境では既存のAPIを使用、本番環境では静的ファイルとして読み込み
- Viteプラグインでビルド時にdatasourcesフォルダをdistにコピー

## Test plan
- [ ] 開発環境（pnpm dev）でMarkdownファイルが正常に表示されることを確認
- [ ] 本番ビルド（pnpm build）後にMarkdownファイルが正常に表示されることを確認
- [ ] 既存のテストが全て通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)