### PR TITLE
chore: dependabotスケジュールとPostToolUseフックのパスを修正

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd $HOME/repos/lazy-note && pnpm test:run && pnpm lint && pnpm type-check && pnpm prepare"
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && pnpm test:run && pnpm lint && pnpm type-check && pnpm prepare"
           }
         ]
       }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-      time: "06:30"
+      time: "05:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 10
     assignees:
@@ -30,7 +30,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-      time: "06:30"
+      time: "05:00"
       timezone: "Asia/Tokyo"
     cooldown:
       default-days: 7


### PR DESCRIPTION
## 概要

- dependabotが依存関係更新PRを作成する時間帯を 05:00（JST）に早める
- PostToolUseフックが環境依存のハードコードパス（`$HOME/repos/lazy-note`）を使用しており `cd` に失敗していたため、`$CLAUDE_PROJECT_DIR` に修正する

## 変更内容

- `.github/dependabot.yml`: npmとgithub-actionsの両ecosystemの `schedule.time` を `06:30` から `05:00` に変更
- `.claude/settings.json`: PostToolUseフックのコマンドを `cd $HOME/repos/lazy-note ...` から `cd "$CLAUDE_PROJECT_DIR" ...` に変更し、任意の環境でプロジェクトルートへ移動できるようにした

## 備考

- dependabotの曜日設定（saturday）は変更していない
- フック側は `cd` 部分の動作確認を手元で実施済み（`pnpm i` はネットワーク制限で検証不可）
