### PR TITLE
feat: 画像ライトボックス（Headless UI Dialog）

### DIFF
--- a/src/components/common/ImageLightbox.tsx
+++ b/src/components/common/ImageLightbox.tsx
@@ -1,0 +1,124 @@
+import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
+import React, { useCallback, useState } from "react";
+import { css } from "../../../styled-system/css";
+
+interface ImageLightboxProps {
+  isOpen: boolean;
+  imageSrc: string;
+  onClose: () => void;
+}
+
+const backdropStyle = css({
+  position: "fixed",
+  inset: 0,
+  background: "rgba(0, 0, 0, 0.8)",
+});
+
+const containerStyle = css({
+  position: "fixed",
+  inset: 0,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "md",
+});
+
+const panelStyle = css({
+  position: "relative",
+  maxWidth: "90vw",
+  maxHeight: "90vh",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+});
+
+const imageStyle = css({
+  maxWidth: "100%",
+  maxHeight: "90vh",
+  objectFit: "contain",
+  borderRadius: "md",
+});
+
+const closeButtonStyle = css({
+  position: "absolute",
+  top: "-xl",
+  right: "-xl",
+  background: "bg.2",
+  color: "fg.0",
+  border: "1px solid",
+  borderColor: "bg.3",
+  borderRadius: "50%",
+  width: "xl",
+  height: "xl",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  cursor: "pointer",
+  fontSize: "base",
+  lineHeight: 1,
+  _hover: {
+    background: "bg.3",
+  },
+});
+
+const spinnerContainerStyle = css({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "xl",
+});
+
+const spinnerStyle = css({
+  width: "xl",
+  height: "xl",
+  border: "4px solid",
+  borderColor: "bg.3",
+  borderTopColor: "blue.light",
+  borderRadius: "50%",
+  animation: "spin 1s linear infinite",
+});
+
+const ImageLightboxInner = ({
+  isOpen,
+  imageSrc,
+  onClose,
+}: ImageLightboxProps) => {
+  const [isLoading, setIsLoading] = useState(true);
+
+  const handleImageLoad = useCallback(() => {
+    setIsLoading(false);
+  }, []);
+
+  return (
+    <Dialog open={isOpen} onClose={onClose}>
+      <DialogBackdrop className={backdropStyle} />
+      <div className={containerStyle}>
+        <DialogPanel className={panelStyle}>
+          {isLoading && (
+            <div className={spinnerContainerStyle}>
+              <div className={spinnerStyle} />
+            </div>
+          )}
+          <img
+            src={imageSrc}
+            alt=""
+            className={imageStyle}
+            style={{ display: isLoading ? "none" : "block" }}
+            onLoad={handleImageLoad}
+          />
+          <button
+            type="button"
+            className={closeButtonStyle}
+            onClick={onClose}
+            aria-label="閉じる"
+          >
+            x
+          </button>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+};
+
+export const ImageLightbox = React.memo(ImageLightboxInner);
+ImageLightbox.displayName = "ImageLightbox";

--- a/src/components/common/ImageLightbox.tsx
+++ b/src/components/common/ImageLightbox.tsx
@@ -1,10 +1,11 @@
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { css } from "../../../styled-system/css";
 
 interface ImageLightboxProps {
   isOpen: boolean;
   imageSrc: string;
+  imageAlt: string;
   onClose: () => void;
 }
 
@@ -41,13 +42,13 @@ const imageStyle = css({
 
 const closeButtonStyle = css({
   position: "absolute",
-  top: "-xl",
-  right: "-xl",
+  top: "sm",
+  right: "sm",
   background: "bg.2",
   color: "fg.0",
   border: "1px solid",
   borderColor: "bg.3",
-  borderRadius: "50%",
+  borderRadius: "full",
   width: "xl",
   height: "xl",
   display: "flex",
@@ -74,16 +75,23 @@ const spinnerStyle = css({
   border: "4px solid",
   borderColor: "bg.3",
   borderTopColor: "blue.light",
-  borderRadius: "50%",
+  borderRadius: "full",
   animation: "spin 1s linear infinite",
 });
 
 const ImageLightboxInner = ({
   isOpen,
   imageSrc,
+  imageAlt,
   onClose,
 }: ImageLightboxProps) => {
   const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (imageSrc) {
+      setIsLoading(true);
+    }
+  }, [imageSrc]);
 
   const handleImageLoad = useCallback(() => {
     setIsLoading(false);
@@ -101,7 +109,7 @@ const ImageLightboxInner = ({
           )}
           <img
             src={imageSrc}
-            alt=""
+            alt={imageAlt}
             className={imageStyle}
             style={{ display: isLoading ? "none" : "block" }}
             onLoad={handleImageLoad}
@@ -112,7 +120,7 @@ const ImageLightboxInner = ({
             onClick={onClose}
             aria-label="閉じる"
           >
-            x
+            ×
           </button>
         </DialogPanel>
       </div>

--- a/src/components/common/ImageLightbox.tsx
+++ b/src/components/common/ImageLightbox.tsx
@@ -97,6 +97,10 @@ const ImageLightboxInner = ({
     setIsLoading(false);
   }, []);
 
+  const handleImageError = useCallback(() => {
+    setIsLoading(false);
+  }, []);
+
   return (
     <Dialog open={isOpen} onClose={onClose}>
       <DialogBackdrop className={backdropStyle} />
@@ -113,6 +117,7 @@ const ImageLightboxInner = ({
             className={imageStyle}
             style={{ display: isLoading ? "none" : "block" }}
             onLoad={handleImageLoad}
+            onError={handleImageError}
           />
           <button
             type="button"

--- a/src/components/common/__tests__/ImageLightbox.test.tsx
+++ b/src/components/common/__tests__/ImageLightbox.test.tsx
@@ -9,6 +9,7 @@ describe("ImageLightbox", () => {
       <ImageLightbox
         isOpen={true}
         imageSrc="https://example.com/photo.jpg"
+        imageAlt="テスト画像"
         onClose={vi.fn()}
       />,
     );
@@ -21,6 +22,7 @@ describe("ImageLightbox", () => {
       <ImageLightbox
         isOpen={false}
         imageSrc="https://example.com/photo.jpg"
+        imageAlt="テスト画像"
         onClose={vi.fn()}
       />,
     );
@@ -33,6 +35,7 @@ describe("ImageLightbox", () => {
       <ImageLightbox
         isOpen={true}
         imageSrc="https://example.com/photo.jpg"
+        imageAlt="テスト画像"
         onClose={vi.fn()}
       />,
     );
@@ -43,6 +46,19 @@ describe("ImageLightbox", () => {
     expect(img).toBeInTheDocument();
   });
 
+  it("画像にalt属性が設定される", () => {
+    render(
+      <ImageLightbox
+        isOpen={true}
+        imageSrc="https://example.com/photo.jpg"
+        imageAlt="テスト画像"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByAltText("テスト画像")).toBeInTheDocument();
+  });
+
   it("閉じるボタンクリックでonCloseが呼ばれる", async () => {
     const handleClose = vi.fn();
     const user = userEvent.setup();
@@ -51,6 +67,7 @@ describe("ImageLightbox", () => {
       <ImageLightbox
         isOpen={true}
         imageSrc="https://example.com/photo.jpg"
+        imageAlt="テスト画像"
         onClose={handleClose}
       />,
     );
@@ -58,5 +75,20 @@ describe("ImageLightbox", () => {
     await user.click(screen.getByRole("button", { name: "閉じる" }));
 
     expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("閉じるボタンに×が表示される", () => {
+    render(
+      <ImageLightbox
+        isOpen={true}
+        imageSrc="https://example.com/photo.jpg"
+        imageAlt=""
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "閉じる" })).toHaveTextContent(
+      "×",
+    );
   });
 });

--- a/src/components/common/__tests__/ImageLightbox.test.tsx
+++ b/src/components/common/__tests__/ImageLightbox.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ImageLightbox } from "../ImageLightbox";
@@ -75,6 +75,25 @@ describe("ImageLightbox", () => {
     await user.click(screen.getByRole("button", { name: "閉じる" }));
 
     expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("画像読み込みエラー時にスピナーが非表示になる", () => {
+    const { container } = render(
+      <ImageLightbox
+        isOpen={true}
+        imageSrc="https://example.com/broken.jpg"
+        imageAlt="壊れた画像"
+        onClose={vi.fn()}
+      />,
+    );
+
+    const img = container.ownerDocument.querySelector(
+      "img[src='https://example.com/broken.jpg']",
+    ) as HTMLImageElement;
+
+    fireEvent.error(img);
+
+    expect(img.style.display).toBe("block");
   });
 
   it("閉じるボタンに×が表示される", () => {

--- a/src/components/common/__tests__/ImageLightbox.test.tsx
+++ b/src/components/common/__tests__/ImageLightbox.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ImageLightbox } from "../ImageLightbox";
+
+describe("ImageLightbox", () => {
+  it("isOpen=trueの時にダイアログが表示される", () => {
+    render(
+      <ImageLightbox
+        isOpen={true}
+        imageSrc="https://example.com/photo.jpg"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("isOpen=falseの時にダイアログが非表示になる", () => {
+    render(
+      <ImageLightbox
+        isOpen={false}
+        imageSrc="https://example.com/photo.jpg"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("画像がsrc URLで表示される", () => {
+    const { container } = render(
+      <ImageLightbox
+        isOpen={true}
+        imageSrc="https://example.com/photo.jpg"
+        onClose={vi.fn()}
+      />,
+    );
+
+    const img = container.ownerDocument.querySelector(
+      "img[src='https://example.com/photo.jpg']",
+    );
+    expect(img).toBeInTheDocument();
+  });
+
+  it("閉じるボタンクリックでonCloseが呼ばれる", async () => {
+    const handleClose = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ImageLightbox
+        isOpen={true}
+        imageSrc="https://example.com/photo.jpg"
+        onClose={handleClose}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "閉じる" }));
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -14,7 +14,7 @@ interface PostDetailPageProps {
 
 export const PostDetailPage = ({ post }: PostDetailPageProps) => {
   const contentRef = useRef<HTMLDivElement>(null);
-  const { isOpen, imageSrc, close } = useImageLightbox(contentRef);
+  const { isOpen, imageSrc, imageAlt, close } = useImageLightbox(contentRef);
 
   return (
     <>
@@ -182,6 +182,7 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
           <ImageLightbox
             isOpen={isOpen}
             imageSrc={imageSrc}
+            imageAlt={imageAlt}
             onClose={close}
           />
         </div>

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -1,8 +1,11 @@
 import DOMPurify from "dompurify";
+import { useRef } from "react";
 import { css } from "../../../styled-system/css";
+import { useImageLightbox } from "../../hooks/useImageLightbox";
 import type { Post } from "../../lib/markdown";
 import { Link } from "../atoms/Link";
 import { Heading1 } from "../atoms/Typography";
+import { ImageLightbox } from "../common/ImageLightbox";
 import { MetaInfo } from "../common/MetaInfo";
 
 interface PostDetailPageProps {
@@ -10,6 +13,9 @@ interface PostDetailPageProps {
 }
 
 export const PostDetailPage = ({ post }: PostDetailPageProps) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const { isOpen, imageSrc, close } = useImageLightbox(contentRef);
+
   return (
     <>
       {/* Navigation */}
@@ -101,6 +107,7 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
 
             {/* Article Content */}
             <div
+              ref={contentRef}
               className={css({
                 paddingRight: "md",
                 paddingLeft: "md",
@@ -160,6 +167,7 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
                   borderRadius: "sm",
                   margin: "md 0",
                   display: "block",
+                  cursor: "zoom-in",
                 },
               })}
             >
@@ -171,6 +179,11 @@ export const PostDetailPage = ({ post }: PostDetailPageProps) => {
               />
             </div>
           </article>
+          <ImageLightbox
+            isOpen={isOpen}
+            imageSrc={imageSrc}
+            onClose={close}
+          />
         </div>
       </div>
     </>

--- a/src/hooks/__tests__/useImageLightbox.test.ts
+++ b/src/hooks/__tests__/useImageLightbox.test.ts
@@ -1,0 +1,99 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useImageLightbox } from "../useImageLightbox";
+
+describe("useImageLightbox", () => {
+  let container: HTMLDivElement;
+  let containerRef: React.RefObject<HTMLDivElement | null>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    containerRef = { current: container };
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    vi.restoreAllMocks();
+  });
+
+  it("初期状態ではisOpenがfalseになる", () => {
+    const { result } = renderHook(() => useImageLightbox(containerRef));
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.imageSrc).toBe("");
+  });
+
+  it("imgクリック時にisOpenがtrueになる", () => {
+    const { result } = renderHook(() => useImageLightbox(containerRef));
+
+    const img = document.createElement("img");
+    img.src = "https://example.com/photo.jpg";
+    container.appendChild(img);
+
+    act(() => {
+      img.click();
+    });
+
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("imgクリック時にimageSrcにsrc URLが設定される", () => {
+    const { result } = renderHook(() => useImageLightbox(containerRef));
+
+    const img = document.createElement("img");
+    img.src = "https://example.com/photo.jpg";
+    container.appendChild(img);
+
+    act(() => {
+      img.click();
+    });
+
+    expect(result.current.imageSrc).toBe("https://example.com/photo.jpg");
+  });
+
+  it("close呼び出し時にisOpenがfalseになる", () => {
+    const { result } = renderHook(() => useImageLightbox(containerRef));
+
+    const img = document.createElement("img");
+    img.src = "https://example.com/photo.jpg";
+    container.appendChild(img);
+
+    act(() => {
+      img.click();
+    });
+
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.close();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.imageSrc).toBe("");
+  });
+
+  it("img以外の要素クリックでは反応しない", () => {
+    const { result } = renderHook(() => useImageLightbox(containerRef));
+
+    const paragraph = document.createElement("p");
+    paragraph.textContent = "テキスト";
+    container.appendChild(paragraph);
+
+    act(() => {
+      paragraph.click();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.imageSrc).toBe("");
+  });
+
+  it("containerRefがnullの場合にエラーにならない", () => {
+    const nullRef: React.RefObject<HTMLElement | null> = { current: null };
+
+    const { result } = renderHook(() => useImageLightbox(nullRef));
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.imageSrc).toBe("");
+  });
+});

--- a/src/hooks/__tests__/useImageLightbox.test.ts
+++ b/src/hooks/__tests__/useImageLightbox.test.ts
@@ -22,6 +22,7 @@ describe("useImageLightbox", () => {
 
     expect(result.current.isOpen).toBe(false);
     expect(result.current.imageSrc).toBe("");
+    expect(result.current.imageAlt).toBe("");
   });
 
   it("imgクリック時にisOpenがtrueになる", () => {
@@ -29,6 +30,7 @@ describe("useImageLightbox", () => {
 
     const img = document.createElement("img");
     img.src = "https://example.com/photo.jpg";
+    img.alt = "テスト画像";
     container.appendChild(img);
 
     act(() => {
@@ -38,7 +40,23 @@ describe("useImageLightbox", () => {
     expect(result.current.isOpen).toBe(true);
   });
 
-  it("imgクリック時にimageSrcにsrc URLが設定される", () => {
+  it("imgクリック時にimageSrcとimageAltが設定される", () => {
+    const { result } = renderHook(() => useImageLightbox(containerRef));
+
+    const img = document.createElement("img");
+    img.src = "https://example.com/photo.jpg";
+    img.alt = "テスト画像";
+    container.appendChild(img);
+
+    act(() => {
+      img.click();
+    });
+
+    expect(result.current.imageSrc).toBe("https://example.com/photo.jpg");
+    expect(result.current.imageAlt).toBe("テスト画像");
+  });
+
+  it("alt属性がないimgクリック時にimageAltが空文字になる", () => {
     const { result } = renderHook(() => useImageLightbox(containerRef));
 
     const img = document.createElement("img");
@@ -50,13 +68,15 @@ describe("useImageLightbox", () => {
     });
 
     expect(result.current.imageSrc).toBe("https://example.com/photo.jpg");
+    expect(result.current.imageAlt).toBe("");
   });
 
-  it("close呼び出し時にisOpenがfalseになる", () => {
+  it("close呼び出し時にisOpen・imageSrc・imageAltがリセットされる", () => {
     const { result } = renderHook(() => useImageLightbox(containerRef));
 
     const img = document.createElement("img");
     img.src = "https://example.com/photo.jpg";
+    img.alt = "テスト画像";
     container.appendChild(img);
 
     act(() => {
@@ -71,6 +91,7 @@ describe("useImageLightbox", () => {
 
     expect(result.current.isOpen).toBe(false);
     expect(result.current.imageSrc).toBe("");
+    expect(result.current.imageAlt).toBe("");
   });
 
   it("img以外の要素クリックでは反応しない", () => {
@@ -86,6 +107,7 @@ describe("useImageLightbox", () => {
 
     expect(result.current.isOpen).toBe(false);
     expect(result.current.imageSrc).toBe("");
+    expect(result.current.imageAlt).toBe("");
   });
 
   it("containerRefがnullの場合にエラーにならない", () => {
@@ -95,5 +117,6 @@ describe("useImageLightbox", () => {
 
     expect(result.current.isOpen).toBe(false);
     expect(result.current.imageSrc).toBe("");
+    expect(result.current.imageAlt).toBe("");
   });
 });

--- a/src/hooks/useImageLightbox.ts
+++ b/src/hooks/useImageLightbox.ts
@@ -3,7 +3,8 @@ import { useCallback, useEffect, useState } from "react";
 interface UseImageLightboxReturn {
   isOpen: boolean;
   imageSrc: string;
-  open: (src: string) => void;
+  imageAlt: string;
+  open: (src: string, alt: string) => void;
   close: () => void;
 }
 
@@ -12,15 +13,18 @@ export const useImageLightbox = (
 ): UseImageLightboxReturn => {
   const [isOpen, setIsOpen] = useState(false);
   const [imageSrc, setImageSrc] = useState("");
+  const [imageAlt, setImageAlt] = useState("");
 
-  const open = useCallback((src: string) => {
+  const open = useCallback((src: string, alt: string) => {
     setImageSrc(src);
+    setImageAlt(alt);
     setIsOpen(true);
   }, []);
 
   const close = useCallback(() => {
     setIsOpen(false);
     setImageSrc("");
+    setImageAlt("");
   }, []);
 
   useEffect(() => {
@@ -32,9 +36,9 @@ export const useImageLightbox = (
     const handleClick = (event: MouseEvent) => {
       const target = event.target as HTMLElement;
       if (target.tagName === "IMG") {
-        const src = (target as HTMLImageElement).src;
-        if (src) {
-          open(src);
+        const imgElement = target as HTMLImageElement;
+        if (imgElement.src) {
+          open(imgElement.src, imgElement.alt || "");
         }
       }
     };
@@ -43,5 +47,5 @@ export const useImageLightbox = (
     return () => container.removeEventListener("click", handleClick);
   }, [containerRef, open]);
 
-  return { isOpen, imageSrc, open, close };
+  return { isOpen, imageSrc, imageAlt, open, close };
 };

--- a/src/hooks/useImageLightbox.ts
+++ b/src/hooks/useImageLightbox.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from "react";
+
+interface UseImageLightboxReturn {
+  isOpen: boolean;
+  imageSrc: string;
+  open: (src: string) => void;
+  close: () => void;
+}
+
+export const useImageLightbox = (
+  containerRef: React.RefObject<HTMLElement | null>,
+): UseImageLightboxReturn => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [imageSrc, setImageSrc] = useState("");
+
+  const open = useCallback((src: string) => {
+    setImageSrc(src);
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setImageSrc("");
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (target.tagName === "IMG") {
+        const src = (target as HTMLImageElement).src;
+        if (src) {
+          open(src);
+        }
+      }
+    };
+
+    container.addEventListener("click", handleClick);
+    return () => container.removeEventListener("click", handleClick);
+  }, [containerRef, open]);
+
+  return { isOpen, imageSrc, open, close };
+};


### PR DESCRIPTION
## 概要

Issue #333 対応。記事詳細ページの画像クリックでライトボックス（モーダル）表示する機能を実装。

## 変更内容

- `src/hooks/useImageLightbox.ts`（新規）: イベントデリゲーションによるimg要素クリック検出、ライトボックスの開閉状態・src URL管理のカスタムフック
- `src/components/common/ImageLightbox.tsx`（新規）: Headless UI v2 Dialogベースのモーダルコンポーネント（ESCキー閉じ、オーバーレイクリック閉じ、フォーカストラップ、ロード中スピナー対応）
- `src/components/pages/PostDetailPage.tsx`（修正）: useImageLightboxフックとImageLightboxコンポーネントの統合、img要素にcursor: zoom-inスタイル追加
- `src/hooks/__tests__/useImageLightbox.test.ts`（新規）: フックのテスト（開閉状態、src設定、エッジケース）
- `src/components/common/__tests__/ImageLightbox.test.tsx`（新規）: コンポーネントのテスト（表示/非表示、画像src、閉じるボタン）

## 備考

closes #333