### PR TITLE
fix: font-size: 10px を 62.5% に変更しアクセシビリティ改善

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
 
 :root {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
-  font-size: 10px;
+  font-size: 62.5%;
   line-height: 1.6;
   font-weight: 400;
 


### PR DESCRIPTION
## 概要

`:root` の `font-size: 10px` はブラウザのフォントサイズ設定を上書きしてしまうアクセシビリティ上の問題を修正。`62.5%` に変更することで、計算上同じ 10px 相当を維持しつつ、ユーザーのブラウザ設定に追従する。

Closes #315

## 変更内容

- `src/index.css`: `font-size: 10px;` → `font-size: 62.5%;`

## 技術的背景

- ブラウザデフォルト 16px × 62.5% = 10px（既存の表示は維持）
- ユーザーが font-size を 20px に変更した場合、62.5% = 12.5px となり全体がスケール（WCAG 1.4.4 準拠）
- 既存の `em` ベーストークンは親要素の font-size に対する相対値のため影響なし

## 備考

- Phase 2 (P1: 低リスク改善) の一環
- `pnpm build` 全て成功確認済み