### PR TITLE
refactor: コンポーネントのハードコードpx値をデザイントークンに統一

### DIFF
--- a/src/components/atoms/Link.tsx
+++ b/src/components/atoms/Link.tsx
@@ -36,7 +36,7 @@ export const Link = ({
     navigation: css({
       display: "inline-flex",
       alignItems: "center",
-      gap: "8px",
+      gap: "sm",
       color: "blue.light",
       fontSize: "sm",
       fontWeight: "600",
@@ -48,11 +48,11 @@ export const Link = ({
       display: "inline-flex",
       alignItems: "center",
       justifyContent: "center",
-      padding: "12px 16px",
+      padding: "sm-md md",
       background: "blue.light",
       color: "white",
       fontWeight: "600",
-      borderRadius: "8px",
+      borderRadius: "md",
       "&:hover": {
         background: "blue.dark",
         transform: "translateY(-1px)",

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -13,9 +13,9 @@ const navStyles = css({
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
-  gap: "16px",
-  marginTop: "32px",
-  paddingY: "24px",
+  gap: "md",
+  marginTop: "xl",
+  paddingY: "lg",
 });
 
 const buttonMinWidthStyles = css({
@@ -23,7 +23,7 @@ const buttonMinWidthStyles = css({
 });
 
 const pageInfoStyles = css({
-  fontSize: "16px",
+  fontSize: "base",
   fontWeight: "500",
   color: "text.primary",
   minWidth: "120px",

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -36,7 +36,7 @@ export const Header = ({ postCount }: HeaderProps) => {
               color: "fg.1",
               paddingY: "sm",
               paddingX: "md",
-              borderRadius: "20px",
+              borderRadius: "xl",
               fontSize: "sm",
               fontWeight: "bold",
               boxShadow: "card",

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -19,19 +19,19 @@ const containerStyles = css({
   maxWidth: "900px",
   margin: "0 auto",
   padding: "content",
-  paddingX: "32px",
+  paddingX: "xl",
 });
 
 const postListStyles = css({
   display: "flex",
   flexDirection: "column",
-  gap: "32px",
-  paddingTop: "12px",
+  gap: "xl",
+  paddingTop: "sm-md",
 });
 
 const articleStyles = css({
   background: "bg.1",
-  borderRadius: "12px",
+  borderRadius: "lg",
   overflow: "hidden",
   boxShadow: "card",
   transition: "transform 0.2s ease, box-shadow 0.2s ease",
@@ -43,8 +43,8 @@ const articleStyles = css({
 
 const articleHeaderStyles = css({
   padding: "card",
-  paddingBottom: "16px",
-  paddingX: "12px",
+  paddingBottom: "md",
+  paddingX: "sm-md",
   borderBottom: "1px solid",
   borderColor: "surface.200",
 });

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -18,7 +18,7 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
           background: "bg.1",
           borderBottom: "1px solid",
           borderColor: "bg.3",
-          paddingY: "12px",
+          paddingY: "sm-md",
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
@@ -52,7 +52,7 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
           <article
             className={css({
               background: "bg.1",
-              borderRadius: "12px",
+              borderRadius: "lg",
               overflow: "hidden",
               boxShadow: "card-hover",
               border: "1px solid",


### PR DESCRIPTION
## 概要

複数のコンポーネントでハードコードされた px 値を Panda CSS のデザイントークンに統一し、デザインの一貫性を確保する。

Closes #316

## 変更内容

- `src/components/common/Pagination.tsx`: gap/marginTop/paddingY/fontSizeのpx値をトークン化
- `src/components/pages/HomePage.tsx`: paddingX/gap/paddingTop/borderRadius/paddingBottom等のpx値をトークン化
- `src/components/pages/PostDetailPage.tsx`: paddingY/borderRadiusのpx値をトークン化
- `src/components/atoms/Link.tsx`: gap/padding/borderRadiusのpx値をトークン化
- `src/components/layouts/Header.tsx`: borderRadiusのpx値をトークン化

### 維持した値
- `minWidth: "100px"` / `"120px"` (Pagination): 対応するトークンなし
- `maxWidth: "900px"`: sizes.contentトークンへの置換は別途対応

## 備考

- Phase 2 (P1: 低リスク改善) の一環
- 全トークン値はpanda.config.tsの定義と一致確認済み
- `pnpm build` 全て成功確認済み