### PR TITLE
chore: Dependabotの同時PR上限を10に引き上げ

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: "saturday"
       time: "06:30"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     assignees:
       - "amkkr"
     commit-message:
@@ -25,3 +25,4 @@ updates:
       day: "saturday"
       time: "06:30"
       timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## 概要

Dependabotが一度に作成できるPull Requestの上限を5から10に引き上げます。

## 変更内容

- `.github/dependabot.yml`: npmパッケージエコシステムの`open-pull-requests-limit`を5から10に変更
- `.github/dependabot.yml`: GitHub Actionsエコシステムに`open-pull-requests-limit: 10`を追加

## 備考

この変更により、Dependabotはより多くの依存関係更新を並行して処理できるようになります。週次更新時により効率的に複数のパッケージを更新できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)