### PR TITLE
fix: コンポーネント内ハードコード色をGruvboxトークンに統一

### DIFF
--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -32,7 +32,7 @@ const baseButtonStyles = css({
 const variantStyles = {
   primary: css({
     background: "blue.light",
-    color: "white",
+    color: "fg.0",
     "&:hover:not(:disabled)": {
       background: "blue.dark",
       transform: "translateY(-1px)",

--- a/src/components/atoms/Link.tsx
+++ b/src/components/atoms/Link.tsx
@@ -50,7 +50,7 @@ export const Link = ({
       justifyContent: "center",
       padding: "12px 16px",
       background: "blue.light",
-      color: "white",
+      color: "fg.0",
       fontWeight: "600",
       borderRadius: "8px",
       "&:hover": {

--- a/src/components/common/MetaInfo.tsx
+++ b/src/components/common/MetaInfo.tsx
@@ -23,12 +23,12 @@ const itemBaseStyles = css({
 });
 
 const itemCardStyles = css({
-  color: "#6b7280",
+  color: "fg.4",
 });
 
 const itemHeaderStyles = css({
-  color: "white",
-  background: "rgba(255, 255, 255, 0.2)",
+  color: "fg.0",
+  background: "rgba(251, 241, 199, 0.15)",
   paddingY: "sm",
   paddingX: "md",
   borderRadius: "xl",


### PR DESCRIPTION
## 概要

複数のコンポーネントで Gruvbox パレット外の色がハードコードされており、デザインの一貫性が損なわれている問題を修正する。

Closes #311

## 変更内容

- `src/components/common/MetaInfo.tsx`: `#6b7280` → `fg.4`（Gruvboxのグレートーンに統一）、`white` → `fg.0`（Gruvboxの最明色に統一）、`rgba(255,255,255,0.2)` → `rgba(251,241,199,0.15)`（fg.0の暖色系に合わせた半透明色）
- `src/components/atoms/Button.tsx`: `white` → `fg.0`（Gruvboxのクリーム白に統一）
- `src/components/atoms/Link.tsx`: `white` → `fg.0`（同上）

## 備考

- Phase 1 (P0: 実バグ修正) の一環
- 既存テストは色値をassertしていないため修正不要
- `pnpm build` 全て成功確認済み