### PR TITLE
feat: Gruvboxテーマシステム基盤を実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Lazy Note - シンプルで読みやすいブログプラットフォーム。日々の思考やアイデアを気軽に記録・共有できます。" />
     <title>Lazy Note</title>
+    <script>
+      try {
+        var t = localStorage.getItem("theme");
+        if (!t) t = matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+        document.documentElement.dataset.theme = t;
+      } catch(e) {
+        document.documentElement.dataset.theme = "dark";
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,10 @@
     <script>
       try {
         var t = localStorage.getItem("theme");
-        if (!t) t = matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+        if (t !== "light" && t !== "dark") {
+          t = matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+          localStorage.setItem("theme", t);
+        }
         document.documentElement.dataset.theme = t;
       } catch(e) {
         document.documentElement.dataset.theme = "dark";

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -10,6 +10,13 @@ export default defineConfig({
   // Files to exclude
   exclude: [],
 
+  conditions: {
+    extend: {
+      light: "[data-theme=light] &",
+      dark: "[data-theme=dark] &",
+    },
+  },
+
   // Useful for theme customization
   theme: {
     tokens: {
@@ -37,20 +44,31 @@ export default defineConfig({
     extend: {
       tokens: {
         colors: {
-          // Gruvbox dark color palette
-          bg: {
-            0: { value: "#282828" }, // bg0
-            1: { value: "#3c3836" }, // bg1
-            2: { value: "#504945" }, // bg2
-            3: { value: "#665c54" }, // bg3
-            4: { value: "#7c6f64" }, // bg4
-          },
-          fg: {
-            0: { value: "#fbf1c7" }, // fg0
-            1: { value: "#ebdbb2" }, // fg1
-            2: { value: "#d5c4a1" }, // fg2
-            3: { value: "#bdae93" }, // fg3
-            4: { value: "#a89984" }, // fg4
+          gruvbox: {
+            dark: {
+              bg0: { value: "#282828" },
+              bg1: { value: "#3c3836" },
+              bg2: { value: "#504945" },
+              bg3: { value: "#665c54" },
+              bg4: { value: "#7c6f64" },
+              fg0: { value: "#fbf1c7" },
+              fg1: { value: "#ebdbb2" },
+              fg2: { value: "#d5c4a1" },
+              fg3: { value: "#bdae93" },
+              fg4: { value: "#a89984" },
+            },
+            light: {
+              bg0: { value: "#fbf1c7" },
+              bg1: { value: "#ebdbb2" },
+              bg2: { value: "#d5c4a1" },
+              bg3: { value: "#bdae93" },
+              bg4: { value: "#a89984" },
+              fg0: { value: "#282828" },
+              fg1: { value: "#3c3836" },
+              fg2: { value: "#504945" },
+              fg3: { value: "#665c54" },
+              fg4: { value: "#7c6f64" },
+            },
           },
           red: {
             light: { value: "#fb4934" },
@@ -85,17 +103,6 @@ export default defineConfig({
             dark: { value: "#928374" },
           },
         },
-        gradients: {
-          hero: { value: "linear-gradient(135deg, #458588 0%, #689d6a 100%)" },
-          card: { value: "linear-gradient(145deg, #3c3836 0%, #282828 100%)" },
-          accent: { value: "linear-gradient(90deg, #fe8019 0%, #d65d0e 100%)" },
-          primary: {
-            value: "linear-gradient(135deg, #458588 0%, #689d6a 100%)",
-          },
-          cardStripe: {
-            value: "linear-gradient(90deg, #458588 0%, #689d6a 100%)",
-          },
-        },
         spacing: {
           "2xs": { value: "2px" },
           xs: { value: "4px" },
@@ -124,16 +131,143 @@ export default defineConfig({
           article: { value: "800px" },
           header: { value: "70px" },
         },
-        shadows: {
-          card: {
-            value:
+      },
+    },
+    semanticTokens: {
+      colors: {
+        bg: {
+          0: {
+            value: {
+              _dark: "{colors.gruvbox.dark.bg0}",
+              _light: "{colors.gruvbox.light.bg0}",
+            },
+          },
+          1: {
+            value: {
+              _dark: "{colors.gruvbox.dark.bg1}",
+              _light: "{colors.gruvbox.light.bg1}",
+            },
+          },
+          2: {
+            value: {
+              _dark: "{colors.gruvbox.dark.bg2}",
+              _light: "{colors.gruvbox.light.bg2}",
+            },
+          },
+          3: {
+            value: {
+              _dark: "{colors.gruvbox.dark.bg3}",
+              _light: "{colors.gruvbox.light.bg3}",
+            },
+          },
+          4: {
+            value: {
+              _dark: "{colors.gruvbox.dark.bg4}",
+              _light: "{colors.gruvbox.light.bg4}",
+            },
+          },
+        },
+        fg: {
+          0: {
+            value: {
+              _dark: "{colors.gruvbox.dark.fg0}",
+              _light: "{colors.gruvbox.light.fg0}",
+            },
+          },
+          1: {
+            value: {
+              _dark: "{colors.gruvbox.dark.fg1}",
+              _light: "{colors.gruvbox.light.fg1}",
+            },
+          },
+          2: {
+            value: {
+              _dark: "{colors.gruvbox.dark.fg2}",
+              _light: "{colors.gruvbox.light.fg2}",
+            },
+          },
+          3: {
+            value: {
+              _dark: "{colors.gruvbox.dark.fg3}",
+              _light: "{colors.gruvbox.light.fg3}",
+            },
+          },
+          4: {
+            value: {
+              _dark: "{colors.gruvbox.dark.fg4}",
+              _light: "{colors.gruvbox.light.fg4}",
+            },
+          },
+        },
+        accent: {
+          blue: {
+            value: {
+              _dark: "{colors.blue.light}",
+              _light: "{colors.blue.dark}",
+            },
+          },
+          "blue-hover": {
+            value: {
+              _dark: "{colors.aqua.light}",
+              _light: "{colors.aqua.dark}",
+            },
+          },
+        },
+      },
+      shadows: {
+        card: {
+          value: {
+            _dark:
               "0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2)",
+            _light:
+              "0 4px 6px -1px rgba(0, 0, 0, 0.08), 0 2px 4px -1px rgba(0, 0, 0, 0.05)",
           },
-          "card-hover": {
-            value:
+        },
+        "card-hover": {
+          value: {
+            _dark:
               "0 20px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.2)",
+            _light:
+              "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.06)",
           },
-          glow: { value: "0 0 20px rgba(131, 165, 152, 0.4)" },
+        },
+        glow: {
+          value: {
+            _dark: "0 0 20px rgba(131, 165, 152, 0.4)",
+            _light: "0 0 20px rgba(69, 133, 136, 0.3)",
+          },
+        },
+      },
+      gradients: {
+        hero: {
+          value: {
+            _dark: "linear-gradient(135deg, #458588 0%, #689d6a 100%)",
+            _light: "linear-gradient(135deg, #076678 0%, #79740e 100%)",
+          },
+        },
+        card: {
+          value: {
+            _dark: "linear-gradient(145deg, #3c3836 0%, #282828 100%)",
+            _light: "linear-gradient(145deg, #ebdbb2 0%, #fbf1c7 100%)",
+          },
+        },
+        accent: {
+          value: {
+            _dark: "linear-gradient(90deg, #fe8019 0%, #d65d0e 100%)",
+            _light: "linear-gradient(90deg, #af3a03 0%, #d65d0e 100%)",
+          },
+        },
+        primary: {
+          value: {
+            _dark: "linear-gradient(135deg, #458588 0%, #689d6a 100%)",
+            _light: "linear-gradient(135deg, #076678 0%, #79740e 100%)",
+          },
+        },
+        cardStripe: {
+          value: {
+            _dark: "linear-gradient(90deg, #458588 0%, #689d6a 100%)",
+            _light: "linear-gradient(90deg, #076678 0%, #79740e 100%)",
+          },
         },
       },
     },

--- a/src/components/common/ThemeToggle.tsx
+++ b/src/components/common/ThemeToggle.tsx
@@ -1,0 +1,47 @@
+import { Switch } from "@headlessui/react";
+import { css } from "../../../styled-system/css";
+import { useTheme } from "../../hooks/useTheme";
+
+const switchStyles = css({
+  position: "relative",
+  display: "inline-flex",
+  alignItems: "center",
+  width: "56px",
+  height: "28px",
+  borderRadius: "full",
+  border: "2px solid",
+  borderColor: "bg.3",
+  cursor: "pointer",
+  transition: "all 0.2s ease",
+  background: "bg.2",
+});
+
+const thumbStyles = css({
+  display: "inline-block",
+  width: "20px",
+  height: "20px",
+  borderRadius: "full",
+  background: "fg.0",
+  transition: "transform 0.2s ease",
+});
+
+const thumbTranslateOff = css({ transform: "translateX(2px)" });
+const thumbTranslateOn = css({ transform: "translateX(28px)" });
+
+export const ThemeToggle = () => {
+  const { theme, toggleTheme } = useTheme();
+  const isLight = theme === "light";
+
+  return (
+    <Switch
+      checked={isLight}
+      onChange={toggleTheme}
+      className={switchStyles}
+      aria-label="テーマ切替"
+    >
+      <span
+        className={`${thumbStyles} ${isLight ? thumbTranslateOn : thumbTranslateOff}`}
+      />
+    </Switch>
+  );
+};

--- a/src/components/common/__tests__/ThemeToggle.test.tsx
+++ b/src/components/common/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ThemeToggle } from "../ThemeToggle";
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.dataset.theme = "dark";
+  });
+
+  it("スイッチが表示される", () => {
+    render(<ThemeToggle />);
+
+    const toggle = screen.getByRole("switch", { name: "テーマ切替" });
+    expect(toggle).toBeInTheDocument();
+  });
+
+  it("クリックでテーマがdarkからlightに切り替わる", () => {
+    render(<ThemeToggle />);
+
+    const toggle = screen.getByRole("switch", { name: "テーマ切替" });
+    fireEvent.click(toggle);
+
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+
+  it("クリック2回でテーマがdarkに戻る", () => {
+    render(<ThemeToggle />);
+
+    const toggle = screen.getByRole("switch", { name: "テーマ切替" });
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+
+    expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+});

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,5 +1,6 @@
 import { css } from "../../../styled-system/css";
 import { BrandName } from "../common/BrandName";
+import { ThemeToggle } from "../common/ThemeToggle";
 
 interface HeaderProps {
   postCount?: number;
@@ -29,22 +30,31 @@ export const Header = ({ postCount }: HeaderProps) => {
       >
         <BrandName variant="header" />
 
-        {postCount !== undefined && (
-          <div
-            className={css({
-              background: "bg.2",
-              color: "fg.1",
-              paddingY: "sm",
-              paddingX: "md",
-              borderRadius: "xl",
-              fontSize: "sm",
-              fontWeight: "bold",
-              boxShadow: "card",
-            })}
-          >
-            📚 {postCount}記事
-          </div>
-        )}
+        <div
+          className={css({
+            display: "flex",
+            alignItems: "center",
+            gap: "md",
+          })}
+        >
+          {postCount !== undefined && (
+            <div
+              className={css({
+                background: "bg.2",
+                color: "fg.1",
+                paddingY: "sm",
+                paddingX: "md",
+                borderRadius: "xl",
+                fontSize: "sm",
+                fontWeight: "bold",
+                boxShadow: "card",
+              })}
+            >
+              📚 {postCount}記事
+            </div>
+          )}
+          <ThemeToggle />
+        </div>
       </div>
     </header>
   );

--- a/src/hooks/__tests__/useTheme.test.ts
+++ b/src/hooks/__tests__/useTheme.test.ts
@@ -1,0 +1,87 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useTheme } from "../useTheme";
+
+describe("useTheme", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.dataset.theme = "dark";
+    vi.restoreAllMocks();
+  });
+
+  it("デフォルトで'dark'を返す", () => {
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe("dark");
+  });
+
+  it("localStorageに'light'が保存されている場合に'light'を返す", () => {
+    localStorage.setItem("theme", "light");
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe("light");
+  });
+
+  it("setThemeでテーマを'light'に切替できる", () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.setTheme("light");
+    });
+
+    expect(result.current.theme).toBe("light");
+  });
+
+  it("setThemeでテーマを'dark'に切替できる", () => {
+    localStorage.setItem("theme", "light");
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.setTheme("dark");
+    });
+
+    expect(result.current.theme).toBe("dark");
+  });
+
+  it("toggleThemeでdarkからlightに切替できる", () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(result.current.theme).toBe("light");
+  });
+
+  it("toggleThemeでlightからdarkに切替できる", () => {
+    localStorage.setItem("theme", "light");
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(result.current.theme).toBe("dark");
+  });
+
+  it("setThemeがlocalStorageに値を保存する", () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.setTheme("light");
+    });
+
+    expect(localStorage.getItem("theme")).toBe("light");
+  });
+
+  it("setThemeがdocument.documentElement.dataset.themeを更新する", () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.setTheme("light");
+    });
+
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+});

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,47 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+type Theme = "dark" | "light";
+const STORAGE_KEY = "theme";
+
+const getThemeSnapshot = (): Theme => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark") return stored;
+  } catch {
+    /* localStorageにアクセスできない場合はデフォルト値を返す */
+  }
+  return "dark";
+};
+
+const getServerSnapshot = (): Theme => "dark";
+
+const subscribe = (callback: () => void): (() => void) => {
+  const handleStorage = (e: StorageEvent) => {
+    if (e.key === STORAGE_KEY) callback();
+  };
+  window.addEventListener("storage", handleStorage);
+  return () => window.removeEventListener("storage", handleStorage);
+};
+
+export const useTheme = () => {
+  const theme = useSyncExternalStore(
+    subscribe,
+    getThemeSnapshot,
+    getServerSnapshot,
+  );
+
+  const setTheme = useCallback((newTheme: Theme) => {
+    localStorage.setItem(STORAGE_KEY, newTheme);
+    document.documentElement.dataset.theme = newTheme;
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: STORAGE_KEY }),
+    );
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    const current = getThemeSnapshot();
+    setTheme(current === "dark" ? "light" : "dark");
+  }, [setTheme]);
+
+  return { theme, setTheme, toggleTheme };
+};

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -10,7 +10,11 @@ const getThemeSnapshot = (): Theme => {
       return stored;
     }
   } catch {
-    /* localStorageにアクセスできない場合はデフォルト値を返す */
+    /* localStorageにアクセスできない場合はフォールバック */
+  }
+  const domTheme = document.documentElement.dataset.theme;
+  if (domTheme === "light" || domTheme === "dark") {
+    return domTheme;
   }
   return "dark";
 };

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -6,7 +6,9 @@ const STORAGE_KEY = "theme";
 const getThemeSnapshot = (): Theme => {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === "light" || stored === "dark") return stored;
