### PR TITLE
refactor: Transitionスタイル定数の共通化

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,13 @@
 import { Transition } from "@headlessui/react";
-import { css } from "../../styled-system/css";
 import { CardSkeleton } from "../components/common/CardSkeleton";
 import { Layout } from "../components/layouts/Layout";
 import { HomePage } from "../components/pages/HomePage";
 import { usePosts } from "../hooks/usePosts";
-
-const enterStyles = css({ transition: "all 0.3s ease" });
-const enterFromStyles = css({ opacity: 0, transform: "translateY(8px)" });
-const enterToStyles = css({ opacity: 1, transform: "translateY(0)" });
+import {
+  fadeInEnter,
+  fadeInEnterFrom,
+  fadeInEnterTo,
+} from "../styles/transitions";
 
 const Index = () => {
   const {
@@ -28,9 +28,9 @@ const Index = () => {
           as="div"
           show={true}
           appear={true}
-          enter={enterStyles}
-          enterFrom={enterFromStyles}
-          enterTo={enterToStyles}
+          enter={fadeInEnter}
+          enterFrom={fadeInEnterFrom}
+          enterTo={fadeInEnterTo}
         >
           <HomePage
             posts={posts}

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -1,6 +1,5 @@
 import { Transition } from "@headlessui/react";
 import { useParams } from "react-router-dom";
-import { css } from "../../../styled-system/css";
 import { ArticleSkeleton } from "../../components/common/ArticleSkeleton";
 import { EmptyState } from "../../components/common/EmptyState";
 import { ReadingProgressBar } from "../../components/common/ReadingProgressBar";
@@ -8,10 +7,11 @@ import { Layout } from "../../components/layouts/Layout";
 import { PostDetailPage } from "../../components/pages/PostDetailPage";
 import { useAdjacentPosts } from "../../hooks/useAdjacentPosts";
 import { usePost } from "../../hooks/usePost";
-
-const enterStyles = css({ transition: "all 0.3s ease" });
-const enterFromStyles = css({ opacity: 0, transform: "translateY(8px)" });
-const enterToStyles = css({ opacity: 1, transform: "translateY(0)" });
+import {
+  fadeInEnter,
+  fadeInEnterFrom,
+  fadeInEnterTo,
+} from "../../styles/transitions";
 
 const Post = () => {
   const { timestamp } = useParams<{ timestamp: string }>();
@@ -51,11 +51,15 @@ const Post = () => {
         as="div"
         show={true}
         appear={true}
-        enter={enterStyles}
-        enterFrom={enterFromStyles}
-        enterTo={enterToStyles}
+        enter={fadeInEnter}
+        enterFrom={fadeInEnterFrom}
+        enterTo={fadeInEnterTo}
       >
-        <PostDetailPage post={post} olderPost={olderPost} newerPost={newerPost} />
+        <PostDetailPage
+          post={post}
+          olderPost={olderPost}
+          newerPost={newerPost}
+        />
       </Transition>
     </Layout>
   );

--- a/src/styles/transitions.ts
+++ b/src/styles/transitions.ts
@@ -1,0 +1,13 @@
+import { css } from "../../styled-system/css";
+
+/** ページ表示時のフェードイン: enter */
+export const fadeInEnter = css({ transition: "all 0.3s ease" });
+
+/** ページ表示時のフェードイン: enterFrom（初期状態） */
+export const fadeInEnterFrom = css({
+  opacity: 0,
+  transform: "translateY(8px)",
+});
+
+/** ページ表示時のフェードイン: enterTo（最終状態） */
+export const fadeInEnterTo = css({ opacity: 1, transform: "translateY(0)" });


### PR DESCRIPTION
## 概要

`enterStyles`, `enterFromStyles`, `enterToStyles` がページコンポーネント(`index.tsx`, `Post.tsx`)で重複定義されていたため、共通モジュール `src/styles/transitions.ts` に切り出してDRYにした。

closes #342

## 変更内容

- `src/styles/transitions.ts` を新規作成し、`fadeInEnter`, `fadeInEnterFrom`, `fadeInEnterTo` を共通定数として定義
- `src/pages/index.tsx` からローカルのスタイル定数を削除し、共通モジュールからのimportに変更
- `src/pages/posts/Post.tsx` からローカルのスタイル定数を削除し、共通モジュールからのimportに変更
- `BackToTop.tsx` はduration・translateYの値が異なるため変更対象外（0.2s/10px vs 0.3s/8px）

## 備考

- 全243テスト通過、ビルド・lint・型チェックすべて正常