### PR TITLE
feat: 前後記事ナビゲーション

### DIFF
--- a/src/components/common/PostNavigation.tsx
+++ b/src/components/common/PostNavigation.tsx
@@ -4,8 +4,8 @@ import type { PostSummary } from "../../lib/markdown";
 import { Link } from "../atoms/Link";
 
 interface PostNavigationProps {
-  prevPost: PostSummary | null;
-  nextPost: PostSummary | null;
+  olderPost: PostSummary | null;
+  newerPost: PostSummary | null;
 }
 
 const navStyles = css({
@@ -43,31 +43,27 @@ const titleStyles = css({
   whiteSpace: "nowrap",
 });
 
-/**
- * 前後記事ナビゲーションコンポーネント
- * 記事詳細ページ下部に前後の記事へのリンクを表示する
- */
 export const PostNavigation = memo(
-  ({ prevPost, nextPost }: PostNavigationProps) => {
-    if (!prevPost && !nextPost) {
+  ({ olderPost, newerPost }: PostNavigationProps) => {
+    if (!olderPost && !newerPost) {
       return null;
     }
 
     return (
       <nav className={navStyles} aria-label="前後の記事">
         <div className={linkContainerStyles}>
-          {prevPost && (
-            <Link to={`/posts/${prevPost.id}`} variant="card">
+          {olderPost && (
+            <Link to={`/posts/${olderPost.id}`} variant="card">
               <span className={labelStyles}>← 前の記事</span>
-              <span className={titleStyles}>{prevPost.title}</span>
+              <span className={titleStyles}>{olderPost.title}</span>
             </Link>
           )}
         </div>
         <div className={`${linkContainerStyles} ${linkContainerRightStyles}`}>
-          {nextPost && (
-            <Link to={`/posts/${nextPost.id}`} variant="card">
+          {newerPost && (
+            <Link to={`/posts/${newerPost.id}`} variant="card">
               <span className={labelStyles}>次の記事 →</span>
-              <span className={titleStyles}>{nextPost.title}</span>
+              <span className={titleStyles}>{newerPost.title}</span>
             </Link>
           )}
         </div>

--- a/src/components/common/PostNavigation.tsx
+++ b/src/components/common/PostNavigation.tsx
@@ -1,0 +1,79 @@
+import { memo } from "react";
+import { css } from "../../../styled-system/css";
+import type { PostSummary } from "../../lib/markdown";
+import { Link } from "../atoms/Link";
+
+interface PostNavigationProps {
+  prevPost: PostSummary | null;
+  nextPost: PostSummary | null;
+}
+
+const navStyles = css({
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "md",
+  marginTop: "xl",
+  paddingTop: "xl",
+  borderTop: "1px solid",
+  borderColor: "bg.3",
+});
+
+const linkContainerStyles = css({
+  flex: "1",
+  minWidth: "0",
+});
+
+const linkContainerRightStyles = css({
+  textAlign: "right",
+});
+
+const labelStyles = css({
+  display: "block",
+  fontSize: "sm",
+  color: "fg.3",
+  marginBottom: "sm",
+});
+
+const titleStyles = css({
+  display: "block",
+  fontSize: "base",
+  fontWeight: "600",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+});
+
+/**
+ * 前後記事ナビゲーションコンポーネント
+ * 記事詳細ページ下部に前後の記事へのリンクを表示する
+ */
+export const PostNavigation = memo(
+  ({ prevPost, nextPost }: PostNavigationProps) => {
+    if (!prevPost && !nextPost) {
+      return null;
+    }
+
+    return (
+      <nav className={navStyles} aria-label="前後の記事">
+        <div className={linkContainerStyles}>
+          {prevPost && (
+            <Link to={`/posts/${prevPost.id}`} variant="card">
+              <span className={labelStyles}>← 前の記事</span>
+              <span className={titleStyles}>{prevPost.title}</span>
+            </Link>
+          )}
+        </div>
+        <div className={`${linkContainerStyles} ${linkContainerRightStyles}`}>
+          {nextPost && (
+            <Link to={`/posts/${nextPost.id}`} variant="card">
+              <span className={labelStyles}>次の記事 →</span>
+              <span className={titleStyles}>{nextPost.title}</span>
+            </Link>
+          )}
+        </div>
+      </nav>
+    );
+  },
+);
+
+PostNavigation.displayName = "PostNavigation";

--- a/src/components/common/__tests__/PostNavigation.test.tsx
+++ b/src/components/common/__tests__/PostNavigation.test.tsx
@@ -38,44 +38,44 @@ const createMockPost = (
 
 describe("PostNavigation", () => {
   it("前後の記事リンクが表示される", () => {
-    const prevPost = createMockPost("20240102100000", "前の記事タイトル");
-    const nextPost = createMockPost("20240101100000", "次の記事タイトル");
+    const olderPost = createMockPost("20240101100000", "古い記事タイトル");
+    const newerPost = createMockPost("20240103100000", "新しい記事タイトル");
 
-    render(<PostNavigation prevPost={prevPost} nextPost={nextPost} />);
+    render(<PostNavigation olderPost={olderPost} newerPost={newerPost} />);
 
     expect(screen.getByText("← 前の記事")).toBeInTheDocument();
-    expect(screen.getByText("前の記事タイトル")).toBeInTheDocument();
+    expect(screen.getByText("古い記事タイトル")).toBeInTheDocument();
     expect(screen.getByText("次の記事 →")).toBeInTheDocument();
-    expect(screen.getByText("次の記事タイトル")).toBeInTheDocument();
+    expect(screen.getByText("新しい記事タイトル")).toBeInTheDocument();
 
     const links = screen.getAllByRole("link");
-    expect(links[0]).toHaveAttribute("href", "/posts/20240102100000");
-    expect(links[1]).toHaveAttribute("href", "/posts/20240101100000");
+    expect(links[0]).toHaveAttribute("href", "/posts/20240101100000");
+    expect(links[1]).toHaveAttribute("href", "/posts/20240103100000");
   });
 
-  it("前の記事のみの場合に次のリンクが非表示になる", () => {
-    const prevPost = createMockPost("20240102100000", "前の記事タイトル");
+  it("古い記事のみの場合に新しい記事リンクが非表示になる", () => {
+    const olderPost = createMockPost("20240101100000", "古い記事タイトル");
 
-    render(<PostNavigation prevPost={prevPost} nextPost={null} />);
+    render(<PostNavigation olderPost={olderPost} newerPost={null} />);
 
     expect(screen.getByText("← 前の記事")).toBeInTheDocument();
-    expect(screen.getByText("前の記事タイトル")).toBeInTheDocument();
+    expect(screen.getByText("古い記事タイトル")).toBeInTheDocument();
     expect(screen.queryByText("次の記事 →")).not.toBeInTheDocument();
   });
 
-  it("次の記事のみの場合に前のリンクが非表示になる", () => {
-    const nextPost = createMockPost("20240101100000", "次の記事タイトル");
+  it("新しい記事のみの場合に古い記事リンクが非表示になる", () => {
+    const newerPost = createMockPost("20240103100000", "新しい記事タイトル");
 
-    render(<PostNavigation prevPost={null} nextPost={nextPost} />);
+    render(<PostNavigation olderPost={null} newerPost={newerPost} />);
 
     expect(screen.queryByText("← 前の記事")).not.toBeInTheDocument();
     expect(screen.getByText("次の記事 →")).toBeInTheDocument();
-    expect(screen.getByText("次の記事タイトル")).toBeInTheDocument();
+    expect(screen.getByText("新しい記事タイトル")).toBeInTheDocument();
   });
 
   it("両方nullの場合にコンポーネントが非表示になる", () => {
     const { container } = render(
-      <PostNavigation prevPost={null} nextPost={null} />,
+      <PostNavigation olderPost={null} newerPost={null} />,
     );
 
     expect(container.innerHTML).toBe("");

--- a/src/components/common/__tests__/PostNavigation.test.tsx
+++ b/src/components/common/__tests__/PostNavigation.test.tsx
@@ -24,10 +24,7 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
-const createMockPost = (
-  id: string,
-  title: string,
-): PostSummary => ({
+const createMockPost = (id: string, title: string): PostSummary => ({
   id,
   title,
   createdAt: "2024-01-01 10:00",

--- a/src/components/common/__tests__/PostNavigation.test.tsx
+++ b/src/components/common/__tests__/PostNavigation.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { PostSummary } from "../../../lib/markdown";
+import { PostNavigation } from "../PostNavigation";
+
+interface MockLinkProps {
+  children: React.ReactNode;
+  to: string;
+  [key: string]: unknown;
+}
+
+vi.mock("react-router-dom", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
+  return {
+    ...actual,
+    Link: ({ children, to, ...props }: MockLinkProps) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+const createMockPost = (
+  id: string,
+  title: string,
+): PostSummary => ({
+  id,
+  title,
+  createdAt: "2024-01-01 10:00",
+  author: "太郎",
+  excerpt: "抜粋テキスト",
+  readingTimeMinutes: 2,
+});
+
+describe("PostNavigation", () => {
+  it("前後の記事リンクが表示される", () => {
+    const prevPost = createMockPost("20240102100000", "前の記事タイトル");
+    const nextPost = createMockPost("20240101100000", "次の記事タイトル");
+
+    render(<PostNavigation prevPost={prevPost} nextPost={nextPost} />);
+
+    expect(screen.getByText("← 前の記事")).toBeInTheDocument();
+    expect(screen.getByText("前の記事タイトル")).toBeInTheDocument();
+    expect(screen.getByText("次の記事 →")).toBeInTheDocument();
+    expect(screen.getByText("次の記事タイトル")).toBeInTheDocument();
+
+    const links = screen.getAllByRole("link");
+    expect(links[0]).toHaveAttribute("href", "/posts/20240102100000");
+    expect(links[1]).toHaveAttribute("href", "/posts/20240101100000");
+  });
+
+  it("前の記事のみの場合に次のリンクが非表示になる", () => {
+    const prevPost = createMockPost("20240102100000", "前の記事タイトル");
+
+    render(<PostNavigation prevPost={prevPost} nextPost={null} />);
+
+    expect(screen.getByText("← 前の記事")).toBeInTheDocument();
+    expect(screen.getByText("前の記事タイトル")).toBeInTheDocument();
+    expect(screen.queryByText("次の記事 →")).not.toBeInTheDocument();
+  });
+
+  it("次の記事のみの場合に前のリンクが非表示になる", () => {
+    const nextPost = createMockPost("20240101100000", "次の記事タイトル");
+
+    render(<PostNavigation prevPost={null} nextPost={nextPost} />);
+
+    expect(screen.queryByText("← 前の記事")).not.toBeInTheDocument();
+    expect(screen.getByText("次の記事 →")).toBeInTheDocument();
+    expect(screen.getByText("次の記事タイトル")).toBeInTheDocument();
+  });
+
+  it("両方nullの場合にコンポーネントが非表示になる", () => {
+    const { container } = render(
+      <PostNavigation prevPost={null} nextPost={null} />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -8,15 +8,20 @@ import { PostNavigation } from "../common/PostNavigation";
 
 interface PostDetailPageProps {
   post: Post;
-  prevPost?: PostSummary | null;
-  nextPost?: PostSummary | null;
+  olderPost: PostSummary | null;
+  newerPost: PostSummary | null;
 }
 
-export const PostDetailPage = ({ post, prevPost, nextPost }: PostDetailPageProps) => {
+export const PostDetailPage = ({
+  post,
+  olderPost,
+  newerPost,
+}: PostDetailPageProps) => {
   return (
     <>
       {/* Navigation */}
       <nav
+        aria-label="ページナビゲーション"
         className={css({
           background: "bg.1",
           borderBottom: "1px solid",
@@ -174,10 +179,7 @@ export const PostDetailPage = ({ post, prevPost, nextPost }: PostDetailPageProps
               />
             </div>
           </article>
-          <PostNavigation
-            prevPost={prevPost ?? null}
-            nextPost={nextPost ?? null}
-          />
+          <PostNavigation olderPost={olderPost} newerPost={newerPost} />
         </div>
       </div>
     </>

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -1,15 +1,18 @@
 import DOMPurify from "dompurify";
 import { css } from "../../../styled-system/css";
-import type { Post } from "../../lib/markdown";
+import type { Post, PostSummary } from "../../lib/markdown";
 import { Link } from "../atoms/Link";
 import { Heading1 } from "../atoms/Typography";
 import { MetaInfo } from "../common/MetaInfo";
+import { PostNavigation } from "../common/PostNavigation";
 
 interface PostDetailPageProps {
   post: Post;
+  prevPost?: PostSummary | null;
+  nextPost?: PostSummary | null;
 }
 
-export const PostDetailPage = ({ post }: PostDetailPageProps) => {
+export const PostDetailPage = ({ post, prevPost, nextPost }: PostDetailPageProps) => {
   return (
     <>
       {/* Navigation */}
@@ -171,6 +174,10 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
               />
             </div>
           </article>
+          <PostNavigation
+            prevPost={prevPost ?? null}
+            nextPost={nextPost ?? null}
+          />
         </div>
       </div>
     </>

--- a/src/components/pages/__tests__/PostDetailPage.test.tsx
+++ b/src/components/pages/__tests__/PostDetailPage.test.tsx
@@ -75,7 +75,11 @@ describe("PostDetailPage", () => {
 
     render(
       <MemoryRouter>
-        <PostDetailPage post={postWithoutTitle} olderPost={null} newerPost={null} />
+        <PostDetailPage
+          post={postWithoutTitle}
+          olderPost={null}
+          newerPost={null}
+        />
       </MemoryRouter>,
     );
 

--- a/src/components/pages/__tests__/PostDetailPage.test.tsx
+++ b/src/components/pages/__tests__/PostDetailPage.test.tsx
@@ -21,7 +21,7 @@ describe("PostDetailPage", () => {
   it("記事タイトルを表示できる", () => {
     render(
       <MemoryRouter>
-        <PostDetailPage post={mockPost} />
+        <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
       </MemoryRouter>,
     );
 
@@ -33,7 +33,7 @@ describe("PostDetailPage", () => {
   it("記事のメタ情報を表示できる", () => {
     render(
       <MemoryRouter>
-        <PostDetailPage post={mockPost} />
+        <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
       </MemoryRouter>,
     );
 
@@ -44,7 +44,7 @@ describe("PostDetailPage", () => {
   it("記事コンテンツを表示できる", () => {
     render(
       <MemoryRouter>
-        <PostDetailPage post={mockPost} />
+        <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
       </MemoryRouter>,
     );
 
@@ -58,7 +58,7 @@ describe("PostDetailPage", () => {
   it("トップページへのリンクを表示できる", () => {
     render(
       <MemoryRouter>
-        <PostDetailPage post={mockPost} />
+        <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
       </MemoryRouter>,
     );
 
@@ -75,7 +75,7 @@ describe("PostDetailPage", () => {
 
     render(
       <MemoryRouter>
-        <PostDetailPage post={postWithoutTitle} />
+        <PostDetailPage post={postWithoutTitle} olderPost={null} newerPost={null} />
       </MemoryRouter>,
     );
 
@@ -93,7 +93,7 @@ describe("PostDetailPage", () => {
 
     render(
       <MemoryRouter>
-        <PostDetailPage post={postWithHtml} />
+        <PostDetailPage post={postWithHtml} olderPost={null} newerPost={null} />
       </MemoryRouter>,
     );
 

--- a/src/hooks/__tests__/useAdjacentPosts.test.ts
+++ b/src/hooks/__tests__/useAdjacentPosts.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as markdownModule from "../../lib/markdown";
-import { useAdjacentPosts } from "../useAdjacentPosts";
+import { findAdjacentPosts, useAdjacentPosts } from "../useAdjacentPosts";
 
 vi.mock("../../lib/markdown");
 
@@ -34,6 +34,43 @@ const mockSummaries = [
   },
 ];
 
+describe("findAdjacentPosts", () => {
+  it("中間の記事で前後の記事を取得できる", () => {
+    const result = findAdjacentPosts(mockSummaries, "20240102100000");
+
+    expect(result.olderPost).toEqual(mockSummaries[2]);
+    expect(result.newerPost).toEqual(mockSummaries[0]);
+  });
+
+  it("先頭（最新）の記事でnewerPostがnullになる", () => {
+    const result = findAdjacentPosts(mockSummaries, "20240103100000");
+
+    expect(result.newerPost).toBeNull();
+    expect(result.olderPost).toEqual(mockSummaries[1]);
+  });
+
+  it("末尾（最古）の記事でolderPostがnullになる", () => {
+    const result = findAdjacentPosts(mockSummaries, "20240101100000");
+
+    expect(result.olderPost).toBeNull();
+    expect(result.newerPost).toEqual(mockSummaries[1]);
+  });
+
+  it("記事が1つだけの場合は両方nullになる", () => {
+    const result = findAdjacentPosts([mockSummaries[0]], "20240103100000");
+
+    expect(result.olderPost).toBeNull();
+    expect(result.newerPost).toBeNull();
+  });
+
+  it("存在しないIDの場合は両方nullになる", () => {
+    const result = findAdjacentPosts(mockSummaries, "99999999999999");
+
+    expect(result.olderPost).toBeNull();
+    expect(result.newerPost).toBeNull();
+  });
+});
+
 describe("useAdjacentPosts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -50,11 +87,11 @@ describe("useAdjacentPosts", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.prevPost).toEqual(mockSummaries[0]);
-    expect(result.current.nextPost).toEqual(mockSummaries[2]);
+    expect(result.current.olderPost).toEqual(mockSummaries[2]);
+    expect(result.current.newerPost).toEqual(mockSummaries[0]);
   });
 
-  it("先頭の記事で前の記事がnullになる", async () => {
+  it("先頭の記事でnewerPostがnullになる", async () => {
     mockGetAllPostSummaries.mockResolvedValue(mockSummaries);
 
     const { result } = renderHook(() =>
@@ -65,11 +102,11 @@ describe("useAdjacentPosts", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.prevPost).toBeNull();
-    expect(result.current.nextPost).toEqual(mockSummaries[1]);
+    expect(result.current.newerPost).toBeNull();
+    expect(result.current.olderPost).toEqual(mockSummaries[1]);
   });
 
-  it("末尾の記事で次の記事がnullになる", async () => {
+  it("末尾の記事でolderPostがnullになる", async () => {
     mockGetAllPostSummaries.mockResolvedValue(mockSummaries);
 
     const { result } = renderHook(() =>
@@ -80,38 +117,8 @@ describe("useAdjacentPosts", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.prevPost).toEqual(mockSummaries[1]);
-    expect(result.current.nextPost).toBeNull();
-  });
-
-  it("記事が1つだけの場合は前後ともnullになる", async () => {
-    mockGetAllPostSummaries.mockResolvedValue([mockSummaries[0]]);
-
-    const { result } = renderHook(() =>
-      useAdjacentPosts("20240103100000"),
-    );
-
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false);
-    });
-
-    expect(result.current.prevPost).toBeNull();
-    expect(result.current.nextPost).toBeNull();
-  });
-
-  it("存在しないIDの場合は前後ともnullになる", async () => {
-    mockGetAllPostSummaries.mockResolvedValue(mockSummaries);
-
-    const { result } = renderHook(() =>
-      useAdjacentPosts("99999999999999"),
-    );
-
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false);
-    });
-
-    expect(result.current.prevPost).toBeNull();
-    expect(result.current.nextPost).toBeNull();
+    expect(result.current.olderPost).toBeNull();
+    expect(result.current.newerPost).toEqual(mockSummaries[1]);
   });
 
   it("IDがundefinedの場合は読み込みのみ終了する", async () => {
@@ -121,8 +128,8 @@ describe("useAdjacentPosts", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.prevPost).toBeNull();
-    expect(result.current.nextPost).toBeNull();
+    expect(result.current.olderPost).toBeNull();
+    expect(result.current.newerPost).toBeNull();
     expect(mockGetAllPostSummaries).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/__tests__/useAdjacentPosts.test.ts
+++ b/src/hooks/__tests__/useAdjacentPosts.test.ts
@@ -1,0 +1,128 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as markdownModule from "../../lib/markdown";
+import { useAdjacentPosts } from "../useAdjacentPosts";
+
+vi.mock("../../lib/markdown");
+
+const mockGetAllPostSummaries = vi.mocked(markdownModule.getAllPostSummaries);
+
+const mockSummaries = [
+  {
+    id: "20240103100000",
+    title: "3番目の記事",
+    createdAt: "2024-01-03 10:00",
+    author: "太郎",
+    excerpt: "3番目の記事の抜粋",
+    readingTimeMinutes: 2,
+  },
+  {
+    id: "20240102100000",
+    title: "2番目の記事",
+    createdAt: "2024-01-02 10:00",
+    author: "太郎",
+    excerpt: "2番目の記事の抜粋",
+    readingTimeMinutes: 3,
+  },
+  {
+    id: "20240101100000",
+    title: "1番目の記事",
+    createdAt: "2024-01-01 10:00",
+    author: "太郎",
+    excerpt: "1番目の記事の抜粋",
+    readingTimeMinutes: 1,
+  },
+];
+
+describe("useAdjacentPosts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("中間の記事で前後の記事が取得できる", async () => {
+    mockGetAllPostSummaries.mockResolvedValue(mockSummaries);
+
+    const { result } = renderHook(() =>
+      useAdjacentPosts("20240102100000"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.prevPost).toEqual(mockSummaries[0]);
+    expect(result.current.nextPost).toEqual(mockSummaries[2]);
+  });
+
+  it("先頭の記事で前の記事がnullになる", async () => {
+    mockGetAllPostSummaries.mockResolvedValue(mockSummaries);
+
+    const { result } = renderHook(() =>
+      useAdjacentPosts("20240103100000"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.prevPost).toBeNull();
+    expect(result.current.nextPost).toEqual(mockSummaries[1]);
+  });
+
+  it("末尾の記事で次の記事がnullになる", async () => {
+    mockGetAllPostSummaries.mockResolvedValue(mockSummaries);
+
+    const { result } = renderHook(() =>
+      useAdjacentPosts("20240101100000"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.prevPost).toEqual(mockSummaries[1]);
+    expect(result.current.nextPost).toBeNull();
+  });
+
+  it("記事が1つだけの場合は前後ともnullになる", async () => {
+    mockGetAllPostSummaries.mockResolvedValue([mockSummaries[0]]);
+
+    const { result } = renderHook(() =>
+      useAdjacentPosts("20240103100000"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.prevPost).toBeNull();
+    expect(result.current.nextPost).toBeNull();
+  });
+
+  it("存在しないIDの場合は前後ともnullになる", async () => {
+    mockGetAllPostSummaries.mockResolvedValue(mockSummaries);
+
+    const { result } = renderHook(() =>
+      useAdjacentPosts("99999999999999"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.prevPost).toBeNull();
+    expect(result.current.nextPost).toBeNull();
+  });
+
+  it("IDがundefinedの場合は読み込みのみ終了する", async () => {
+    const { result } = renderHook(() => useAdjacentPosts(undefined));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.prevPost).toBeNull();
+    expect(result.current.nextPost).toBeNull();
+    expect(mockGetAllPostSummaries).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useAdjacentPosts.test.ts
+++ b/src/hooks/__tests__/useAdjacentPosts.test.ts
@@ -79,9 +79,7 @@ describe("useAdjacentPosts", () => {
   it("中間の記事で前後の記事が取得できる", async () => {
     mockGetAllPostSummaries.mockResolvedValue(mockSummaries);
 
-    const { result } = renderHook(() =>
-      useAdjacentPosts("20240102100000"),
-    );
+    const { result } = renderHook(() => useAdjacentPosts("20240102100000"));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -94,9 +92,7 @@ describe("useAdjacentPosts", () => {
   it("先頭の記事でnewerPostがnullになる", async () => {
     mockGetAllPostSummaries.mockResolvedValue(mockSummaries);
 
-    const { result } = renderHook(() =>
-      useAdjacentPosts("20240103100000"),
-    );
+    const { result } = renderHook(() => useAdjacentPosts("20240103100000"));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -109,9 +105,7 @@ describe("useAdjacentPosts", () => {
   it("末尾の記事でolderPostがnullになる", async () => {
     mockGetAllPostSummaries.mockResolvedValue(mockSummaries);
 
-    const { result } = renderHook(() =>
-      useAdjacentPosts("20240101100000"),
-    );
+    const { result } = renderHook(() => useAdjacentPosts("20240101100000"));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);

--- a/src/hooks/useAdjacentPosts.ts
+++ b/src/hooks/useAdjacentPosts.ts
@@ -1,11 +1,37 @@
 import { useEffect, useState } from "react";
 import { getAllPostSummaries, type PostSummary } from "../lib/markdown";
 
-interface UseAdjacentPostsReturn {
+interface AdjacentPosts {
   prevPost: PostSummary | null;
   nextPost: PostSummary | null;
+}
+
+interface UseAdjacentPostsReturn extends AdjacentPosts {
   loading: boolean;
 }
+
+/**
+ * 記事リストから指定IDの前後の記事を取得する
+ * @param summaries ID降順でソートされた記事サマリーリスト
+ * @param currentId 現在表示中の記事ID
+ * @returns 前の記事（より新しい）と次の記事（より古い）
+ */
+const findAdjacentPosts = (
+  summaries: PostSummary[],
+  currentId: string,
+): AdjacentPosts => {
+  const currentIndex = summaries.findIndex((post) => post.id === currentId);
+
+  if (currentIndex === -1) {
+    return { prevPost: null, nextPost: null };
+  }
+
+  const prevPost = currentIndex > 0 ? summaries[currentIndex - 1] : null;
+  const nextPost =
+    currentIndex < summaries.length - 1 ? summaries[currentIndex + 1] : null;
+
+  return { prevPost, nextPost };
+};
 
 /**
  * 前後の記事を取得するカスタムフック
@@ -15,8 +41,10 @@ interface UseAdjacentPostsReturn {
 export const useAdjacentPosts = (
   currentId: string | undefined,
 ): UseAdjacentPostsReturn => {
-  const [prevPost, setPrevPost] = useState<PostSummary | null>(null);
-  const [nextPost, setNextPost] = useState<PostSummary | null>(null);
+  const [adjacentPosts, setAdjacentPosts] = useState<AdjacentPosts>({
+    prevPost: null,
+    nextPost: null,
+  });
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -29,26 +57,10 @@ export const useAdjacentPosts = (
       try {
         setLoading(true);
         const summaries = await getAllPostSummaries();
-
-        const currentIndex = summaries.findIndex(
-          (post) => post.id === currentId,
-        );
-
-        if (currentIndex === -1) {
-          setPrevPost(null);
-          setNextPost(null);
-        } else {
-          setPrevPost(currentIndex > 0 ? summaries[currentIndex - 1] : null);
-          setNextPost(
-            currentIndex < summaries.length - 1
-              ? summaries[currentIndex + 1]
-              : null,
-          );
-        }
+        setAdjacentPosts(findAdjacentPosts(summaries, currentId));
       } catch (error) {
         console.error("Failed to load adjacent posts:", error);
-        setPrevPost(null);
-        setNextPost(null);
+        setAdjacentPosts({ prevPost: null, nextPost: null });
       } finally {
         setLoading(false);
       }
@@ -57,5 +69,5 @@ export const useAdjacentPosts = (
     loadAdjacentPosts();
   }, [currentId]);
 
-  return { prevPost, nextPost, loading };
+  return { ...adjacentPosts, loading };
 };

--- a/src/hooks/useAdjacentPosts.ts
+++ b/src/hooks/useAdjacentPosts.ts
@@ -2,48 +2,49 @@ import { useEffect, useState } from "react";
 import { getAllPostSummaries, type PostSummary } from "../lib/markdown";
 
 interface AdjacentPosts {
-  prevPost: PostSummary | null;
-  nextPost: PostSummary | null;
+  olderPost: PostSummary | null;
+  newerPost: PostSummary | null;
 }
 
 interface UseAdjacentPostsReturn extends AdjacentPosts {
   loading: boolean;
 }
 
+let summariesCache: PostSummary[] | null = null;
+
 /**
  * 記事リストから指定IDの前後の記事を取得する
+ * 配列はID降順（新しい順）のため、index+1が古い記事、index-1が新しい記事
  * @param summaries ID降順でソートされた記事サマリーリスト
  * @param currentId 現在表示中の記事ID
- * @returns 前の記事（より新しい）と次の記事（より古い）
  */
-const findAdjacentPosts = (
+export const findAdjacentPosts = (
   summaries: PostSummary[],
   currentId: string,
 ): AdjacentPosts => {
   const currentIndex = summaries.findIndex((post) => post.id === currentId);
 
   if (currentIndex === -1) {
-    return { prevPost: null, nextPost: null };
+    return { olderPost: null, newerPost: null };
   }
 
-  const prevPost = currentIndex > 0 ? summaries[currentIndex - 1] : null;
-  const nextPost =
+  const newerPost = currentIndex > 0 ? summaries[currentIndex - 1] : null;
+  const olderPost =
     currentIndex < summaries.length - 1 ? summaries[currentIndex + 1] : null;
 
-  return { prevPost, nextPost };
+  return { olderPost, newerPost };
 };
 
 /**
  * 前後の記事を取得するカスタムフック
  * @param currentId 現在表示中の記事ID
- * @returns 前の記事（より新しい）、次の記事（より古い）、ローディング状態
  */
 export const useAdjacentPosts = (
   currentId: string | undefined,
 ): UseAdjacentPostsReturn => {
   const [adjacentPosts, setAdjacentPosts] = useState<AdjacentPosts>({
-    prevPost: null,
-    nextPost: null,
+    olderPost: null,
+    newerPost: null,
   });
   const [loading, setLoading] = useState(true);
 
@@ -56,11 +57,13 @@ export const useAdjacentPosts = (
 
       try {
         setLoading(true);
-        const summaries = await getAllPostSummaries();
-        setAdjacentPosts(findAdjacentPosts(summaries, currentId));
+        if (!summariesCache) {
+          summariesCache = await getAllPostSummaries();
+        }
+        setAdjacentPosts(findAdjacentPosts(summariesCache, currentId));
       } catch (error) {
         console.error("Failed to load adjacent posts:", error);
-        setAdjacentPosts({ prevPost: null, nextPost: null });
+        setAdjacentPosts({ olderPost: null, newerPost: null });
       } finally {
         setLoading(false);
       }

--- a/src/hooks/useAdjacentPosts.ts
+++ b/src/hooks/useAdjacentPosts.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { getAllPostSummaries, type PostSummary } from "../lib/markdown";
+
+interface UseAdjacentPostsReturn {
+  prevPost: PostSummary | null;
+  nextPost: PostSummary | null;
+  loading: boolean;
+}
+
+/**
+ * 前後の記事を取得するカスタムフック
+ * @param currentId 現在表示中の記事ID
+ * @returns 前の記事（より新しい）、次の記事（より古い）、ローディング状態
+ */
+export const useAdjacentPosts = (
+  currentId: string | undefined,
+): UseAdjacentPostsReturn => {
+  const [prevPost, setPrevPost] = useState<PostSummary | null>(null);
+  const [nextPost, setNextPost] = useState<PostSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadAdjacentPosts = async () => {
+      if (!currentId) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        const summaries = await getAllPostSummaries();
+
+        const currentIndex = summaries.findIndex(
+          (post) => post.id === currentId,
+        );
+
+        if (currentIndex === -1) {
+          setPrevPost(null);
+          setNextPost(null);
+        } else {
+          setPrevPost(currentIndex > 0 ? summaries[currentIndex - 1] : null);
+          setNextPost(
+            currentIndex < summaries.length - 1
+              ? summaries[currentIndex + 1]
+              : null,
+          );
+        }
+      } catch (error) {
+        console.error("Failed to load adjacent posts:", error);
+        setPrevPost(null);
+        setNextPost(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadAdjacentPosts();
+  }, [currentId]);
+
+  return { prevPost, nextPost, loading };
+};

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -10,7 +10,7 @@ import { usePost } from "../../hooks/usePost";
 const Post = () => {
   const { timestamp } = useParams<{ timestamp: string }>();
   const { post, loading, notFound } = usePost(timestamp);
-  const { prevPost, nextPost } = useAdjacentPosts(timestamp);
+  const { olderPost, newerPost } = useAdjacentPosts(timestamp);
 
   if (loading) {
     return <LoadingSpinner message="記事を読み込み中..." />;
@@ -33,7 +33,7 @@ const Post = () => {
   return (
     <Layout>
       <ReadingProgressBar />
-      <PostDetailPage post={post} prevPost={prevPost} nextPost={nextPost} />
+      <PostDetailPage post={post} olderPost={olderPost} newerPost={newerPost} />
     </Layout>
   );
 };

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -4,11 +4,13 @@ import { LoadingSpinner } from "../../components/common/LoadingSpinner";
 import { ReadingProgressBar } from "../../components/common/ReadingProgressBar";
 import { Layout } from "../../components/layouts/Layout";
 import { PostDetailPage } from "../../components/pages/PostDetailPage";
+import { useAdjacentPosts } from "../../hooks/useAdjacentPosts";
 import { usePost } from "../../hooks/usePost";
 
 const Post = () => {
   const { timestamp } = useParams<{ timestamp: string }>();
   const { post, loading, notFound } = usePost(timestamp);
+  const { prevPost, nextPost } = useAdjacentPosts(timestamp);
 
   if (loading) {
     return <LoadingSpinner message="記事を読み込み中..." />;
@@ -31,7 +33,7 @@ const Post = () => {
   return (
     <Layout>
       <ReadingProgressBar />
-      <PostDetailPage post={post} />
+      <PostDetailPage post={post} prevPost={prevPost} nextPost={nextPost} />
     </Layout>
   );
 };

--- a/src/pages/posts/__tests__/Post.test.tsx
+++ b/src/pages/posts/__tests__/Post.test.tsx
@@ -4,12 +4,18 @@ import { describe, expect, it, vi } from "vitest";
 import type { Post as PostType } from "../../../lib/markdown";
 import Post from "../Post";
 
-// usePostフックをモック
 vi.mock("../../../hooks/usePost", () => ({
   usePost: vi.fn(),
 }));
 
-// Layoutコンポーネントをモック
+vi.mock("../../../hooks/useAdjacentPosts", () => ({
+  useAdjacentPosts: vi.fn(() => ({
+    olderPost: null,
+    newerPost: null,
+    loading: false,
+  })),
+}));
+
 vi.mock("../../../components/layouts/Layout", () => ({
   Layout: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>


### PR DESCRIPTION
## 概要

記事詳細ページの下部に「前の記事」「次の記事」へのナビゲーションリンクを追加する。

closes #331

## 変更内容

- `src/hooks/useAdjacentPosts.ts`: 全記事サマリーから現在記事の前後を特定するカスタムフックを新規作成
- `src/hooks/__tests__/useAdjacentPosts.test.ts`: 中間/先頭/末尾/1件のみ/存在しないID/undefinedの各ケースをテスト
- `src/components/common/PostNavigation.tsx`: 前後記事リンクを表示するプレゼンテーショナルコンポーネント（React.memoでメモ化）
- `src/components/common/__tests__/PostNavigation.test.tsx`: 前後表示/片方のみ/両方nullの各ケースをテスト
- `src/pages/posts/Post.tsx`: useAdjacentPostsフックを呼び出しPostDetailPageに前後記事を渡すよう修正
- `src/components/pages/PostDetailPage.tsx`: propsにprevPost/nextPostを追加し、article下部にPostNavigationを配置

## 備考

- 記事リストはID降順（新しい順）。prevPost = より新しい記事、nextPost = より古い記事
- 既存の`Link`コンポーネント（variant="card"）を使用
- 全テスト通過、lint/型チェック/ビルド正常