+    if (stored === "light" || stored === "dark") {
+      return stored;
+    }
   } catch {
     /* localStorageにアクセスできない場合はデフォルト値を返す */
   }
@@ -17,7 +19,9 @@ const getServerSnapshot = (): Theme => "dark";
 
 const subscribe = (callback: () => void): (() => void) => {
   const handleStorage = (e: StorageEvent) => {
-    if (e.key === STORAGE_KEY) callback();
+    if (e.key === STORAGE_KEY) {
+      callback();
+    }
   };
   window.addEventListener("storage", handleStorage);
   return () => window.removeEventListener("storage", handleStorage);
@@ -33,9 +37,7 @@ export const useTheme = () => {
   const setTheme = useCallback((newTheme: Theme) => {
     localStorage.setItem(STORAGE_KEY, newTheme);
     document.documentElement.dataset.theme = newTheme;
-    window.dispatchEvent(
-      new StorageEvent("storage", { key: STORAGE_KEY }),
-    );
+    window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
   }, []);
 
   const toggleTheme = useCallback(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,6 @@
   line-height: 1.6;
   font-weight: 400;
 
-  color-scheme: dark;
   color: var(--colors-fg-1);
   background: var(--colors-bg-0);
 
@@ -98,4 +97,7 @@ button:focus-visible {
     transform: rotate(360deg);
   }
 }
+
+[data-theme="dark"] { color-scheme: dark; }
+[data-theme="light"] { color-scheme: light; }
 


### PR DESCRIPTION
## 概要

Gruvboxカラーテーマのlight/dark切替システムを実装。Panda CSSのsemantic tokensとconditionsを活用し、`data-theme`属性によるテーマ切替基盤を構築。

## 変更内容

- panda.config.tsにlight/darkのconditionsとsemantic tokensを追加し、bg/fg/shadow/gradientをテーマ対応に移行
- index.htmlにFOUC防止スクリプトを追加（localStorage/prefers-color-schemeからテーマ初期化）
- src/index.cssのcolor-schemeをdata-theme属性ベースに変更
- useSyncExternalStoreベースのuseThemeフックを作成（localStorage同期、data-theme属性更新）
- Headless UI SwitchベースのThemeToggleコンポーネントを作成
- HeaderにThemeToggleを配置
- useThemeフックとThemeToggleコンポーネントのテストを追加

## 備考

closes #326