### PR TITLE
feat: レスポンシブデザイン対応

### DIFF
--- a/src/components/common/MetaInfo.tsx
+++ b/src/components/common/MetaInfo.tsx
@@ -12,7 +12,12 @@ const containerStyles = css({
   display: "flex",
   alignItems: "center",
   justifyContent: "space-between",
-  gap: "md",
+  flexWrap: "wrap",
+  gap: "sm",
+  md: {
+    gap: "md",
+    flexWrap: "nowrap",
+  },
 });
 
 const itemBaseStyles = css({

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -13,21 +13,31 @@ const navStyles = css({
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
-  gap: "md",
+  gap: "sm",
   marginTop: "xl",
   paddingY: "lg",
+  md: {
+    gap: "md",
+  },
 });
 
 const buttonMinWidthStyles = css({
-  minWidth: "100px",
+  minWidth: "80px",
+  md: {
+    minWidth: "100px",
+  },
 });
 
 const pageInfoStyles = css({
-  fontSize: "base",
+  fontSize: "sm",
   fontWeight: "500",
   color: "fg.1",
-  minWidth: "120px",
+  minWidth: "100px",
   textAlign: "center",
+  md: {
+    fontSize: "base",
+    minWidth: "120px",
+  },
 });
 
 /**

--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -7,13 +7,16 @@ export const Footer = () => {
       className={css({
         background: "bg.1",
         color: "fg.2",
-        padding: "content",
+        padding: "md",
         minHeight: "header",
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
         textAlign: "center",
+        md: {
+          padding: "content",
+        },
       })}
     >
       <div

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -13,10 +13,14 @@ export const Header = ({ postCount }: HeaderProps) => {
         background: "bg.0",
         color: "fg.1",
         paddingY: "content",
+        paddingX: "md",
         minHeight: "header",
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
+        md: {
+          paddingX: "0",
+        },
       })}
     >
       <div

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -16,10 +16,13 @@ interface HomePageProps {
 
 // スタイルをコンポーネント外に定数として定義
 const containerStyles = css({
-  maxWidth: "900px",
+  maxWidth: "content",
   margin: "0 auto",
   padding: "content",
-  paddingX: "xl",
+  paddingX: "md",
+  md: {
+    paddingX: "xl",
+  },
 });
 
 const postListStyles = css({
@@ -42,15 +45,22 @@ const articleStyles = css({
 });
 
 const articleHeaderStyles = css({
-  padding: "card",
+  padding: "sm-md",
   paddingBottom: "md",
-  paddingX: "sm-md",
   borderBottom: "1px solid",
   borderColor: "bg.3",
+  md: {
+    padding: "card",
+    paddingBottom: "md",
+    paddingX: "sm-md",
+  },
 });
 
 const articleContentStyles = css({
-  padding: "card",
+  padding: "sm-md",
+  md: {
+    padding: "card",
+  },
 });
 
 /**

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -19,14 +19,18 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
           borderBottom: "1px solid",
           borderColor: "bg.3",
           paddingY: "sm-md",
+          paddingX: "md",
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
+          md: {
+            paddingX: "0",
+          },
         })}
       >
         <div
           className={css({
-            maxWidth: "900px",
+            maxWidth: "content",
             width: "100%",
           })}
         >
@@ -46,7 +50,10 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
           className={css({
             maxWidth: "article",
             margin: "0 auto",
-            padding: "content",
+            padding: "md",
+            md: {
+              padding: "content",
+            },
           })}
         >
           <article
@@ -64,7 +71,10 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
               className={css({
                 background: "gradients.primary",
                 color: "fg.0",
-                padding: "section",
+                padding: "md",
+                md: {
+                  padding: "section",
+                },
               })}
             >
               <Heading1
@@ -92,9 +102,14 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
             {/* Article Content */}
             <div
               className={css({
-                paddingRight: "section",
-                paddingLeft: "section",
-                paddingBottom: "section",
+                paddingRight: "md",
+                paddingLeft: "md",
+                paddingBottom: "md",
+                md: {
+                  paddingRight: "section",
+                  paddingLeft: "section",
+                  paddingBottom: "section",
+                },
                 lineHeight: "body",
                 fontSize: "base",
                 color: "fg.1",


### PR DESCRIPTION
## 概要

全コンポーネントにPanda CSSのブレイクポイント（md: 48rem=768px）を使用したレスポンシブスタイルを追加し、モバイル端末での表示を改善する。

## 変更内容

- Header: モバイルでpaddingXを追加し、md以上で解除。コンテンツが画面端に張り付かないようにする
- Footer: モバイルでpadding縮小（md → content）し、md以上で元のcontent幅に復帰
- HomePage: containerのpaddingXをレスポンシブ化（md → xl）、カードヘッダー・コンテンツの余白をモバイル対応、maxWidthをハードコード値からcontentトークンに変更
- PostDetailPage: ナビゲーションバー・記事ラッパー・記事ヘッダー・記事コンテンツのpaddingをモバイル対応。ナビバーのmaxWidthもcontentトークンに統一
- Pagination: ボタン最小幅・フォントサイズ・gapをモバイルで縮小し、md以上で元のサイズに復帰
- MetaInfo: flexWrapとgapをレスポンシブ対応し、小画面での折り返し表示に対応

## 備考

- Panda CSSのデフォルトブレイクポイント md（48rem=768px）をモバイルファーストで使用
- PostDetailPageのハードコードされた `maxWidth: "900px"` を `content` トークンに統一

Closes #327