### PR TITLE
fix: index.cssのハードコード色をPanda CSS変数に統一

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,8 +8,8 @@
   font-weight: 400;
 
   color-scheme: dark;
-  color: #ebdbb2;
-  background: #282828;
+  color: var(--colors-fg-1);
+  background: var(--colors-bg-0);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -19,12 +19,12 @@
 
 a {
   font-weight: 500;
-  color: #83a598;
+  color: var(--colors-blue-light);
   text-decoration: none;
   transition: all 0.2s ease;
 }
 a:hover {
-  color: #8ec07c;
+  color: var(--colors-aqua-light);
 }
 
 body {
@@ -37,7 +37,7 @@ body {
 /* Typography Base Styles */
 h1, h2, h3 {
   font-weight: bold;
-  color: #ebdbb2;
+  color: var(--colors-fg-1);
   line-height: 1.2; /* snug */
 }
 
@@ -48,7 +48,7 @@ h1 {
 
 p {
   line-height: 1.7; /* body */
-  color: #d5c4a1;
+  color: var(--colors-fg-2);
 }
 
 /* List Base Styles */


### PR DESCRIPTION
## 概要

`index.css` に Gruvbox カラーがハードコードされており、`panda.config.ts` のトークンシステムと二重管理になっている問題を修正する。

Closes #310

## 変更内容

- `src/index.css`: 以下のハードコード色を Panda CSS が生成する CSS 変数に置き換え
  - `#ebdbb2` → `var(--colors-fg-1)` （:root color, h1-h3 color）
  - `#282828` → `var(--colors-bg-0)` （:root background）
  - `#83a598` → `var(--colors-blue-light)` （a color）
  - `#8ec07c` → `var(--colors-aqua-light)` （a:hover color）
  - `#d5c4a1` → `var(--colors-fg-2)` （p color）

## 備考

- Phase 1 (P0: 実バグ修正) の一環
- CSS変数名は `styled-system/styles.css` の `@layer tokens` で定義される実際の変数名と一致確認済み
- `pnpm build` 全て成功確認済み