### PR TITLE
記事一覧にページング機能を実装

### DIFF
--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,0 +1,85 @@
+import { css } from "../../../styled-system/css";
+import { Button } from "../atoms/Button";
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+/**
+ * ページネーションコンポーネント
+ * 前へ/次へボタンと現在のページ情報を表示
+ */
+export const Pagination = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: PaginationProps) => {
+  const canGoPrevious = currentPage > 1;
+  const canGoNext = currentPage < totalPages;
+
+  const handlePrevious = () => {
+    if (canGoPrevious) {
+      onPageChange(currentPage - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (canGoNext) {
+      onPageChange(currentPage + 1);
+    }
+  };
+
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  return (
+    <nav
+      className={css({
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        gap: "16px",
+        marginTop: "32px",
+        paddingY: "24px",
+      })}
+      aria-label="ページネーション"
+    >
+      <Button
+        onClick={handlePrevious}
+        disabled={!canGoPrevious}
+        variant="secondary"
+        className={css({
+          minWidth: "100px",
+        })}
+      >
+        前へ
+      </Button>
+
+      <span
+        className={css({
+          fontSize: "16px",
+          fontWeight: "500",
+          color: "text.primary",
+          minWidth: "120px",
+          textAlign: "center",
+        })}
+      >
+        {currentPage} / {totalPages} ページ
+      </span>
+
+      <Button
+        onClick={handleNext}
+        disabled={!canGoNext}
+        variant="secondary"
+        className={css({
+          minWidth: "100px",
+        })}
+      >
+        次へ
+      </Button>
+    </nav>
+  );
+};

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -4,12 +4,21 @@ import { Link } from "../atoms/Link";
 import { Heading2 } from "../atoms/Typography";
 import { EmptyState } from "../common/EmptyState";
 import { MetaInfo } from "../common/MetaInfo";
+import { Pagination } from "../common/Pagination";
 
 interface HomePageProps {
   posts: Post[];
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
 }
 
-export const HomePage = ({ posts }: HomePageProps) => {
+export const HomePage = ({
+  posts,
+  currentPage,
+  totalPages,
+  onPageChange,
+}: HomePageProps) => {
   return (
     <div
       className={css({
@@ -26,55 +35,63 @@ export const HomePage = ({ posts }: HomePageProps) => {
           description="まもなく素晴らしい記事が公開される予定です。創造性に満ちたコンテンツをお届けします。"
         />
       ) : (
-        <div
-          className={css({
-            display: "flex",
-            flexDirection: "column",
-            gap: "32px",
-            paddingTop: "12px",
-          })}
-        >
-          {posts.map((post) => (
-            <article
-              key={post.id}
-              className={css({
-                background: "bg.1",
-                borderRadius: "12px",
-                overflow: "hidden",
-                boxShadow: "card",
-                transition: "transform 0.2s ease, box-shadow 0.2s ease",
-                "&:hover": {
-                  transform: "translateY(-4px)",
-                  boxShadow: "card-hover",
-                },
-              })}
-            >
-              <div
+        <>
+          <div
+            className={css({
+              display: "flex",
+              flexDirection: "column",
+              gap: "32px",
+              paddingTop: "12px",
+            })}
+          >
+            {posts.map((post) => (
+              <article
+                key={post.id}
                 className={css({
-                  padding: "card",
-                  paddingBottom: "16px",
-                  paddingX: "12px",
-                  borderBottom: "1px solid",
-                  borderColor: "surface.200",
+                  background: "bg.1",
+                  borderRadius: "12px",
+                  overflow: "hidden",
+                  boxShadow: "card",
+                  transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                  "&:hover": {
+                    transform: "translateY(-4px)",
+                    boxShadow: "card-hover",
+                  },
                 })}
               >
-                <MetaInfo
-                  createdAt={post.createdAt}
-                  author={post.author}
-                  variant="card"
-                />
-              </div>
+                <div
+                  className={css({
+                    padding: "card",
+                    paddingBottom: "16px",
+                    paddingX: "12px",
+                    borderBottom: "1px solid",
+                    borderColor: "surface.200",
+                  })}
+                >
+                  <MetaInfo
+                    createdAt={post.createdAt}
+                    author={post.author}
+                    variant="card"
+                  />
+                </div>
 
-              <div className={css({ padding: "card" })}>
-                <Link to={`/posts/${post.id}`} variant="card">
-                  <Heading2 variant="card">
-                    {post.title || "無題の記事"}
-                  </Heading2>
-                </Link>
-              </div>
-            </article>
-          ))}
-        </div>
+                <div className={css({ padding: "card" })}>
+                  <Link to={`/posts/${post.id}`} variant="card">
+                    <Heading2 variant="card">
+                      {post.title || "無題の記事"}
+                    </Heading2>
+                  </Link>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={onPageChange}
+          />
+        </>
       )}
     </div>
   );

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -1,28 +1,34 @@
 import { useEffect, useState } from "react";
 import { getAllPosts, type Post } from "../lib/markdown";
 
+const POSTS_PER_PAGE = 10;
+
 interface UsePostsReturn {
   posts: Post[];
   loading: boolean;
   error: string | null;
+  currentPage: number;
+  totalPages: number;
+  setCurrentPage: (page: number) => void;
 }
 
 /**
- * 記事一覧を取得するカスタムフック
- * @returns 記事一覧、ローディング状態、エラー状態
+ * 記事一覧を取得するカスタムフック（ページング機能付き）
+ * @returns 記事一覧、ローディング状態、エラー状態、ページング情報
  */
 export const usePosts = (): UsePostsReturn => {
-  const [posts, setPosts] = useState<Post[]>([]);
+  const [allPosts, setAllPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
     const loadPosts = async () => {
       try {
         setLoading(true);
         setError(null);
-        const allPosts = await getAllPosts();
-        setPosts(allPosts);
+        const posts = await getAllPosts();
+        setAllPosts(posts);
       } catch (err) {
         console.error("Failed to load posts:", err);
         setError(
@@ -36,5 +42,10 @@ export const usePosts = (): UsePostsReturn => {
     loadPosts();
   }, []);
 
-  return { posts, loading, error };
+  const totalPages = Math.ceil(allPosts.length / POSTS_PER_PAGE);
+  const startIndex = (currentPage - 1) * POSTS_PER_PAGE;
+  const endIndex = startIndex + POSTS_PER_PAGE;
+  const posts = allPosts.slice(startIndex, endIndex);
+
+  return { posts, loading, error, currentPage, totalPages, setCurrentPage };
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,8 @@ import { HomePage } from "../components/pages/HomePage";
 import { usePosts } from "../hooks/usePosts";
 
 const Index = () => {
-  const { posts, loading } = usePosts();
+  const { posts, loading, currentPage, totalPages, setCurrentPage } =
+    usePosts();
 
   if (loading) {
     return <LoadingSpinner />;
@@ -12,7 +13,12 @@ const Index = () => {
 
   return (
     <Layout postCount={posts.length}>
-      <HomePage posts={posts} />
+      <HomePage
+        posts={posts}
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={setCurrentPage}
+      />
     </Layout>
   );
 };


### PR DESCRIPTION
## 概要

記事数が増えた時のために、記事一覧にページング処理を実装しました。1ページあたり最大10記事を表示します。

## 変更内容

- `src/components/common/Pagination.tsx`: ページネーションコンポーネントを新規作成。前へ/次へボタンと現在のページ情報を表示
- `src/hooks/usePosts.ts`: ページング機能を追加。1ページあたり10記事に制限し、currentPage、totalPages、setCurrentPageを返すように拡張
- `src/components/pages/HomePage.tsx`: Paginationコンポーネントを配置し、ページング情報を受け取るようにPropsを更新
- `src/pages/index.tsx`: usePostsフックから取得したページング情報をHomePageに渡すように更新

## 備考

- 記事が10件以下の場合、ページネーションは非表示になります
- 最初のページでは「前へ」ボタン、最後のページでは「次へ」ボタンが無効化されます
- Panda CSSを使用してスタイリングし、既存のデザインシステムに統一しています