### PR TITLE
feat: スクロール管理基盤 + Back to Top + 読了プログレスバー

### DIFF
--- a/src/components/common/BackToTop.tsx
+++ b/src/components/common/BackToTop.tsx
@@ -1,0 +1,68 @@
+import { Transition } from "@headlessui/react";
+import { css } from "../../../styled-system/css";
+import { useScrollPosition } from "../../hooks/useScrollPosition";
+
+const SHOW_THRESHOLD = 300;
+
+const buttonStyles = css({
+  position: "fixed",
+  bottom: "32px",
+  right: "32px",
+  width: "48px",
+  height: "48px",
+  borderRadius: "full",
+  background: "bg.2",
+  color: "fg.1",
+  border: "1px solid",
+  borderColor: "bg.3",
+  cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  fontSize: "xl",
+  boxShadow: "card",
+  zIndex: 50,
+  transition: "all 0.2s ease",
+  "&:hover": {
+    background: "bg.3",
+    transform: "translateY(-2px)",
+    boxShadow: "card-hover",
+  },
+});
+
+const enterStyles = css({ transition: "all 0.2s ease" });
+const enterFromStyles = css({ opacity: 0, transform: "translateY(10px)" });
+const enterToStyles = css({ opacity: 1, transform: "translateY(0)" });
+const leaveStyles = css({ transition: "all 0.15s ease" });
+const leaveFromStyles = css({ opacity: 1, transform: "translateY(0)" });
+const leaveToStyles = css({ opacity: 0, transform: "translateY(10px)" });
+
+const handleClick = () => {
+  window.scrollTo({ top: 0, behavior: "smooth" });
+};
+
+export const BackToTop = () => {
+  const scrollY = useScrollPosition();
+  const isVisible = scrollY > SHOW_THRESHOLD;
+
+  return (
+    <Transition
+      show={isVisible}
+      enter={enterStyles}
+      enterFrom={enterFromStyles}
+      enterTo={enterToStyles}
+      leave={leaveStyles}
+      leaveFrom={leaveFromStyles}
+      leaveTo={leaveToStyles}
+    >
+      <button
+        type="button"
+        className={buttonStyles}
+        onClick={handleClick}
+        aria-label="ページトップへ戻る"
+      >
+        ↑
+      </button>
+    </Transition>
+  );
+};

--- a/src/components/common/ReadingProgressBar.tsx
+++ b/src/components/common/ReadingProgressBar.tsx
@@ -1,0 +1,34 @@
+import { css } from "../../../styled-system/css";
+import { useReadingProgress } from "../../hooks/useReadingProgress";
+
+const barContainerStyles = css({
+  position: "fixed",
+  top: 0,
+  left: 0,
+  right: 0,
+  height: "3px",
+  background: "bg.2",
+  zIndex: 100,
+});
+
+const barStyles = css({
+  height: "100%",
+  background: "accent.blue",
+  transition: "width 0.1s ease-out",
+});
+
+export const ReadingProgressBar = () => {
+  const progress = useReadingProgress();
+
+  return (
+    <div
+      className={barContainerStyles}
+      role="progressbar"
+      aria-valuenow={progress}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <div className={barStyles} style={{ width: `${progress}%` }} />
+    </div>
+  );
+};

--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathnameの変更をトリガーとしてスクロール位置をリセットする
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};

