### PR TITLE
refactor: テストの弱いアサーション修正（toBeDefined → 具体的検証）

### DIFF
--- a/src/components/atoms/__tests__/Button.test.tsx
+++ b/src/components/atoms/__tests__/Button.test.tsx
@@ -70,47 +70,89 @@ describe("Button", () => {
   });
 
   it("デフォルトでprimaryスタイルになる", () => {
-    const { container } = render(<Button>Primary Button</Button>);
-
-    const button = container.querySelector("button");
-    expect(button?.className).toBeDefined();
-  });
-
-  it("secondaryスタイルに変更できる", () => {
-    const { container } = render(
+    const { container: primaryContainer } = render(
+      <Button>Primary Button</Button>,
+    );
+    const { container: secondaryContainer } = render(
       <Button variant="secondary">Secondary Button</Button>,
     );
 
-    const button = container.querySelector("button");
-    expect(button?.className).toBeDefined();
+    const primaryClass = primaryContainer.querySelector("button")?.className;
+    const secondaryClass =
+      secondaryContainer.querySelector("button")?.className;
+    expect(primaryClass).not.toBe("");
+    expect(primaryClass).not.toBe(secondaryClass);
+  });
+
+  it("secondaryスタイルに変更できる", () => {
+    const { container: secondaryContainer } = render(
+      <Button variant="secondary">Secondary Button</Button>,
+    );
+    const { container: ghostContainer } = render(
+      <Button variant="ghost">Ghost Button</Button>,
+    );
+
+    const secondaryClass =
+      secondaryContainer.querySelector("button")?.className;
+    const ghostClass = ghostContainer.querySelector("button")?.className;
+    expect(secondaryClass).not.toBe("");
+    expect(secondaryClass).not.toBe(ghostClass);
   });
 
   it("ghostスタイルに変更できる", () => {
-    const { container } = render(<Button variant="ghost">Ghost Button</Button>);
+    const { container: ghostContainer } = render(
+      <Button variant="ghost">Ghost Button</Button>,
+    );
+    const { container: primaryContainer } = render(
+      <Button>Primary Button</Button>,
+    );
 
-    const button = container.querySelector("button");
-    expect(button?.className).toBeDefined();
+    const ghostClass = ghostContainer.querySelector("button")?.className;
+    const primaryClass = primaryContainer.querySelector("button")?.className;
+    expect(ghostClass).not.toBe("");
+    expect(ghostClass).not.toBe(primaryClass);
   });
 
   it("デフォルトでmediumサイズになる", () => {
-    const { container } = render(<Button>Medium Button</Button>);
+    const { container: mediumContainer } = render(
+      <Button>Medium Button</Button>,
+    );
+    const { container: smallContainer } = render(
+      <Button size="small">Small Button</Button>,
+    );
 
-    const button = container.querySelector("button");
-    expect(button?.className).toBeDefined();
+    const mediumClass = mediumContainer.querySelector("button")?.className;
+    const smallClass = smallContainer.querySelector("button")?.className;
+    expect(mediumClass).not.toBe("");
+    expect(mediumClass).not.toBe(smallClass);
   });
 
   it("smallサイズに変更できる", () => {
-    const { container } = render(<Button size="small">Small Button</Button>);
+    const { container: smallContainer } = render(
+      <Button size="small">Small Button</Button>,
+    );
+    const { container: largeContainer } = render(
+      <Button size="large">Large Button</Button>,
+    );
 
-    const button = container.querySelector("button");
-    expect(button?.className).toBeDefined();
+    const smallClass = smallContainer.querySelector("button")?.className;
+    const largeClass = largeContainer.querySelector("button")?.className;
+    expect(smallClass).not.toBe("");
+    expect(smallClass).not.toBe(largeClass);
   });
 
   it("largeサイズに変更できる", () => {
-    const { container } = render(<Button size="large">Large Button</Button>);
+    const { container: largeContainer } = render(
+      <Button size="large">Large Button</Button>,
+    );
+    const { container: mediumContainer } = render(
+      <Button>Medium Button</Button>,
+    );
 
-    const button = container.querySelector("button");
-    expect(button?.className).toBeDefined();
+    const largeClass = largeContainer.querySelector("button")?.className;
+    const mediumClass = mediumContainer.querySelector("button")?.className;
+    expect(largeClass).not.toBe("");
+    expect(largeClass).not.toBe(mediumClass);
   });
 
   it("複数の子要素を受け入れる", () => {

--- a/src/components/atoms/__tests__/Link.test.tsx
+++ b/src/components/atoms/__tests__/Link.test.tsx
@@ -42,18 +42,12 @@ describe("Link", () => {
   });
 
   it("デフォルトでdefaultスタイルになる", () => {
-    const { container } = render(
+    const { container: defaultContainer } = render(
       <MemoryRouter>
         <Link to="/home">Home</Link>
       </MemoryRouter>,
     );
-
-    const link = container.querySelector("a");
-    expect(link?.className).toBeDefined();
-  });
-
-  it("navigationスタイルに変更できる", () => {
-    const { container } = render(
+    const { container: navContainer } = render(
       <MemoryRouter>
         <Link to="/nav" variant="navigation">
           Navigation Link
@@ -61,12 +55,21 @@ describe("Link", () => {
       </MemoryRouter>,
     );
 
-    const link = container.querySelector("a");
-    expect(link?.className).toBeDefined();
+    const defaultClass = defaultContainer.querySelector("a")?.className;
+    const navClass = navContainer.querySelector("a")?.className;
+    expect(defaultClass).not.toBe("");
+    expect(defaultClass).not.toBe(navClass);
   });
 
-  it("buttonスタイルに変更できる", () => {
-    const { container } = render(
+  it("navigationスタイルに変更できる", () => {
+    const { container: navContainer } = render(
+      <MemoryRouter>
+        <Link to="/nav" variant="navigation">
+          Navigation Link
+        </Link>
+      </MemoryRouter>,
+    );
+    const { container: buttonContainer } = render(
       <MemoryRouter>
         <Link to="/action" variant="button">
           Button Link
@@ -74,12 +77,21 @@ describe("Link", () => {
       </MemoryRouter>,
     );
 
-    const link = container.querySelector("a");
-    expect(link?.className).toBeDefined();
+    const navClass = navContainer.querySelector("a")?.className;
+    const buttonClass = buttonContainer.querySelector("a")?.className;
+    expect(navClass).not.toBe("");
+    expect(navClass).not.toBe(buttonClass);
   });
 
-  it("cardスタイルに変更できる", () => {
-    const { container } = render(
+  it("buttonスタイルに変更できる", () => {
+    const { container: buttonContainer } = render(
+      <MemoryRouter>
+        <Link to="/action" variant="button">
+          Button Link
+        </Link>
+      </MemoryRouter>,
+    );
+    const { container: cardContainer } = render(
       <MemoryRouter>
         <Link to="/card" variant="card">
           Card Link
@@ -87,8 +99,30 @@ describe("Link", () => {
       </MemoryRouter>,
     );
 
-    const link = container.querySelector("a");
-    expect(link?.className).toBeDefined();
+    const buttonClass = buttonContainer.querySelector("a")?.className;
+    const cardClass = cardContainer.querySelector("a")?.className;
+    expect(buttonClass).not.toBe("");
+    expect(buttonClass).not.toBe(cardClass);
+  });
+
+  it("cardスタイルに変更できる", () => {
+    const { container: cardContainer } = render(
+      <MemoryRouter>
+        <Link to="/card" variant="card">
+          Card Link
+        </Link>
+      </MemoryRouter>,
+    );
+    const { container: defaultContainer } = render(
+      <MemoryRouter>
+        <Link to="/home">Home</Link>
+      </MemoryRouter>,
+    );
+
+    const cardClass = cardContainer.querySelector("a")?.className;
+    const defaultClass = defaultContainer.querySelector("a")?.className;
+    expect(cardClass).not.toBe("");
+    expect(cardClass).not.toBe(defaultClass);
   });
 
   it("カスタムCSSクラスを追加できる", () => {
@@ -119,17 +153,29 @@ describe("Link", () => {
   });
 
   it("外部リンクにvariantを設定できる", () => {
-    const { container } = render(
+    const { container: buttonContainer } = render(
       <MemoryRouter>
         <Link to="https://example.com" external variant="button">
           External Button
         </Link>
       </MemoryRouter>,
     );
+    const { container: defaultContainer } = render(
+      <MemoryRouter>
+        <Link to="https://example.com" external>
+          External Default
+        </Link>
+      </MemoryRouter>,
+    );
 
-    const link = container.querySelector("a");
-    expect(link?.className).toBeDefined();
-    expect(link).toHaveAttribute("target", "_blank");
+    const buttonClass = buttonContainer.querySelector("a")?.className;
+    const defaultClass = defaultContainer.querySelector("a")?.className;
+    expect(buttonClass).not.toBe("");
+    expect(buttonClass).not.toBe(defaultClass);
+    expect(buttonContainer.querySelector("a")).toHaveAttribute(
+      "target",
+      "_blank",
+    );
   });
 
   it("ルート相対パスでリンクできる", () => {

--- a/src/components/atoms/__tests__/Typography.test.tsx
+++ b/src/components/atoms/__tests__/Typography.test.tsx
@@ -11,25 +11,42 @@ describe("Heading1", () => {
   });
 
   it("デフォルトでpageスタイルになる", () => {
-    const { container } = render(<Heading1>Page Heading</Heading1>);
-    const heading = container.querySelector("h1");
-    expect(heading?.className).toBeDefined();
+    const { container: defaultContainer } = render(
+      <Heading1>Page Heading</Heading1>,
+    );
+    const { container: articleContainer } = render(
+      <Heading1 variant="article">Article Heading</Heading1>,
+    );
+    const defaultClass = defaultContainer.querySelector("h1")?.className;
+    const articleClass = articleContainer.querySelector("h1")?.className;
+    expect(defaultClass).not.toBe("");
+    expect(defaultClass).not.toBe(articleClass);
   });
 
   it("articleスタイルに変更できる", () => {
-    const { container } = render(
+    const { container: articleContainer } = render(
       <Heading1 variant="article">Article Heading</Heading1>,
     );
-    const heading = container.querySelector("h1");
-    expect(heading?.className).toBeDefined();
+    const { container: defaultContainer } = render(
+      <Heading1>Default Heading</Heading1>,
+    );
+    const articleClass = articleContainer.querySelector("h1")?.className;
+    const defaultClass = defaultContainer.querySelector("h1")?.className;
+    expect(articleClass).not.toBe("");
+    expect(articleClass).not.toBe(defaultClass);
   });
 
   it("cardスタイルに変更できる", () => {
-    const { container } = render(
+    const { container: cardContainer } = render(
       <Heading1 variant="card">Card Heading</Heading1>,
     );
-    const heading = container.querySelector("h1");
-    expect(heading?.className).toBeDefined();
+    const { container: defaultContainer } = render(
+      <Heading1>Default Heading</Heading1>,
+    );
+    const cardClass = cardContainer.querySelector("h1")?.className;
+    const defaultClass = defaultContainer.querySelector("h1")?.className;
+    expect(cardClass).not.toBe("");
+    expect(cardClass).not.toBe(defaultClass);
   });
 
   it("カスタムCSSクラスを追加できる", () => {
@@ -51,25 +68,42 @@ describe("Heading2", () => {
   });
 
   it("デフォルトでarticleスタイルになる", () => {
-    const { container } = render(<Heading2>Article Heading</Heading2>);
-    const heading = container.querySelector("h2");
-    expect(heading?.className).toBeDefined();
+    const { container: defaultContainer } = render(
+      <Heading2>Article Heading</Heading2>,
+    );
+    const { container: pageContainer } = render(
+      <Heading2 variant="page">Page Heading</Heading2>,
+    );
+    const defaultClass = defaultContainer.querySelector("h2")?.className;
+    const pageClass = pageContainer.querySelector("h2")?.className;
+    expect(defaultClass).not.toBe("");
+    expect(defaultClass).not.toBe(pageClass);
   });
 
   it("pageスタイルに変更できる", () => {
-    const { container } = render(
+    const { container: pageContainer } = render(
       <Heading2 variant="page">Page Heading</Heading2>,
     );
-    const heading = container.querySelector("h2");
-    expect(heading?.className).toBeDefined();
+    const { container: cardContainer } = render(
+      <Heading2 variant="card">Card Heading</Heading2>,
+    );
+    const pageClass = pageContainer.querySelector("h2")?.className;
+    const cardClass = cardContainer.querySelector("h2")?.className;
+    expect(pageClass).not.toBe("");
+    expect(pageClass).not.toBe(cardClass);
   });
 
   it("cardスタイルに変更できる", () => {
-    const { container } = render(
+    const { container: cardContainer } = render(
       <Heading2 variant="card">Card Heading</Heading2>,
     );
-    const heading = container.querySelector("h2");
-    expect(heading?.className).toBeDefined();
+    const { container: defaultContainer } = render(
+      <Heading2>Default Heading</Heading2>,
+    );
+    const cardClass = cardContainer.querySelector("h2")?.className;
+    const defaultClass = defaultContainer.querySelector("h2")?.className;
+    expect(cardClass).not.toBe("");
+    expect(cardClass).not.toBe(defaultClass);
   });
 
   it("カスタムCSSクラスを追加できる", () => {
@@ -91,25 +125,42 @@ describe("Heading3", () => {
   });
 
   it("デフォルトでarticleスタイルになる", () => {
-    const { container } = render(<Heading3>Article Heading</Heading3>);
-    const heading = container.querySelector("h3");
-    expect(heading?.className).toBeDefined();
+    const { container: defaultContainer } = render(
+      <Heading3>Article Heading</Heading3>,
+    );
+    const { container: pageContainer } = render(
+      <Heading3 variant="page">Page Heading</Heading3>,
+    );
+    const defaultClass = defaultContainer.querySelector("h3")?.className;
+    const pageClass = pageContainer.querySelector("h3")?.className;
+    expect(defaultClass).not.toBe("");
+    expect(defaultClass).not.toBe(pageClass);
   });
 
   it("pageスタイルに変更できる", () => {
-    const { container } = render(
+    const { container: pageContainer } = render(
       <Heading3 variant="page">Page Heading</Heading3>,
     );
-    const heading = container.querySelector("h3");
-    expect(heading?.className).toBeDefined();
+    const { container: cardContainer } = render(
+      <Heading3 variant="card">Card Heading</Heading3>,
+    );
+    const pageClass = pageContainer.querySelector("h3")?.className;
+    const cardClass = cardContainer.querySelector("h3")?.className;
+    expect(pageClass).not.toBe("");
+    expect(pageClass).not.toBe(cardClass);
   });
 
   it("cardスタイルに変更できる", () => {
-    const { container } = render(
+    const { container: cardContainer } = render(
       <Heading3 variant="card">Card Heading</Heading3>,
     );
-    const heading = container.querySelector("h3");
-    expect(heading?.className).toBeDefined();
+    const { container: pageContainer } = render(
+      <Heading3 variant="page">Page Heading</Heading3>,
+    );
+    const cardClass = cardContainer.querySelector("h3")?.className;
+    const pageClass = pageContainer.querySelector("h3")?.className;
+    expect(cardClass).not.toBe("");
+    expect(cardClass).not.toBe(pageClass);
   });
 
   it("カスタムCSSクラスを追加できる", () => {
@@ -136,25 +187,42 @@ describe("Paragraph", () => {
   });
 
   it("デフォルトでbodyスタイルになる", () => {
-    const { container } = render(<Paragraph>Body Text</Paragraph>);
-    const paragraph = container.querySelector("p");
-    expect(paragraph?.className).toBeDefined();
+    const { container: defaultContainer } = render(
+      <Paragraph>Body Text</Paragraph>,
+    );
+    const { container: smallContainer } = render(
+      <Paragraph variant="small">Small Text</Paragraph>,
+    );
+    const defaultClass = defaultContainer.querySelector("p")?.className;
+    const smallClass = smallContainer.querySelector("p")?.className;
+    expect(defaultClass).not.toBe("");
+    expect(defaultClass).not.toBe(smallClass);
   });
 
   it("smallスタイルに変更できる", () => {
-    const { container } = render(
+    const { container: smallContainer } = render(
       <Paragraph variant="small">Small Text</Paragraph>,
     );
-    const paragraph = container.querySelector("p");
-    expect(paragraph?.className).toBeDefined();
+    const { container: largeContainer } = render(
+      <Paragraph variant="large">Large Text</Paragraph>,
+    );
+    const smallClass = smallContainer.querySelector("p")?.className;
+    const largeClass = largeContainer.querySelector("p")?.className;
+    expect(smallClass).not.toBe("");
+    expect(smallClass).not.toBe(largeClass);
   });
 
   it("largeスタイルに変更できる", () => {
-    const { container } = render(
+    const { container: largeContainer } = render(
       <Paragraph variant="large">Large Text</Paragraph>,
     );
-    const paragraph = container.querySelector("p");
-    expect(paragraph?.className).toBeDefined();
+    const { container: defaultContainer } = render(
+      <Paragraph>Default Text</Paragraph>,
+    );
+    const largeClass = largeContainer.querySelector("p")?.className;
+    const defaultClass = defaultContainer.querySelector("p")?.className;
+    expect(largeClass).not.toBe("");
+    expect(largeClass).not.toBe(defaultClass);
   });
 
   it("カスタムCSSクラスを追加できる", () => {


### PR DESCRIPTION
## 概要

テストファイルで使用されていた `toBeDefined()` による弱いアサーションを、variant/size間のクラス名比較による具体的な検証に修正。

## 変更内容

- `src/components/atoms/__tests__/Button.test.tsx`: variant（primary/secondary/ghost）およびsize（medium/small/large）のスタイルテストで、異なるvariant/sizeのクラス名を比較して差分を検証するように修正
- `src/components/atoms/__tests__/Link.test.tsx`: variant（default/navigation/button/card）のスタイルテストで、異なるvariantのクラス名を比較して差分を検証するように修正
- `src/components/atoms/__tests__/Typography.test.tsx`: Heading1/Heading2/Heading3/Paragraphの各variantスタイルテストで、異なるvariantのクラス名を比較して差分を検証するように修正

## 備考

Closes #262