### PR TITLE
feat: スケルトンローディング + Headless UI Transition

### DIFF
--- a/src/components/common/ArticleSkeleton.tsx
+++ b/src/components/common/ArticleSkeleton.tsx
@@ -1,0 +1,177 @@
+import { memo } from "react";
+import { css } from "../../../styled-system/css";
+
+const wrapperStyles = css({
+  background: "bg.0",
+  minHeight: "100vh",
+});
+
+const innerStyles = css({
+  maxWidth: "article",
+  margin: "0 auto",
+  padding: "md",
+  md: {
+    padding: "content",
+  },
+});
+
+const articleStyles = css({
+  background: "bg.1",
+  borderRadius: "lg",
+  overflow: "hidden",
+  boxShadow: "card-hover",
+  border: "1px solid",
+  borderColor: "bg.3",
+});
+
+const headerStyles = css({
+  background: "gradients.primary",
+  padding: "md",
+  md: {
+    padding: "section",
+  },
+});
+
+const dividerStyles = css({
+  height: "1px",
+  background: "bg.3",
+});
+
+const contentStyles = css({
+  paddingRight: "md",
+  paddingLeft: "md",
+  paddingBottom: "md",
+  paddingTop: "lg",
+  md: {
+    paddingRight: "section",
+    paddingLeft: "section",
+    paddingBottom: "section",
+    paddingTop: "xl",
+  },
+});
+
+const skeletonBase = css({
+  background: "bg.2",
+  borderRadius: "sm",
+  animation: "skeleton-pulse 1.5s ease-in-out infinite",
+});
+
+const headerTitleStyles = css({
+  height: "32px",
+  width: "70%",
+  marginBottom: "card",
+  opacity: 0.6,
+});
+
+const headerMetaStyles = css({
+  height: "16px",
+  width: "200px",
+  opacity: 0.6,
+});
+
+const paragraphFullStyles = css({
+  height: "16px",
+  width: "100%",
+  marginBottom: "sm-md",
+});
+
+const paragraphPartialStyles = css({
+  height: "16px",
+  width: "85%",
+  marginBottom: "sm-md",
+});
+
+const paragraphShortStyles = css({
+  height: "16px",
+  width: "60%",
+  marginBottom: "lg",
+});
+
+const headingStyles = css({
+  height: "22px",
+  width: "40%",
+  marginTop: "xl",
+  marginBottom: "md",
+});
+
+const navStyles = css({
+  background: "bg.1",
+  borderBottom: "1px solid",
+  borderColor: "bg.3",
+  paddingY: "sm-md",
+  paddingX: "md",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  md: {
+    paddingX: "0",
+  },
+});
+
+const navInnerStyles = css({
+  maxWidth: "content",
+  width: "100%",
+});
+
+const navLinkStyles = css({
+  height: "16px",
+  width: "120px",
+});
+
+/**
+ * 記事詳細ページ用スケルトンローディング
+ */
+export const ArticleSkeleton = memo(() => {
+  return (
+    <div role="status" aria-busy="true" aria-label="記事を読み込み中">
+      {/* ナビゲーションスケルトン */}
+      <nav className={navStyles}>
+        <div className={navInnerStyles}>
+          <div className={`${skeletonBase} ${navLinkStyles}`} />
+        </div>
+      </nav>
+
+      <div className={wrapperStyles}>
+        <div className={innerStyles}>
+          <article className={articleStyles}>
+            {/* ヘッダースケルトン */}
+            <header className={headerStyles}>
+              <div className={`${skeletonBase} ${headerTitleStyles}`} />
+              <div className={`${skeletonBase} ${headerMetaStyles}`} />
+            </header>
+
+            <div className={dividerStyles} />
+
+            {/* コンテンツスケルトン */}
+            <div className={contentStyles}>
+              {/* 段落1 */}
+              <div className={`${skeletonBase} ${paragraphFullStyles}`} />
+              <div className={`${skeletonBase} ${paragraphPartialStyles}`} />
+              <div className={`${skeletonBase} ${paragraphShortStyles}`} />
+
+              {/* 見出し */}
+              <div className={`${skeletonBase} ${headingStyles}`} />
+
+              {/* 段落2 */}
+              <div className={`${skeletonBase} ${paragraphFullStyles}`} />
+              <div className={`${skeletonBase} ${paragraphFullStyles}`} />
+              <div className={`${skeletonBase} ${paragraphPartialStyles}`} />
+              <div className={`${skeletonBase} ${paragraphShortStyles}`} />
+
+              {/* 見出し */}
+              <div className={`${skeletonBase} ${headingStyles}`} />
+
+              {/* 段落3 */}
+              <div className={`${skeletonBase} ${paragraphFullStyles}`} />
+              <div className={`${skeletonBase} ${paragraphPartialStyles}`} />
+              <div className={`${skeletonBase} ${paragraphFullStyles}`} />
+              <div className={`${skeletonBase} ${paragraphShortStyles}`} />
+            </div>
+          </article>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+ArticleSkeleton.displayName = "ArticleSkeleton";

--- a/src/components/common/CardSkeleton.tsx
+++ b/src/components/common/CardSkeleton.tsx
@@ -84,10 +84,18 @@ const excerptLine2Styles = css({
  * ホームページ用カード型スケルトンローディング
  */
 export const CardSkeleton = memo(({ count = 4 }: CardSkeletonProps) => {
-  const skeletonItems = Array.from({ length: count }, (_, i) => `skeleton-${i}`);
+  const skeletonItems = Array.from(
+    { length: count },
+    (_, i) => `skeleton-${i}`,
+  );
 
   return (
-    <div className={containerStyles} role="status" aria-busy="true" aria-label="記事を読み込み中">
+    <div
+      className={containerStyles}
+      role="status"
+      aria-busy="true"
+      aria-label="記事を読み込み中"
+    >
       <div className={listStyles}>
         {skeletonItems.map((key) => (
           <div key={key} className={cardStyles}>

--- a/src/components/common/CardSkeleton.tsx
+++ b/src/components/common/CardSkeleton.tsx
@@ -1,0 +1,109 @@
+import { memo } from "react";
+import { css } from "../../../styled-system/css";
+
+interface CardSkeletonProps {
+  count?: number;
+}
+
+const containerStyles = css({
+  maxWidth: "content",
+  margin: "0 auto",
+  padding: "content",
+  paddingX: "md",
+  md: {
+    paddingX: "xl",
+  },
+});
+
+const listStyles = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "xl",
+  paddingTop: "sm-md",
+});
+
+const cardStyles = css({
+  background: "bg.1",
+  borderRadius: "lg",
+  overflow: "hidden",
+  boxShadow: "card",
+});
+
+const cardHeaderStyles = css({
+  padding: "sm-md",
+  paddingBottom: "md",
+  borderBottom: "1px solid",
+  borderColor: "bg.3",
+  display: "flex",
+  alignItems: "center",
+  gap: "sm",
+  md: {
+    padding: "card",
+    paddingBottom: "md",
+    paddingX: "sm-md",
+  },
+});
+
+const cardContentStyles = css({
+  padding: "sm-md",
+  md: {
+    padding: "card",
+  },
+});
+
+const skeletonBase = css({
+  background: "bg.2",
+  borderRadius: "sm",
+  animation: "skeleton-pulse 1.5s ease-in-out infinite",
+});
+
+const metaLineStyles = css({
+  height: "14px",
+  width: "180px",
+});
+
+const titleLineStyles = css({
+  height: "22px",
+  width: "75%",
+  marginBottom: "sm",
+});
+
+const excerptLine1Styles = css({
+  height: "14px",
+  width: "100%",
+  marginTop: "sm",
+});
+
+const excerptLine2Styles = css({
+  height: "14px",
+  width: "60%",
+  marginTop: "sm",
+});
+
+/**
+ * ホームページ用カード型スケルトンローディング
+ */
+export const CardSkeleton = memo(({ count = 4 }: CardSkeletonProps) => {
+  const skeletonItems = Array.from({ length: count }, (_, i) => `skeleton-${i}`);
+
+  return (
+    <div className={containerStyles} role="status" aria-busy="true" aria-label="記事を読み込み中">
+      <div className={listStyles}>
+        {skeletonItems.map((key) => (
+          <div key={key} className={cardStyles}>
+            <div className={cardHeaderStyles}>
+              <div className={`${skeletonBase} ${metaLineStyles}`} />
+            </div>
+            <div className={cardContentStyles}>
+              <div className={`${skeletonBase} ${titleLineStyles}`} />
+              <div className={`${skeletonBase} ${excerptLine1Styles}`} />
+              <div className={`${skeletonBase} ${excerptLine2Styles}`} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+});
+
+CardSkeleton.displayName = "CardSkeleton";

--- a/src/components/common/__tests__/ArticleSkeleton.test.tsx
+++ b/src/components/common/__tests__/ArticleSkeleton.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ArticleSkeleton } from "../ArticleSkeleton";
+
+describe("ArticleSkeleton", () => {
+  it("記事スケルトンがレンダリングされる", () => {
+    const { container } = render(<ArticleSkeleton />);
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it("aria-busy属性がtrueに設定されている", () => {
+    render(<ArticleSkeleton />);
+
+    const skeleton = screen.getByLabelText("記事を読み込み中");
+    expect(skeleton).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("aria-label属性が設定されている", () => {
+    render(<ArticleSkeleton />);
+
+    const skeleton = screen.getByLabelText("記事を読み込み中");
+    expect(skeleton).toBeInTheDocument();
+  });
+
+  it("ヘッダーセクションを含んでいる", () => {
+    const { container } = render(<ArticleSkeleton />);
+
+    const header = container.querySelector("header");
+    expect(header).toBeInTheDocument();
+  });
+
+  it("記事セクションを含んでいる", () => {
+    const { container } = render(<ArticleSkeleton />);
+
+    const article = container.querySelector("article");
+    expect(article).toBeInTheDocument();
+  });
+
+  it("ナビゲーションセクションを含んでいる", () => {
+    const { container } = render(<ArticleSkeleton />);
+
+    const nav = container.querySelector("nav");
+    expect(nav).toBeInTheDocument();
+  });
+});

--- a/src/components/common/__tests__/CardSkeleton.test.tsx
+++ b/src/components/common/__tests__/CardSkeleton.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CardSkeleton } from "../CardSkeleton";
+
+describe("CardSkeleton", () => {
+  it("デフォルトで4枚のスケルトンカードがレンダリングされる", () => {
+    render(<CardSkeleton />);
+
+    // 各カードにはヘッダーとコンテンツの2つの子divがある構造
+    // aria-label付きコンテナ内の直接のカード数を確認
+    const skeletonContainer = screen.getByLabelText("記事を読み込み中");
+    const listContainer = skeletonContainer.firstElementChild;
+    expect(listContainer?.children).toHaveLength(4);
+  });
+
+  it("count propで指定した数のスケルトンカードがレンダリングされる", () => {
+    render(<CardSkeleton count={3} />);
+
+    const skeletonContainer = screen.getByLabelText("記事を読み込み中");
+    const listContainer = skeletonContainer.firstElementChild;
+    expect(listContainer?.children).toHaveLength(3);
+  });
+
+  it("count=5で5枚のスケルトンカードがレンダリングされる", () => {
+    render(<CardSkeleton count={5} />);
+
+    const skeletonContainer = screen.getByLabelText("記事を読み込み中");
+    const listContainer = skeletonContainer.firstElementChild;
+    expect(listContainer?.children).toHaveLength(5);
+  });
+
+  it("aria-busy属性がtrueに設定されている", () => {
+    render(<CardSkeleton />);
+
+    const container = screen.getByLabelText("記事を読み込み中");
+    expect(container).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("aria-label属性が設定されている", () => {
+    render(<CardSkeleton />);
+
+    const container = screen.getByLabelText("記事を読み込み中");
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -98,6 +98,11 @@ button:focus-visible {
   }
 }
 
+@keyframes skeleton-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
 [data-theme="dark"] { color-scheme: dark; }
 [data-theme="light"] { color-scheme: light; }
 

--- a/src/index.css
+++ b/src/index.css
@@ -103,6 +103,14 @@ button:focus-visible {
   50% { opacity: 0.4; }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  @keyframes skeleton-pulse {
+    0%, 100% {
+      opacity: 0.7;
+    }
+  }
+}
+
 [data-theme="dark"] { color-scheme: dark; }
 [data-theme="light"] { color-scheme: light; }
 

--- a/src/pages/__tests__/index.test.tsx
+++ b/src/pages/__tests__/index.test.tsx
@@ -45,7 +45,7 @@ describe("Indexコンポーネント", () => {
     vi.clearAllMocks();
   });
 
-  it("読み込み中の状態を表示する", async () => {
+  it("読み込み中にスケルトンローディングを表示する", async () => {
     // usePostsでローディング状態をモック
     mockUsePosts.mockReturnValue({
       posts: [],
@@ -63,7 +63,7 @@ describe("Indexコンポーネント", () => {
       </TestWrapper>,
     );
 
-    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
+    expect(screen.getByLabelText("記事を読み込み中")).toBeInTheDocument();
   });
 
   describe("記事が存在する場合の表示", () => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,27 +19,27 @@ const Index = () => {
     setCurrentPage,
   } = usePosts();
 
-  if (loading) {
-    return <CardSkeleton />;
-  }
-
   return (
-    <Layout postCount={totalPosts}>
-      <Transition
-        as="div"
-        show={!loading}
-        appear={true}
-        enter={enterStyles}
-        enterFrom={enterFromStyles}
-        enterTo={enterToStyles}
-      >
-        <HomePage
-          posts={posts}
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={setCurrentPage}
-        />
-      </Transition>
+    <Layout postCount={loading ? undefined : totalPosts}>
+      {loading ? (
+        <CardSkeleton />
+      ) : (
+        <Transition
+          as="div"
+          show={true}
+          appear={true}
+          enter={enterStyles}
+          enterFrom={enterFromStyles}
+          enterTo={enterToStyles}
+        >
+          <HomePage
+            posts={posts}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+          />
+        </Transition>
+      )}
     </Layout>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,13 @@
-import { LoadingSpinner } from "../components/common/LoadingSpinner";
+import { Transition } from "@headlessui/react";
+import { css } from "../../styled-system/css";
+import { CardSkeleton } from "../components/common/CardSkeleton";
 import { Layout } from "../components/layouts/Layout";
 import { HomePage } from "../components/pages/HomePage";
 import { usePosts } from "../hooks/usePosts";
+
+const enterStyles = css({ transition: "all 0.3s ease" });
+const enterFromStyles = css({ opacity: 0, transform: "translateY(8px)" });
+const enterToStyles = css({ opacity: 1, transform: "translateY(0)" });
 
 const Index = () => {
   const {
@@ -14,17 +20,26 @@ const Index = () => {
   } = usePosts();
 
   if (loading) {
-    return <LoadingSpinner />;
+    return <CardSkeleton />;
   }
 
   return (
     <Layout postCount={totalPosts}>
-      <HomePage
-        posts={posts}
-        currentPage={currentPage}
-        totalPages={totalPages}
-        onPageChange={setCurrentPage}
-      />
+      <Transition
+        as="div"
+        show={!loading}
+        appear={true}
+        enter={enterStyles}
+        enterFrom={enterFromStyles}
+        enterTo={enterToStyles}
+      >
+        <HomePage
+          posts={posts}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
+      </Transition>
     </Layout>
   );
 };

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -30,25 +30,31 @@ const Post = () => {
     );
   }
 
+  if (loading) {
+    return (
+      <Layout>
+        <ArticleSkeleton />
+      </Layout>
+    );
+  }
+
+  if (!post) {
+    return null;
+  }
+
   return (
     <Layout>
-      {loading ? (
-        <ArticleSkeleton />
-      ) : (
-        <>
-          <ReadingProgressBar />
-          <Transition
-            as="div"
-            show={true}
-            appear={true}
-            enter={enterStyles}
-            enterFrom={enterFromStyles}
-            enterTo={enterToStyles}
-          >
-            <PostDetailPage post={post!} />
-          </Transition>
-        </>
-      )}
+      <ReadingProgressBar />
+      <Transition
+        as="div"
+        show={true}
+        appear={true}
+        enter={enterStyles}
+        enterFrom={enterFromStyles}
+        enterTo={enterToStyles}
+      >
+        <PostDetailPage post={post} />
+      </Transition>
     </Layout>
   );
 };

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -1,17 +1,23 @@
+import { Transition } from "@headlessui/react";
 import { useParams } from "react-router-dom";
+import { css } from "../../../styled-system/css";
+import { ArticleSkeleton } from "../../components/common/ArticleSkeleton";
 import { EmptyState } from "../../components/common/EmptyState";
-import { LoadingSpinner } from "../../components/common/LoadingSpinner";
 import { ReadingProgressBar } from "../../components/common/ReadingProgressBar";
 import { Layout } from "../../components/layouts/Layout";
 import { PostDetailPage } from "../../components/pages/PostDetailPage";
 import { usePost } from "../../hooks/usePost";
+
+const enterStyles = css({ transition: "all 0.3s ease" });
+const enterFromStyles = css({ opacity: 0, transform: "translateY(8px)" });
+const enterToStyles = css({ opacity: 1, transform: "translateY(0)" });
 
 const Post = () => {
   const { timestamp } = useParams<{ timestamp: string }>();
   const { post, loading, notFound } = usePost(timestamp);
 
   if (loading) {
-    return <LoadingSpinner message="記事を読み込み中..." />;
+    return <ArticleSkeleton />;
   }
 
   if (notFound || !post) {
@@ -31,7 +37,16 @@ const Post = () => {
   return (
     <Layout>
       <ReadingProgressBar />
-      <PostDetailPage post={post} />
+      <Transition
+        as="div"
+        show={!loading}
+        appear={true}
+        enter={enterStyles}
+        enterFrom={enterFromStyles}
+        enterTo={enterToStyles}
+      >
+        <PostDetailPage post={post} />
+      </Transition>
     </Layout>
   );
 };

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -16,11 +16,7 @@ const Post = () => {
   const { timestamp } = useParams<{ timestamp: string }>();
   const { post, loading, notFound } = usePost(timestamp);
 
-  if (loading) {
-    return <ArticleSkeleton />;
-  }
-
-  if (notFound || !post) {
+  if (notFound || (!loading && !post)) {
     return (
       <EmptyState
         icon="😕"
@@ -36,17 +32,23 @@ const Post = () => {
 
   return (
     <Layout>
-      <ReadingProgressBar />
-      <Transition
-        as="div"
-        show={!loading}
-        appear={true}
-        enter={enterStyles}
-        enterFrom={enterFromStyles}
-        enterTo={enterToStyles}
-      >
-        <PostDetailPage post={post} />
-      </Transition>
+      {loading ? (
+        <ArticleSkeleton />
+      ) : (
+        <>
+          <ReadingProgressBar />
+          <Transition
+            as="div"
+            show={true}
+            appear={true}
+            enter={enterStyles}
+            enterFrom={enterFromStyles}
+            enterTo={enterToStyles}
+          >
+            <PostDetailPage post={post!} />
+          </Transition>
+        </>
+      )}
     </Layout>
   );
 };

--- a/src/pages/posts/__tests__/Post.test.tsx
+++ b/src/pages/posts/__tests__/Post.test.tsx
@@ -30,7 +30,7 @@ const mockPost: PostType = {
 };
 
 describe("Post", () => {
-  it("ローディング中はスピナーが表示される", () => {
+  it("ローディング中はスケルトンローディングが表示される", () => {
     vi.mocked(usePost).mockReturnValue({
       post: null,
       loading: true,
@@ -46,7 +46,7 @@ describe("Post", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("記事を読み込み中...")).toBeInTheDocument();
+    expect(screen.getByLabelText("記事を読み込み中")).toBeInTheDocument();
   });
 
   it("記事が見つからない場合はEmptyStateが表示される", () => {


### PR DESCRIPTION
## 概要

LoadingSpinnerをページ固有のスケルトンローディングに置換し、Headless UI Transitionによるフェードインアニメーションを追加。

## 変更内容

- `src/index.css`: `@keyframes skeleton-pulse` アニメーション定義を追加
- `src/components/common/CardSkeleton.tsx`: ホームページ用カード型スケルトンローディングコンポーネントを新規作成（パルスアニメーション、aria属性対応）
- `src/components/common/ArticleSkeleton.tsx`: 記事詳細ページ用スケルトンローディングコンポーネントを新規作成（ヘッダー・本文構造のスケルトン）
- `src/pages/index.tsx`: LoadingSpinnerをCardSkeletonに置換、Headless UI Transitionでコンテンツのフェードインを実装
- `src/pages/posts/Post.tsx`: LoadingSpinnerをArticleSkeletonに置換、Headless UI Transitionでコンテンツのフェードインを実装
- `src/components/common/__tests__/CardSkeleton.test.tsx`: CardSkeletonのテストを新規作成
- `src/components/common/__tests__/ArticleSkeleton.test.tsx`: ArticleSkeletonのテストを新規作成
- `src/pages/__tests__/index.test.tsx`: ローディングテストをスケルトン表示の検証に更新
- `src/pages/posts/__tests__/Post.test.tsx`: ローディングテストをスケルトン表示の検証に更新

## 備考

- 既存のLoadingSpinnerコンポーネントは汎用ローディングとして残しています
- `@headlessui/react` v2.2.10（インストール済み）のTransitionコンポーネントを使用
- Panda CSSのデザイントークンに準拠したスタイリング

Closes #330