--- a/src/components/common/__tests__/BackToTop.test.tsx
+++ b/src/components/common/__tests__/BackToTop.test.tsx
@@ -1,0 +1,59 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BackToTop } from "../BackToTop";
+
+vi.mock("../../../hooks/useScrollPosition", () => ({
+  useScrollPosition: vi.fn(() => 0),
+}));
+
+import { useScrollPosition } from "../../../hooks/useScrollPosition";
+
+describe("BackToTop", () => {
+  beforeEach(() => {
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("スクロール位置が閾値以下の時にボタンが非表示", () => {
+    vi.mocked(useScrollPosition).mockReturnValue(0);
+
+    render(<BackToTop />);
+
+    expect(
+      screen.queryByRole("button", { name: "ページトップへ戻る" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("スクロール位置が閾値を超えた時にボタンが表示される", () => {
+    vi.mocked(useScrollPosition).mockReturnValue(500);
+
+    render(<BackToTop />);
+
+    expect(
+      screen.getByRole("button", { name: "ページトップへ戻る" }),
+    ).toBeInTheDocument();
+  });
+
+  it("ボタンクリック時にページトップへスクロールする", () => {
+    vi.mocked(useScrollPosition).mockReturnValue(500);
+    window.scrollTo = vi.fn();
+
+    render(<BackToTop />);
+
+    act(() => {
+      screen.getByRole("button", { name: "ページトップへ戻る" }).click();
+    });
+
+    expect(window.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: "smooth",
+    });
+  });
+});

--- a/src/components/common/__tests__/ScrollToTop.test.tsx
+++ b/src/components/common/__tests__/ScrollToTop.test.tsx
@@ -1,0 +1,41 @@
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ScrollToTop } from "../ScrollToTop";
+
+describe("ScrollToTop", () => {
+  beforeEach(() => {
+    window.scrollTo = vi.fn();
+  });
+
+  it("パス変更時にwindow.scrollToが呼ばれる", () => {
+    const { unmount } = render(
+      <MemoryRouter initialEntries={["/"]}>
+        <ScrollToTop />
+      </MemoryRouter>,
+    );
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+
+    unmount();
+
+    render(
+      <MemoryRouter initialEntries={["/posts/123"]}>
+        <ScrollToTop />
+      </MemoryRouter>,
+    );
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+    expect(window.scrollTo).toHaveBeenCalledTimes(2);
+  });
+
+  it("nullを返す", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ScrollToTop />
+      </MemoryRouter>,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { css } from "../../../styled-system/css";
+import { BackToTop } from "../common/BackToTop";
 import { Footer } from "./Footer";
 import { Header } from "./Header";
 
@@ -33,6 +34,7 @@ export const Layout = ({
       </main>
 
       <Footer />
+      <BackToTop />
     </div>
   );
 };

--- a/src/hooks/__tests__/useReadingProgress.test.ts
+++ b/src/hooks/__tests__/useReadingProgress.test.ts
@@ -1,0 +1,84 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useReadingProgress } from "../useReadingProgress";
+
+describe("useReadingProgress", () => {
+  beforeEach(() => {
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    Object.defineProperty(document.documentElement, "scrollHeight", {
+      value: 2000,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      value: 1000,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window, "scrollY", {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("デフォルトで0を返す", () => {
+    const { result } = renderHook(() => useReadingProgress());
+
+    expect(result.current).toBe(0);
+  });
+
+  it("スクロール位置に応じた進捗率を返す", () => {
+    const { result } = renderHook(() => useReadingProgress());
+
+    act(() => {
+      Object.defineProperty(window, "scrollY", {
+        value: 500,
+        writable: true,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(result.current).toBe(50);
+  });
+
+  it("ページ末尾で100を返す", () => {
+    const { result } = renderHook(() => useReadingProgress());
+
+    act(() => {
+      Object.defineProperty(window, "scrollY", {
+        value: 1000,
+        writable: true,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(result.current).toBe(100);
+  });
+
+  it("スクロール可能領域を超えても100を超えない", () => {
+    const { result } = renderHook(() => useReadingProgress());
+
+    act(() => {
+      Object.defineProperty(window, "scrollY", {
+        value: 1500,
+        writable: true,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(result.current).toBe(100);
+  });
+});

--- a/src/hooks/__tests__/useScrollPosition.test.ts
+++ b/src/hooks/__tests__/useScrollPosition.test.ts
@@ -1,0 +1,51 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useScrollPosition } from "../useScrollPosition";
+
+describe("useScrollPosition", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "addEventListener");
+    vi.spyOn(window, "removeEventListener");
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("デフォルトで0を返す", () => {
+    const { result } = renderHook(() => useScrollPosition());
+
+    expect(result.current).toBe(0);
+  });
+
+  it("スクロールイベントで値が更新される", () => {
+    const { result } = renderHook(() => useScrollPosition());
+
+    act(() => {
+      Object.defineProperty(window, "scrollY", {
+        value: 500,
+        writable: true,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(result.current).toBe(500);
+  });
+
+  it("アンマウント時にイベントリスナーが解除される", () => {
+    const { unmount } = renderHook(() => useScrollPosition());
+
+    unmount();
+
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+    );
+  });
+});

--- a/src/hooks/useReadingProgress.ts
+++ b/src/hooks/useReadingProgress.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+import { useScrollPosition } from "./useScrollPosition";
+
+export const useReadingProgress = () => {
+  const scrollY = useScrollPosition();
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const docHeight =
+      document.documentElement.scrollHeight - window.innerHeight;
+    if (docHeight > 0) {
+      setProgress(Math.min(Math.round((scrollY / docHeight) * 100), 100));
+    }
+  }, [scrollY]);
+
+  return progress;
+};

--- a/src/hooks/useScrollPosition.ts
+++ b/src/hooks/useScrollPosition.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+export const useScrollPosition = () => {
+  const [scrollY, setScrollY] = useState(0);
+
+  useEffect(() => {
+    let rafId: number;
+    const handleScroll = () => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        setScrollY(window.scrollY);
+      });
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  return scrollY;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React, { lazy, Suspense } from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { ScrollToTop } from "./components/common/ScrollToTop";
 import "./index.css";
 
 const IndexPage = lazy(() => import("./pages/index"));
@@ -8,12 +9,15 @@ const PostPage = lazy(() => import("./pages/posts/Post"));
 
 const App = () => {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <Routes>
-        <Route path="/" element={<IndexPage />} />
-        <Route path="/posts/:timestamp" element={<PostPage />} />
-      </Routes>
-    </Suspense>
+    <>
+      <ScrollToTop />
+      <Suspense fallback={<div>Loading...</div>}>
+        <Routes>
+          <Route path="/" element={<IndexPage />} />
+          <Route path="/posts/:timestamp" element={<PostPage />} />
+        </Routes>
+      </Suspense>
+    </>
   );
 };
 

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "react-router-dom";
 import { EmptyState } from "../../components/common/EmptyState";
 import { LoadingSpinner } from "../../components/common/LoadingSpinner";
+import { ReadingProgressBar } from "../../components/common/ReadingProgressBar";
 import { Layout } from "../../components/layouts/Layout";
 import { PostDetailPage } from "../../components/pages/PostDetailPage";
 import { usePost } from "../../hooks/usePost";
@@ -29,6 +30,7 @@ const Post = () => {
 
   return (
     <Layout>
+      <ReadingProgressBar />
       <PostDetailPage post={post} />
     </Layout>
   );


### PR DESCRIPTION
## 概要

スクロール位置の監視基盤を構築し、それを活用した3つの機能（ScrollToTop、BackToTop、ReadingProgressBar）を実装する。

Closes #328

## 変更内容

- `useScrollPosition` フック: requestAnimationFrameでスクロール位置を監視する共通フック
- `useReadingProgress` フック: ページの読了進捗率（0-100%）を計算するフック
- `ScrollToTop` コンポーネント: React Router遷移時にスクロール位置をリセット
- `BackToTop` コンポーネント: スクロール閾値超過時にページトップへ戻るボタンを表示（Headless UI Transitionでアニメーション）
- `ReadingProgressBar` コンポーネント: 記事詳細ページ上部に読了進捗バーを表示

## 備考

- 既存の `markdownParser.test.ts` のテスト失敗はmasterに存在する問題であり、本PRの変更とは無関係
- BackToTopはLayout.tsxに配置（全ページで利用可能）、ReadingProgressBarは記事詳細ページのみに配置