### PR TITLE
refactor: テストの1テスト多概念を分割

### DIFF
--- a/src/components/pages/__tests__/HomePage.test.tsx
+++ b/src/components/pages/__tests__/HomePage.test.tsx
@@ -62,7 +62,7 @@ describe("HomePage", () => {
     expect(screen.getByText("テスト記事2")).toBeInTheDocument();
   });
 
-  it("各記事のメタ情報を表示できる", () => {
+  it("各記事の著者名を表示できる", () => {
     render(
       <MemoryRouter>
         <HomePage
@@ -76,6 +76,20 @@ describe("HomePage", () => {
 
     expect(screen.getByText("著者1")).toBeInTheDocument();
     expect(screen.getByText("著者2")).toBeInTheDocument();
+  });
+
+  it("各記事の投稿日時を表示できる", () => {
+    render(
+      <MemoryRouter>
+        <HomePage
+          posts={mockPosts}
+          currentPage={1}
+          totalPages={1}
+          onPageChange={mockOnPageChange}
+        />
+      </MemoryRouter>,
+    );
+
     expect(screen.getByText("2024-01-01")).toBeInTheDocument();
     expect(screen.getByText("2024-01-02")).toBeInTheDocument();
   });

--- a/src/hooks/__tests__/usePost.test.ts
+++ b/src/hooks/__tests__/usePost.test.ts
@@ -24,6 +24,17 @@ describe("usePost", () => {
     vi.clearAllMocks();
   });
 
+  it("フック呼び出し直後にローディング状態になる", () => {
+    mockGetPost.mockResolvedValue(mockPost);
+
+    const { result } = renderHook(() => usePost("20240101100000"));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.post).toBe(null);
+    expect(result.current.error).toBe(null);
+    expect(result.current.notFound).toBe(false);
+  });
+
   it("記事データを取得できる", async () => {
     mockGetPost.mockResolvedValue(mockPost);
 

--- a/src/hooks/__tests__/usePost.test.ts
+++ b/src/hooks/__tests__/usePost.test.ts
@@ -24,27 +24,30 @@ describe("usePost", () => {
     vi.clearAllMocks();
   });
 
-  it("記事詳細を正しく取得する", async () => {
+  it("記事データを取得できる", async () => {
     mockGetPost.mockResolvedValue(mockPost);
 
     const { result } = renderHook(() => usePost("20240101100000"));
 
-    // 初期状態の確認
-    expect(result.current.loading).toBe(true);
-    expect(result.current.post).toBe(null);
-    expect(result.current.error).toBe(null);
-    expect(result.current.notFound).toBe(false);
-
-    // 読み込み完了まで待機
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
 
-    // 最終状態の確認
     expect(result.current.post).toEqual(mockPost);
+    expect(mockGetPost).toHaveBeenCalledWith("20240101100000");
+  });
+
+  it("取得完了後にローディングが解除される", async () => {
+    mockGetPost.mockResolvedValue(mockPost);
+
+    const { result } = renderHook(() => usePost("20240101100000"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
     expect(result.current.error).toBe(null);
     expect(result.current.notFound).toBe(false);
-    expect(mockGetPost).toHaveBeenCalledWith("20240101100000");
   });
 
   it("timestampがundefinedの場合にnotFoundを設定する", async () => {
@@ -75,7 +78,7 @@ describe("usePost", () => {
     expect(mockGetPost).toHaveBeenCalledWith("nonexistent");
   });
 
-  it("エラーが発生した場合を正しく処理する", async () => {
+  it("エラー発生時にエラーメッセージが設定される", async () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const errorMessage = "ネットワークエラー";
     mockGetPost.mockRejectedValue(new Error(errorMessage));

--- a/src/hooks/__tests__/usePosts.test.ts
+++ b/src/hooks/__tests__/usePosts.test.ts
@@ -29,6 +29,16 @@ describe("usePosts", () => {
     vi.clearAllMocks();
   });
 
+  it("フック呼び出し直後にローディング状態になる", () => {
+    mockGetAllPostSummaries.mockResolvedValue(mockPosts);
+
+    const { result } = renderHook(() => usePosts());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.posts).toEqual([]);
+    expect(result.current.error).toBe(null);
+  });
+
   it("記事一覧データを取得できる", async () => {
     mockGetAllPostSummaries.mockResolvedValue(mockPosts);
 

--- a/src/hooks/__tests__/usePosts.test.ts
+++ b/src/hooks/__tests__/usePosts.test.ts
@@ -29,28 +29,32 @@ describe("usePosts", () => {
     vi.clearAllMocks();
   });
 
-  it("記事一覧を正しく取得する", async () => {
+  it("記事一覧データを取得できる", async () => {
     mockGetAllPostSummaries.mockResolvedValue(mockPosts);
 
     const { result } = renderHook(() => usePosts());
 
-    // 初期状態の確認
-    expect(result.current.loading).toBe(true);
-    expect(result.current.posts).toEqual([]);
-    expect(result.current.error).toBe(null);
-
-    // 読み込み完了まで待機
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
 
-    // 最終状態の確認
     expect(result.current.posts).toEqual(mockPosts);
-    expect(result.current.error).toBe(null);
     expect(mockGetAllPostSummaries).toHaveBeenCalledTimes(1);
   });
 
-  it("記事一覧が空の場合を正しく処理する", async () => {
+  it("取得完了後にローディングが解除される", async () => {
+    mockGetAllPostSummaries.mockResolvedValue(mockPosts);
+
+    const { result } = renderHook(() => usePosts());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe(null);
+  });
+
+  it("記事一覧が空の場合に空配列を返す", async () => {
     mockGetAllPostSummaries.mockResolvedValue([]);
 
     const { result } = renderHook(() => usePosts());
@@ -63,7 +67,7 @@ describe("usePosts", () => {
     expect(result.current.error).toBe(null);
   });
 
-  it("エラーが発生した場合を正しく処理する", async () => {
+  it("エラー発生時にエラーメッセージが設定される", async () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const errorMessage = "ネットワークエラー";
     mockGetAllPostSummaries.mockRejectedValue(new Error(errorMessage));

--- a/src/pages/__tests__/index.test.tsx
+++ b/src/pages/__tests__/index.test.tsx
@@ -62,91 +62,47 @@ describe("Indexコンポーネント", () => {
     expect(screen.getByText("読み込み中...")).toBeInTheDocument();
   });
 
-  it("ヘッダーとフッターにブランド名を表示できる", async () => {
-    mockUsePosts.mockReturnValue({
-      posts: mockPosts,
-      loading: false,
-      error: null,
-      currentPage: 1,
-      totalPages: 1,
-      totalPosts: 2,
-      setCurrentPage: vi.fn(),
+  describe("記事が存在する場合の表示", () => {
+    beforeEach(() => {
+      mockUsePosts.mockReturnValue({
+        posts: mockPosts,
+        loading: false,
+        error: null,
+        currentPage: 1,
+        totalPages: 1,
+        totalPosts: 2,
+        setCurrentPage: vi.fn(),
+      });
+
+      render(
+        <TestWrapper>
+          <Index />
+        </TestWrapper>,
+      );
     });
 
-    render(
-      <TestWrapper>
-        <Index />
-      </TestWrapper>,
-    );
-
-    expect(screen.getAllByText("✨ Lazy Note")).toHaveLength(2);
-  });
-
-  it("記事タイトルを見出しとして表示できる", async () => {
-    mockUsePosts.mockReturnValue({
-      posts: mockPosts,
-      loading: false,
-      error: null,
-      currentPage: 1,
-      totalPages: 1,
-      totalPosts: 2,
-      setCurrentPage: vi.fn(),
+    it("ヘッダーとフッターにブランド名を表示できる", async () => {
+      expect(screen.getAllByText("✨ Lazy Note")).toHaveLength(2);
     });
 
-    render(
-      <TestWrapper>
-        <Index />
-      </TestWrapper>,
-    );
-
-    expect(
-      screen.getByRole("heading", { name: "2つ目の記事" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { name: "最初の記事" }),
-    ).toBeInTheDocument();
-  });
-
-  it("記事の投稿日時を表示できる", async () => {
-    mockUsePosts.mockReturnValue({
-      posts: mockPosts,
-      loading: false,
-      error: null,
-      currentPage: 1,
-      totalPages: 1,
-      totalPosts: 2,
-      setCurrentPage: vi.fn(),
+    it("記事タイトルを見出しとして表示できる", async () => {
+      expect(
+        screen.getByRole("heading", { name: "2つ目の記事" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "最初の記事" }),
+      ).toBeInTheDocument();
     });
 
-    render(
-      <TestWrapper>
-        <Index />
-      </TestWrapper>,
-    );
-
-    expect(screen.getByText("2024-01-02 12:00")).toBeInTheDocument();
-    expect(screen.getByText("2024-01-01 10:00")).toBeInTheDocument();
-  });
-
-  it("記事の筆者名を表示できる", async () => {
-    mockUsePosts.mockReturnValue({
-      posts: mockPosts,
-      loading: false,
-      error: null,
-      currentPage: 1,
-      totalPages: 1,
-      totalPosts: 2,
-      setCurrentPage: vi.fn(),
+    it("記事の投稿日時を表示できる", async () => {
+      expect(screen.getByText("2024-01-02 12:00")).toBeInTheDocument();
+      expect(screen.getByText("2024-01-01 10:00")).toBeInTheDocument();
     });
 
-    render(
-      <TestWrapper>
-        <Index />
-      </TestWrapper>,
-    );
-
-    expect(screen.getByText("花子")).toBeInTheDocument();
-    expect(screen.getByText("太郎")).toBeInTheDocument();
+    it("記事の筆者名を表示できる", async () => {
+      expect(screen.getByText("花子")).toBeInTheDocument();
+      expect(screen.getByText("太郎")).toBeInTheDocument();
+    });
   });
 
   it("記事がない場合に案内メッセージを表示する", async () => {

--- a/src/pages/__tests__/index.test.tsx
+++ b/src/pages/__tests__/index.test.tsx
@@ -62,7 +62,7 @@ describe("Indexコンポーネント", () => {
     expect(screen.getByText("読み込み中...")).toBeInTheDocument();
   });
 
-  it("記事一覧を表示できる", async () => {
+  it("ヘッダーとフッターにブランド名を表示できる", async () => {
     mockUsePosts.mockReturnValue({
       posts: mockPosts,
       loading: false,
@@ -79,27 +79,77 @@ describe("Indexコンポーネント", () => {
       </TestWrapper>,
     );
 
-    // ブランド名の確認
-    expect(screen.getAllByText("✨ Lazy Note")).toHaveLength(2); // ヘッダーとフッター
+    expect(screen.getAllByText("✨ Lazy Note")).toHaveLength(2);
+  });
 
-    // 記事タイトルの確認
+  it("記事タイトルを見出しとして表示できる", async () => {
+    mockUsePosts.mockReturnValue({
+      posts: mockPosts,
+      loading: false,
+      error: null,
+      currentPage: 1,
+      totalPages: 1,
+      totalPosts: 2,
+      setCurrentPage: vi.fn(),
+    });
+
+    render(
+      <TestWrapper>
+        <Index />
+      </TestWrapper>,
+    );
+
     expect(
       screen.getByRole("heading", { name: "2つ目の記事" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "最初の記事" }),
     ).toBeInTheDocument();
+  });
 
-    // 投稿日時の確認
+  it("記事の投稿日時を表示できる", async () => {
+    mockUsePosts.mockReturnValue({
+      posts: mockPosts,
+      loading: false,
+      error: null,
+      currentPage: 1,
+      totalPages: 1,
+      totalPosts: 2,
+      setCurrentPage: vi.fn(),
+    });
+
+    render(
+      <TestWrapper>
+        <Index />
+      </TestWrapper>,
+    );
+
     expect(screen.getByText("2024-01-02 12:00")).toBeInTheDocument();
     expect(screen.getByText("2024-01-01 10:00")).toBeInTheDocument();
+  });
 
-    // 筆者名の確認
+  it("記事の筆者名を表示できる", async () => {
+    mockUsePosts.mockReturnValue({
+      posts: mockPosts,
+      loading: false,
+      error: null,
+      currentPage: 1,
+      totalPages: 1,
+      totalPosts: 2,
+      setCurrentPage: vi.fn(),
+    });
+
+    render(
+      <TestWrapper>
+        <Index />
+      </TestWrapper>,
+    );
+
     expect(screen.getByText("花子")).toBeInTheDocument();
     expect(screen.getByText("太郎")).toBeInTheDocument();
   });
 
-  it("記事がない場合に適切なメッセージを表示する", async () => {
+  it("記事がない場合に案内メッセージを表示する", async () => {
     mockUsePosts.mockReturnValue({
       posts: [],
       loading: false,


### PR DESCRIPTION
## 概要

1つのテストケースで複数の概念を検証していた箇所を、概念ごとに独立したテストケースに分割するリファクタリング。

## 変更内容

- `src/hooks/__tests__/usePost.test.ts`: 「記事詳細を正しく取得する」を「記事データを取得できる」と「取得完了後にローディングが解除される」に分割。フック呼び出し直後のローディング初期状態テストを追加
- `src/hooks/__tests__/usePosts.test.ts`: 「記事一覧を正しく取得する」を「記事一覧データを取得できる」と「取得完了後にローディングが解除される」に分割。フック呼び出し直後のローディング初期状態テストを追加
- `src/pages/__tests__/index.test.tsx`: 9アサーションの「記事一覧を表示できる」をブランド名・タイトル・日時・筆者名の4テストに分割
- `src/components/pages/__tests__/HomePage.test.tsx`: 「各記事のメタ情報を表示できる」を「各記事の著者名を表示できる」と「各記事の投稿日時を表示できる」に分割

## 備考

Closes #263