### PR TITLE
feat: BrandNameをホームへのリンクにする

### DIFF
--- a/src/components/common/BrandName.tsx
+++ b/src/components/common/BrandName.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { css } from "../../../styled-system/css";
 
 interface BrandNameProps {
@@ -12,17 +13,19 @@ export const BrandName = ({
   const isHeader = variant === "header";
 
   return (
-    <div
+    <Link
+      to="/"
       className={css({
         fontSize: isHeader ? "lg" : "sm",
         fontWeight: "bold",
         color: isHeader ? "fg.0" : "fg.2",
+        textDecoration: "none",
         ...(variant === "footer" && {
           marginBottom: "xs",
         }),
       })}
     >
       {showIcon && "✨ "}Lazy Note
-    </div>
+    </Link>
   );
 };

--- a/src/components/common/__tests__/BrandName.test.tsx
+++ b/src/components/common/__tests__/BrandName.test.tsx
@@ -1,10 +1,15 @@
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import { BrandName } from "../BrandName";
 
 describe("BrandName", () => {
   it("ヘッダースタイルで表示できる", () => {
-    render(<BrandName variant="header" />);
+    render(
+      <MemoryRouter>
+        <BrandName variant="header" />
+      </MemoryRouter>,
+    );
 
     const brandName = screen.getByText("✨ Lazy Note");
     expect(brandName).toBeInTheDocument();
@@ -13,7 +18,11 @@ describe("BrandName", () => {
   });
 
   it("フッタースタイルで表示できる", () => {
-    render(<BrandName variant="footer" />);
+    render(
+      <MemoryRouter>
+        <BrandName variant="footer" />
+      </MemoryRouter>,
+    );
 
     const brandName = screen.getByText("✨ Lazy Note");
     expect(brandName).toBeInTheDocument();
@@ -22,14 +31,22 @@ describe("BrandName", () => {
   });
 
   it("デフォルトでヘッダーバリアントが使用される", () => {
-    render(<BrandName />);
+    render(
+      <MemoryRouter>
+        <BrandName />
+      </MemoryRouter>,
+    );
 
     const brandName = screen.getByText("✨ Lazy Note");
     expect(brandName).toBeInTheDocument();
   });
 
   it("showIcon=falseの時、アイコンが表示されない", () => {
-    render(<BrandName showIcon={false} />);
+    render(
+      <MemoryRouter>
+        <BrandName showIcon={false} />
+      </MemoryRouter>,
+    );
 
     const brandName = screen.getByText("Lazy Note");
     expect(brandName).toBeInTheDocument();
@@ -37,10 +54,38 @@ describe("BrandName", () => {
   });
 
   it("showIcon=trueの時、アイコンが表示される", () => {
-    render(<BrandName showIcon={true} />);
+    render(
+      <MemoryRouter>
+        <BrandName showIcon={true} />
+      </MemoryRouter>,
+    );
 
     const brandName = screen.getByText("✨ Lazy Note");
     expect(brandName).toBeInTheDocument();
     expect(brandName.textContent).toContain("✨");
+  });
+
+  it("ホームページへのリンクとして機能する", () => {
+    render(
+      <MemoryRouter>
+        <BrandName />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link", { name: "✨ Lazy Note" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/");
+  });
+
+  it("フッターバリアントでもホームページへのリンクとして機能する", () => {
+    render(
+      <MemoryRouter>
+        <BrandName variant="footer" />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link", { name: "✨ Lazy Note" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/");
   });
 });


### PR DESCRIPTION
## 概要

ヘッダーの BrandName がただのテキスト（`<div>`）であり、クリックしてもホームに遷移しない問題を修正。ブログにおいてサイト名がホームへのリンクであることはユーザーの標準的な期待。

Closes #314

## 変更内容

- `src/components/common/BrandName.tsx`: ルートの `<div>` を `react-router-dom` の `<Link to="/">` に変更。`textDecoration: "none"` を追加してリンクの下線を非表示化
- `src/components/common/__tests__/BrandName.test.tsx`: 全既存テストに `MemoryRouter` ラップを追加、リンク機能テスト2件を新規追加

## 備考

- Phase 2 (P1: 低リスク改善) の一環
- Header.test.tsx、Footer.test.tsxはBrandNameをモック化済みのため影響なし
- `pnpm build` 全て成功確認済み（全169テスト通過）