### PR TITLE
feat: 記事カード改善（抜粋表示 + 読了時間）

### DIFF
--- a/src/api/__tests__/posts.test.ts
+++ b/src/api/__tests__/posts.test.ts
@@ -68,12 +68,16 @@ describe("createPostsMiddleware", () => {
           title: "テスト記事2",
           createdAt: "2025-01-02",
           author: "花子",
+          excerpt: "",
+          readingTimeMinutes: 1,
         },
         {
           id: "20250101",
           title: "テスト記事1",
           createdAt: "2025-01-01",
           author: "太郎",
+          excerpt: "",
+          readingTimeMinutes: 1,
         },
       ];
       expect(res.end).toHaveBeenCalledWith(JSON.stringify(expectedPosts));

--- a/src/components/common/MetaInfo.tsx
+++ b/src/components/common/MetaInfo.tsx
@@ -4,6 +4,7 @@ import { css } from "../../../styled-system/css";
 interface MetaInfoProps {
   createdAt?: string;
   author?: string;
+  readingTimeMinutes?: number;
   variant?: "card" | "header";
 }
 
@@ -38,7 +39,12 @@ const itemHeaderStyles = css({
  * メタ情報コンポーネント（CSS定数抽出 + React.memoでメモ化）
  */
 export const MetaInfo = memo(
-  ({ createdAt, author, variant = "card" }: MetaInfoProps) => {
+  ({
+    createdAt,
+    author,
+    readingTimeMinutes,
+    variant = "card",
+  }: MetaInfoProps) => {
     const itemVariantStyles =
       variant === "header" ? itemHeaderStyles : itemCardStyles;
 
@@ -52,6 +58,12 @@ export const MetaInfo = memo(
           <span>✍️</span>
           <span>{author || "匿名"}</span>
         </div>
+        {readingTimeMinutes !== undefined && (
+          <div className={`${itemBaseStyles} ${itemVariantStyles}`}>
+            <span>⏱</span>
+            <span>{readingTimeMinutes}分で読了</span>
+          </div>
+        )}
       </div>
     );
   },

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -53,6 +53,13 @@ const articleContentStyles = css({
   padding: "card",
 });
 
+const excerptStyles = css({
+  fontSize: "sm",
+  color: "fg.3",
+  lineHeight: "body",
+  marginTop: "sm",
+});
+
 /**
  * ホームページコンポーネント（CSS定数抽出 + React.memoでメモ化）
  */
@@ -75,6 +82,7 @@ export const HomePage = memo(
                     <MetaInfo
                       createdAt={post.createdAt}
                       author={post.author}
+                      readingTimeMinutes={post.readingTimeMinutes}
                       variant="card"
                     />
                   </div>
@@ -85,6 +93,9 @@ export const HomePage = memo(
                         {post.title || "無題の記事"}
                       </Heading2>
                     </Link>
+                    {post.excerpt && (
+                      <p className={excerptStyles}>{post.excerpt}</p>
+                    )}
                   </div>
                 </article>
               ))}

--- a/src/components/pages/__tests__/HomePage.test.tsx
+++ b/src/components/pages/__tests__/HomePage.test.tsx
@@ -12,6 +12,8 @@ const mockPosts: Post[] = [
     author: "著者1",
     createdAt: "2024-01-01",
     rawContent: "# テスト記事1\n\nテストコンテンツ1",
+    excerpt: "テストコンテンツ1の抜粋です",
+    readingTimeMinutes: 1,
   },
   {
     id: "test-post-2",
@@ -20,6 +22,8 @@ const mockPosts: Post[] = [
     author: "著者2",
     createdAt: "2024-01-02",
     rawContent: "# テスト記事2\n\nテストコンテンツ2",
+    excerpt: "テストコンテンツ2の抜粋です",
+    readingTimeMinutes: 3,
   },
 ];
 
@@ -122,6 +126,8 @@ describe("HomePage", () => {
         author: "著者",
         createdAt: "2024-01-01",
         rawContent: "コンテンツ",
+        excerpt: "",
+        readingTimeMinutes: 1,
       },
     ];
 

--- a/src/components/pages/__tests__/PostDetailPage.test.tsx
+++ b/src/components/pages/__tests__/PostDetailPage.test.tsx
@@ -13,6 +13,8 @@ const mockPost: Post = {
   createdAt: "2024-01-15",
   rawContent:
     "# テスト記事タイトル\n\nこれはテスト記事の内容です。\n\n## 見出し\n\n追加のコンテンツ",
+  excerpt: "これはテスト記事の内容です。追加のコンテンツ",
+  readingTimeMinutes: 1,
 };
 
 describe("PostDetailPage", () => {

--- a/src/hooks/__tests__/usePost.test.ts
+++ b/src/hooks/__tests__/usePost.test.ts
@@ -17,6 +17,8 @@ const mockPost = {
   author: "太郎",
   rawContent:
     "# 最初の記事\n\n## 投稿日時\n- 2024-01-01 10:00\n\n## 筆者名\n- 太郎\n\n## 本文\n最初の記事の内容です。",
+  excerpt: "最初の記事の内容です。",
+  readingTimeMinutes: 1,
 };
 
 describe("usePost", () => {

--- a/src/hooks/__tests__/usePosts.test.ts
+++ b/src/hooks/__tests__/usePosts.test.ts
@@ -15,12 +15,16 @@ const mockPosts = [
     title: "2つ目の記事",
     createdAt: "2024-01-02 12:00",
     author: "花子",
+    excerpt: "2つ目の記事の内容です。",
+    readingTimeMinutes: 1,
   },
   {
     id: "20240101100000",
     title: "最初の記事",
     createdAt: "2024-01-01 10:00",
     author: "太郎",
+    excerpt: "最初の記事の内容です。",
+    readingTimeMinutes: 1,
   },
 ];
 

--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -144,9 +144,7 @@ describe("markdown.ts", () => {
 
       const result = parseMarkdown(content, "20240101100000");
 
-      expect(result.content).toBe(
-        "<p>1行目です。</p>\n<p>2行目です。</p>\n",
-      );
+      expect(result.content).toBe("<p>1行目です。</p>\n<p>2行目です。</p>\n");
     });
   });
 });

--- a/src/lib/__tests__/markdownParser.test.ts
+++ b/src/lib/__tests__/markdownParser.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateReadingTime,
+  extractExcerpt,
+  extractSummaryFromContent,
+} from "../markdownParser";
+
+describe("extractExcerpt", () => {
+  it("Markdown記法が除去される", () => {
+    const markdown = [
+      "### 見出し",
+      "**太字**のテスト",
+      "*斜体*のテスト",
+      "`コード`のテスト",
+      "[リンク](https://example.com)のテスト",
+      "![画像](image.png)",
+      "- リスト項目",
+      "1. 番号付き項目",
+      "> 引用テキスト",
+      "---",
+    ].join("\n");
+
+    const result = extractExcerpt(markdown);
+
+    expect(result).not.toContain("###");
+    expect(result).not.toContain("**");
+    expect(result).not.toContain("`");
+    expect(result).not.toContain("[リンク](");
+    expect(result).not.toContain("![");
+    expect(result).not.toContain("---");
+    expect(result).toContain("太字");
+    expect(result).toContain("斜体");
+    expect(result).toContain("コード");
+    expect(result).toContain("リンク");
+    expect(result).toContain("リスト項目");
+    expect(result).toContain("番号付き項目");
+    expect(result).toContain("引用テキスト");
+  });
+
+  it("150文字以上で省略される", () => {
+    const longText = "あ".repeat(200);
+
+    const result = extractExcerpt(longText);
+
+    expect(result.length).toBe(153);
+    expect(result).toMatch(/\.\.\.$/);
+  });
+
+  it("空テキストで空文字を返す", () => {
+    const result = extractExcerpt("");
+
+    expect(result).toBe("");
+  });
+
+  it("150文字以下のテキストは省略されない", () => {
+    const shortText = "これは短いテキストです。";
+
+    const result = extractExcerpt(shortText);
+
+    expect(result).toBe(shortText);
+    expect(result).not.toContain("...");
+  });
+});
+
+describe("calculateReadingTime", () => {
+  it("400文字で1分を返す", () => {
+    const text = "あ".repeat(400);
+
+    const result = calculateReadingTime(text);
+
+    expect(result).toBe(1);
+  });
+
+  it("800文字で2分を返す", () => {
+    const text = "あ".repeat(800);
+
+    const result = calculateReadingTime(text);
+
+    expect(result).toBe(2);
+  });
+
+  it("0文字で1分を返す", () => {
+    const result = calculateReadingTime("");
+
+    expect(result).toBe(1);
+  });
+
+  it("空白のみの場合も1分を返す", () => {
+    const result = calculateReadingTime("   \n\n  ");
+
+    expect(result).toBe(1);
+  });
+
+  it("401文字で2分を返す（切り上げ）", () => {
+    const text = "あ".repeat(401);
+
+    const result = calculateReadingTime(text);
+
+    expect(result).toBe(2);
+  });
+});
+
+describe("extractSummaryFromContent", () => {
+  it("excerptとreadingTimeMinutesが含まれる", () => {
+    const content = `# テストタイトル
+
+## 投稿日時
+- 2024-01-01 10:00
+
+## 筆者名
+- テスト太郎
+
+## 本文
+これはテストの本文です。**太字**も含まれます。`;
+
+    const result = extractSummaryFromContent(content, "20240101100000");
+
+    expect(result.id).toBe("20240101100000");
+    expect(result.title).toBe("テストタイトル");
+    expect(result.createdAt).toBe("2024-01-01 10:00");
+    expect(result.author).toBe("テスト太郎");
+    expect(result.excerpt).toBe("これはテストの本文です。太字も含まれます。");
+    expect(result.readingTimeMinutes).toBe(1);
+  });
+
+  it("本文がない場合はexcerptが空文字でreadingTimeMinutesが1になる", () => {
+    const content = `# テストタイトル
+
+## 投稿日時
+- 2024-01-01 10:00
+
+## 筆者名
+- テスト太郎`;
+
+    const result = extractSummaryFromContent(content, "20240101100000");
+
+    expect(result.excerpt).toBe("");
+    expect(result.readingTimeMinutes).toBe(1);
+  });
+});

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,6 +1,8 @@
 import { marked } from "marked";
 import {
+  calculateReadingTime,
   extractBodyContent,
+  extractExcerpt,
   extractSectionContent,
   extractSummaryFromContent,
   extractTitle,
@@ -64,6 +66,8 @@ export const parseMarkdown = (content: string, timestamp: string): Post => {
     content: marked(bodyContent) as string,
     author,
     rawContent: content,
+    excerpt: extractExcerpt(bodyContent),
+    readingTimeMinutes: calculateReadingTime(bodyContent),
   };
 };
 

--- a/src/lib/markdownParser.ts
+++ b/src/lib/markdownParser.ts
@@ -69,7 +69,51 @@ export interface PostSummary {
   title: string;
   createdAt: string;
   author: string;
+  excerpt: string;
+  readingTimeMinutes: number;
 }
+
+/**
+ * 本文からMarkdown記法を除去し、先頭の指定文字数を抽出する
+ * @param bodyContent 本文のMarkdownコンテンツ
+ * @param maxLength 最大文字数（デフォルト: 150）
+ * @returns プレーンテキストの抜粋
+ */
+export const extractExcerpt = (
+  bodyContent: string,
+  maxLength = 150,
+): string => {
+  const plainText = bodyContent
+    .replace(/#{1,6}\s+/g, "")
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/\*(.+?)\*/g, "$1")
+    .replace(/`(.+?)`/g, "$1")
+    .replace(/\[(.+?)\]\(.+?\)/g, "$1")
+    .replace(/!\[.*?\]\(.+?\)/g, "")
+    .replace(/^[-*+]\s+/gm, "")
+    .replace(/^\d+\.\s+/gm, "")
+    .replace(/^>\s+/gm, "")
+    .replace(/---/g, "")
+    .replace(/\n{2,}/g, " ")
+    .replace(/\n/g, " ")
+    .trim();
+
+  if (plainText.length <= maxLength) {
+    return plainText;
+  }
+  return `${plainText.slice(0, maxLength)}...`;
+};
+
+/**
+ * 本文の文字数から読了時間を算出する（日本語400文字/分ベース）
+ * @param bodyContent 本文のMarkdownコンテンツ
+ * @returns 読了時間（分、最低1分）
+ */
+export const calculateReadingTime = (bodyContent: string): number => {
+  const charCount = bodyContent.replace(/\s/g, "").length;
+  const minutes = Math.ceil(charCount / 400);
+  return Math.max(1, minutes);
+};
 
 /**
  * Markdownコンテンツからサマリー（メタデータ）を抽出する
@@ -85,5 +129,13 @@ export const extractSummaryFromContent = (
   const title = extractTitle(lines);
   const createdAt = extractSectionContent(lines, "投稿日時");
   const author = extractSectionContent(lines, "筆者名");
-  return { id: timestamp, title, createdAt, author };
+  const bodyContent = extractBodyContent(lines);
+  return {
+    id: timestamp,
+    title,
+    createdAt,
+    author,
+    excerpt: extractExcerpt(bodyContent),
+    readingTimeMinutes: calculateReadingTime(bodyContent),
+  };
 };

--- a/src/pages/__tests__/index.test.tsx
+++ b/src/pages/__tests__/index.test.tsx
@@ -19,6 +19,8 @@ const mockPosts = [
     author: "花子",
     rawContent:
       "# 2つ目の記事\n\n## 投稿日時\n- 2024-01-02 12:00\n\n## 筆者名\n- 花子\n\n## 本文\n2つ目の記事の内容です。",
+    excerpt: "2つ目の記事の内容です。",
+    readingTimeMinutes: 1,
   },
   {
     id: "20240101100000",
@@ -28,6 +30,8 @@ const mockPosts = [
     author: "太郎",
     rawContent:
       "# 最初の記事\n\n## 投稿日時\n- 2024-01-01 10:00\n\n## 筆者名\n- 太郎\n\n## 本文\n最初の記事の内容です。",
+    excerpt: "最初の記事の内容です。",
+    readingTimeMinutes: 1,
   },
 ];
 

--- a/src/pages/posts/__tests__/Post.test.tsx
+++ b/src/pages/posts/__tests__/Post.test.tsx
@@ -25,6 +25,8 @@ const mockPost: PostType = {
   author: "モック著者",
   createdAt: "2024-01-20",
   rawContent: "# モックテスト記事\n\nモック記事の内容",
+  excerpt: "モック記事の内容",
+  readingTimeMinutes: 1,
 };
 
 describe("Post", () => {


### PR DESCRIPTION
## 概要

記事カードに抜粋テキストと読了時間を表示する機能を追加。ホームページの記事一覧で各記事の内容を把握しやすくし、読了時間の目安を提供する。

## 変更内容

- `PostSummary`型に`excerpt`（抜粋）と`readingTimeMinutes`（読了時間）フィールドを追加
- `extractExcerpt`関数: 本文からMarkdown記法を除去し先頭150文字を抽出
- `calculateReadingTime`関数: 日本語400文字/分ベースで読了時間を算出
- `MetaInfo`コンポーネントに読了時間の表示を追加
- `HomePage`コンポーネントに抜粋テキストの表示を追加
- 新規テスト: extractExcerpt、calculateReadingTime、extractSummaryFromContentのテストを追加
- 既存テストのモックデータにexcerptとreadingTimeMinutesを追加して型整合性を確保

## 備考

Closes #329