### PR TITLE
fix: パストラバーサル防止ガードを追加

### DIFF
--- a/src/api/__tests__/posts.test.ts
+++ b/src/api/__tests__/posts.test.ts
@@ -159,6 +159,17 @@ describe("createPostsMiddleware", () => {
       expect(res.end).toHaveBeenCalledWith(mockContent);
     });
 
+    it("パストラバーサルを含むリクエストに 403 エラーを返す", () => {
+      req.url = "/../../../etc/passwd";
+      const readSpy = vi.spyOn(fs, "readFileSync");
+
+      middleware(req as IncomingMessage, res as ServerResponse, next);
+
+      expect(res.statusCode).toBe(403);
+      expect(res.end).toHaveBeenCalledWith("Forbidden");
+      expect(readSpy).not.toHaveBeenCalled();
+    });
+
     it("投稿が存在しない場合、404 エラーを返す", () => {
       req.url = "/nonexistent";
       vi.spyOn(fs, "readFileSync").mockImplementation(() => {

--- a/src/api/posts.ts
+++ b/src/api/posts.ts
@@ -26,6 +26,14 @@ export const createPostsMiddleware = () => {
     if (postId) {
       const filePath = path.join(datasourcesPath, `${postId}.md`);
 
+      // パストラバーサル攻撃を防止
+      const resolvedPath = path.resolve(filePath);
+      if (!resolvedPath.startsWith(path.resolve(datasourcesPath))) {
+        res.statusCode = 403;
+        res.end("Forbidden");
+        return;
+      }
+
       try {
         const content = fs.readFileSync(filePath, "utf8");
         res.setHeader("Content-Type", "text/plain; charset=utf-8");

--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -302,6 +302,24 @@ const x = 1;
       expect(result.content).toContain('alt="alt text"');
     });
 
+    it("パストラバーサルを含む画像パスが空文字に変換される", () => {
+      const content = `# テスト
+
+## 投稿日時
+- 2024-01-01 10:00
+
+## 筆者名
+- テスト太郎
+
+## 本文
+![悪意ある画像](images/../../etc/passwd)`;
+
+      const result = parseMarkdown(content, "20240101100000");
+
+      expect(result.content).toContain('src=""');
+      expect(result.content).not.toContain("/etc/passwd");
+    });
+
     it("外部URLの画像はパス変換されない", () => {
       const content = `# テスト
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -29,6 +29,10 @@ export interface TocItem {
 const resolveImagePath = (src: string): string => {
   // images/ で始まる相対パスを /datasources/images/ に変換
   if (src.startsWith("images/")) {
+    // パストラバーサルを防止
+    if (src.includes("..")) {
+      return "";
+    }
     const base = import.meta.env.DEV ? "" : "/lazy-note";
     return `${base}/datasources/${src}`;
   }


### PR DESCRIPTION
## 概要

投稿APIおよび画像パス解決処理にパストラバーサル防止ガードを追加し、セキュリティを強化する。

## 変更内容

- `src/api/posts.ts`: 個別投稿取得時に `path.resolve` + `startsWith` によるパストラバーサル防止ガードを追加（`images.ts` と同様の実装）
- `src/lib/markdown.ts`: `resolveImagePath` 関数で `..` を含むパスを拒否する検証を追加
- `src/api/__tests__/posts.test.ts`: パストラバーサルリクエストに 403 を返すテストを追加
- `src/lib/__tests__/markdown.test.ts`: パストラバーサルを含む画像パスが空文字に変換されるテストを追加

## 備考

closes #351
closes #352