### PR TITLE
fix: Markdownパーサーの空行除去ロジック修正

### DIFF
--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -124,10 +124,10 @@ describe("markdown.ts", () => {
       expect(result.content).not.toContain("これは本文に含まれません。");
     });
 
-    it("空行は本文から除外される", () => {
+    it("空行が段落区切りとして保持される", () => {
       const content = `# テストタイトル
 
-## 投稿日時  
+## 投稿日時
 - 2024-01-01 10:00
 
 ## 筆者名
@@ -144,7 +144,9 @@ describe("markdown.ts", () => {
 
       const result = parseMarkdown(content, "20240101100000");
 
-      expect(result.content).toBe("<p>1行目です。<br>2行目です。</p>\n");
+      expect(result.content).toBe(
+        "<p>1行目です。</p>\n<p>2行目です。</p>\n",
+      );
     });
   });
 });

--- a/src/lib/markdownParser.ts
+++ b/src/lib/markdownParser.ts
@@ -58,7 +58,7 @@ export const extractBodyContent = (lines: string[]): string => {
   const endIndex = nextSectionIndex === -1 ? lines.length : nextSectionIndex;
   const bodyLines = lines.slice(bodyStartIndex + 1, endIndex);
 
-  return bodyLines.join("\n");
+  return bodyLines.join("\n").trim();
 };
 
 /**

--- a/src/lib/markdownParser.ts
+++ b/src/lib/markdownParser.ts
@@ -43,7 +43,7 @@ export const extractSectionContent = (
 /**
  * Markdownの行配列から本文セクションの内容を抽出する
  * @param lines Markdownの行配列
- * @returns 本文の内容（空行を除く）
+ * @returns 本文の内容（空行は段落区切りとして保持）
  */
 export const extractBodyContent = (lines: string[]): string => {
   const bodyStartIndex = lines.findIndex((line) => line.startsWith("## 本文"));
@@ -58,7 +58,7 @@ export const extractBodyContent = (lines: string[]): string => {
   const endIndex = nextSectionIndex === -1 ? lines.length : nextSectionIndex;
   const bodyLines = lines.slice(bodyStartIndex + 1, endIndex);
 
-  return bodyLines.filter((line) => line.trim() !== "").join("\n");
+  return bodyLines.join("\n");
 };
 
 /**


### PR DESCRIPTION
## 概要

Markdownパーサーの`extractBodyContent`が本文中の空行をすべて除去していたため、段落区切りが失われる問題を修正。

Closes #261

## 変更内容

- `src/lib/markdownParser.ts`: `bodyLines.filter((line) => line.trim() !== "")` による空行除去を削除し、空行を段落区切りとして保持するように変更
- `src/lib/__tests__/markdown.test.ts`: テストケース名と期待値を修正（空行除去→段落区切り保持）

## 備考

- CommonMark仕様では空行は段落区切りとして機能するため、除去すると`marked`が段落を正しく分割できなかった
- `marked`の`breaks: true`設定は行末改行の`<br>`変換オプションであり、空行除去を前提とした設計ではない