### PR TITLE
fix: PostDetailPageの<main>二重ネストを修正

### DIFF
--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -90,7 +90,7 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
             />
 
             {/* Article Content */}
-            <main
+            <div
               className={css({
                 paddingRight: "section",
                 paddingLeft: "section",
@@ -154,7 +154,7 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
                   __html: DOMPurify.sanitize(post.content),
                 }}
               />
-            </main>
+            </div>
           </article>
         </div>
       </div>


### PR DESCRIPTION
## 概要

`Layout.tsx` が `<main>` 要素を定義し、その内側で `PostDetailPage.tsx` も `<main>` 要素を使用しているため、HTML仕様に違反した `<main>` の二重ネストが発生していたアクセシビリティバグを修正する。

Closes #312

## 変更内容

- `src/components/pages/PostDetailPage.tsx`: 記事コンテンツのラッパー要素を `<main>` → `<div>` に変更（Layout.tsx の `<main>` がページ唯一のmainランドマークとなるように）

## 備考

- Phase 1 (P0: 実バグ修正) の一環
- HTML Living Standard: `<main>` は祖先に他の `<main>` を持ってはならない
- テストは `<main>` 要素を参照していないため修正不要
- `pnpm build` 全て成功確認済み