### PR TITLE
fix: 未定義デザイントークン参照を修正

### DIFF
--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -24,8 +24,8 @@ export const LoadingSpinner = ({
             width: "16",
             height: "16",
             border: "4px solid",
-            borderColor: "primary.200",
-            borderTopColor: "primary.600",
+            borderColor: "bg.3",
+            borderTopColor: "blue.light",
             borderRadius: "full",
             animation: "spin 1s linear infinite",
           })}
@@ -33,7 +33,7 @@ export const LoadingSpinner = ({
         <p
           className={css({
             fontSize: "lg",
-            color: "secondary.600",
+            color: "fg.3",
             fontWeight: "500",
           })}
         >

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -25,7 +25,7 @@ const buttonMinWidthStyles = css({
 const pageInfoStyles = css({
   fontSize: "16px",
   fontWeight: "500",
-  color: "text.primary",
+  color: "fg.1",
   minWidth: "120px",
   textAlign: "center",
 });

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -46,7 +46,7 @@ const articleHeaderStyles = css({
   paddingBottom: "16px",
   paddingX: "12px",
   borderBottom: "1px solid",
-  borderColor: "surface.200",
+  borderColor: "bg.3",
 });
 
 const articleContentStyles = css({

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -85,7 +85,7 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
             <div
               className={css({
                 height: "1px",
-                background: "surface.200",
+                background: "bg.3",
               })}
             />
 


### PR DESCRIPTION
## 概要

複数のコンポーネントが `panda.config.ts` に存在しないデザイントークンを参照しており、意図したスタイルが適用されていない問題を修正する。

Closes #309

## 変更内容

- `src/components/pages/HomePage.tsx`: `surface.200` → `bg.3`（Gruvboxの定義済みborderカラーに統一）
- `src/components/pages/PostDetailPage.tsx`: `surface.200` → `bg.3`（同上）
- `src/components/common/Pagination.tsx`: `text.primary` → `fg.1`（定義済みの前景色トークンに統一）
- `src/components/common/LoadingSpinner.tsx`: `primary.200` → `bg.3`, `primary.600` → `blue.light`, `secondary.600` → `fg.3`（Gruvboxパレットの定義済みトークンに統一）

## 備考

- Phase 1 (P0: 実バグ修正) の一環
- 既存テストはスタイル値をassertしていないため修正不要
- `pnpm build` 全て成功確認済み