### PR TITLE
feat: ダークモード切替の a11y を強化し prefers-color-scheme に追従

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,17 @@
     <meta name="description" content="Lazy Note - シンプルで読みやすいブログプラットフォーム。日々の思考やアイデアを気軽に記録・共有できます。" />
     <title>Lazy Note</title>
     <script>
+      // ダークモード初期化 (FOUC 対策):
+      // - localStorage の "theme" が "light" / "dark" の場合は手動設定として優先
+      // - それ以外は prefers-color-scheme に従い、localStorage には書き込まない
+      //   (system 追従を維持するため未設定状態を保持する)
       try {
         var t = localStorage.getItem("theme");
         if (t !== "light" && t !== "dark") {
           t = matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
-          localStorage.setItem("theme", t);
         }
         document.documentElement.dataset.theme = t;
-      } catch(e) {
+      } catch (e) {
         document.documentElement.dataset.theme = "dark";
       }
     </script>

--- a/src/components/common/ThemeToggle.tsx
+++ b/src/components/common/ThemeToggle.tsx
@@ -8,12 +8,12 @@ import { useTheme } from "../../hooks/useTheme";
  * a11y:
  * - role=switch + aria-checked は Headless UI の Switch が提供
  * - aria-label は現在の状態と次の操作を含めて動的に変更
- * - フォーカスリングは accent.focus (citrus-500) で可視化
- * - キーボード操作 (Space / Enter) は Headless UI が標準対応
- * - タッチターゲット 44x44 を outer button のパディングで確保 (WCAG 2.5.5)
+ * - フォーカスリングは accent.focus (citrus-500) で可視化 (:focus-visible)
+ * - キーボード操作 (Space) は Headless UI Switch が WAI-ARIA に従い対応
+ * - タッチターゲットは 56x28px。WCAG 2.5.8 (AA: 24x24px) を満たす
+ *   (2.5.5 AAA: 44x44px には届かないため、将来的に拡張余地あり)
  */
 const switchStyles = css({
-  // outer のヒット領域は 44x44 を確保しつつ、視覚的トグルは中央 56x28
   position: "relative",
   display: "inline-flex",
   alignItems: "center",

--- a/src/components/common/ThemeToggle.tsx
+++ b/src/components/common/ThemeToggle.tsx
@@ -2,18 +2,36 @@ import { Switch } from "@headlessui/react";
 import { css } from "../../../styled-system/css";
 import { useTheme } from "../../hooks/useTheme";
 
+/**
+ * テーマ切替トグル。
+ *
+ * a11y:
+ * - role=switch + aria-checked は Headless UI の Switch が提供
+ * - aria-label は現在の状態と次の操作を含めて動的に変更
+ * - フォーカスリングは accent.focus (citrus-500) で可視化
+ * - キーボード操作 (Space / Enter) は Headless UI が標準対応
+ * - タッチターゲット 44x44 を outer button のパディングで確保 (WCAG 2.5.5)
+ */
 const switchStyles = css({
+  // outer のヒット領域は 44x44 を確保しつつ、視覚的トグルは中央 56x28
   position: "relative",
   display: "inline-flex",
   alignItems: "center",
+  justifyContent: "flex-start",
   width: "56px",
   height: "28px",
+  padding: "0",
   borderRadius: "full",
   border: "2px solid",
   borderColor: "bg.3",
   cursor: "pointer",
   transition: "all 0.2s ease",
   background: "bg.2",
+  outline: "none",
+  // キーボードフォーカス時のみ citrus-500 リングを表示
+  _focusVisible: {
+    boxShadow: "0 0 0 2px var(--colors-accent-focus)",
+  },
 });
 
 const thumbStyles = css({
@@ -31,15 +49,20 @@ const thumbTranslateOn = css({ transform: "translateX(28px)" });
 export const ThemeToggle = () => {
   const { theme, toggleTheme } = useTheme();
   const isLight = theme === "light";
+  const ariaLabel = isLight
+    ? "テーマ切替: 現在ライト。クリックでダークに切り替えます"
+    : "テーマ切替: 現在ダーク。クリックでライトに切り替えます";
 
   return (
     <Switch
       checked={isLight}
       onChange={toggleTheme}
       className={switchStyles}
-      aria-label="テーマ切替"
+      aria-label={ariaLabel}
+      title={ariaLabel}
     >
       <span
+        aria-hidden="true"
         className={`${thumbStyles} ${isLight ? thumbTranslateOn : thumbTranslateOff}`}
       />
     </Switch>

--- a/src/components/common/__tests__/ThemeToggle.test.tsx
+++ b/src/components/common/__tests__/ThemeToggle.test.tsx
@@ -1,36 +1,117 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { userEvent } from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeToggle } from "../ThemeToggle";
+
+const setupMatchMedia = (matches: boolean) => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: vi.fn(() => ({
+      matches,
+      media: "",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+};
 
 describe("ThemeToggle", () => {
   beforeEach(() => {
     localStorage.clear();
     document.documentElement.dataset.theme = "dark";
+    setupMatchMedia(false);
   });
 
   it("スイッチが表示される", () => {
     render(<ThemeToggle />);
 
-    const toggle = screen.getByRole("switch", { name: "テーマ切替" });
+    const toggle = screen.getByRole("switch");
     expect(toggle).toBeInTheDocument();
   });
 
-  it("クリックでテーマがdarkからlightに切り替わる", () => {
+  it("aria-checkedで現在のテーマ状態を伝える", () => {
+    localStorage.setItem("theme", "dark");
     render(<ThemeToggle />);
 
-    const toggle = screen.getByRole("switch", { name: "テーマ切替" });
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("light状態ではaria-checked='true'になる", () => {
+    localStorage.setItem("theme", "light");
+    render(<ThemeToggle />);
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("dark時のaria-labelに現在状態と次の操作が含まれる", () => {
+    localStorage.setItem("theme", "dark");
+    render(<ThemeToggle />);
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute(
+      "aria-label",
+      "テーマ切替: 現在ダーク。クリックでライトに切り替えます",
+    );
+  });
+
+  it("light時のaria-labelに現在状態と次の操作が含まれる", () => {
+    localStorage.setItem("theme", "light");
+    render(<ThemeToggle />);
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute(
+      "aria-label",
+      "テーマ切替: 現在ライト。クリックでダークに切り替えます",
+    );
+  });
+
+  it("クリックでテーマがdarkからlightに切り替わる", () => {
+    localStorage.setItem("theme", "dark");
+    render(<ThemeToggle />);
+
+    const toggle = screen.getByRole("switch");
     fireEvent.click(toggle);
 
     expect(document.documentElement.dataset.theme).toBe("light");
   });
 
   it("クリック2回でテーマがdarkに戻る", () => {
+    localStorage.setItem("theme", "dark");
     render(<ThemeToggle />);
 
-    const toggle = screen.getByRole("switch", { name: "テーマ切替" });
+    const toggle = screen.getByRole("switch");
     fireEvent.click(toggle);
     fireEvent.click(toggle);
 
     expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+
+  it("Spaceキーでテーマを切替できる", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem("theme", "dark");
+    render(<ThemeToggle />);
+
+    const toggle = screen.getByRole("switch");
+    toggle.focus();
+    await user.keyboard("[Space]");
+
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+
+  it("Tabでフォーカスを当てられる", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle />);
+
+    await user.tab();
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveFocus();
   });
 });

--- a/src/hooks/__tests__/useTheme.test.ts
+++ b/src/hooks/__tests__/useTheme.test.ts
@@ -1,87 +1,267 @@
 import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useTheme } from "../useTheme";
+
+/**
+ * matchMedia の戻り値をモックする。
+ * change イベントを発火するために addEventListener / removeEventListener を補足する。
+ */
+type MediaListener = (e: MediaQueryListEvent) => void;
+
+const setupMatchMedia = (initialMatches: boolean) => {
+  let matches = initialMatches;
+  const listeners = new Set<MediaListener>();
+
+  const dispatchChange = (next: boolean) => {
+    matches = next;
+    for (const listener of listeners) {
+      listener({ matches: next } as MediaQueryListEvent);
+    }
+  };
+
+  const matchMediaMock = vi.fn((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn((_: string, listener: MediaListener) => {
+      listeners.add(listener);
+    }),
+    removeEventListener: vi.fn((_: string, listener: MediaListener) => {
+      listeners.delete(listener);
+    }),
+    dispatchEvent: vi.fn(),
+  }));
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: matchMediaMock,
+  });
+
+  return { dispatchChange, matchMediaMock };
+};
 
 describe("useTheme", () => {
   beforeEach(() => {
     localStorage.clear();
     document.documentElement.dataset.theme = "dark";
+    setupMatchMedia(false);
+  });
+
+  afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("デフォルトで'dark'を返す", () => {
-    const { result } = renderHook(() => useTheme());
+  describe("初期解決", () => {
+    it("localStorageが空でprefers-color-scheme: darkの場合にdarkを返す", () => {
+      setupMatchMedia(false);
 
-    expect(result.current.theme).toBe("dark");
-  });
+      const { result } = renderHook(() => useTheme());
 
-  it("localStorageに'light'が保存されている場合に'light'を返す", () => {
-    localStorage.setItem("theme", "light");
-
-    const { result } = renderHook(() => useTheme());
-
-    expect(result.current.theme).toBe("light");
-  });
-
-  it("setThemeでテーマを'light'に切替できる", () => {
-    const { result } = renderHook(() => useTheme());
-
-    act(() => {
-      result.current.setTheme("light");
+      expect(result.current.theme).toBe("dark");
+      expect(result.current.preference).toBe("system");
     });
 
-    expect(result.current.theme).toBe("light");
-  });
+    it("localStorageが空でprefers-color-scheme: lightの場合にlightを返す", () => {
+      setupMatchMedia(true);
 
-  it("setThemeでテーマを'dark'に切替できる", () => {
-    localStorage.setItem("theme", "light");
-    const { result } = renderHook(() => useTheme());
+      const { result } = renderHook(() => useTheme());
 
-    act(() => {
-      result.current.setTheme("dark");
+      expect(result.current.theme).toBe("light");
+      expect(result.current.preference).toBe("system");
     });
 
-    expect(result.current.theme).toBe("dark");
-  });
+    it("localStorageに'light'が保存されている場合にlightを返す", () => {
+      localStorage.setItem("theme", "light");
 
-  it("toggleThemeでdarkからlightに切替できる", () => {
-    const { result } = renderHook(() => useTheme());
+      const { result } = renderHook(() => useTheme());
 
-    act(() => {
-      result.current.toggleTheme();
+      expect(result.current.theme).toBe("light");
+      expect(result.current.preference).toBe("light");
     });
 
-    expect(result.current.theme).toBe("light");
-  });
+    it("localStorageに'dark'が保存されている場合にdarkを返す", () => {
+      localStorage.setItem("theme", "dark");
+      setupMatchMedia(true);
 
-  it("toggleThemeでlightからdarkに切替できる", () => {
-    localStorage.setItem("theme", "light");
-    const { result } = renderHook(() => useTheme());
+      const { result } = renderHook(() => useTheme());
 
-    act(() => {
-      result.current.toggleTheme();
+      // localStorage の手動設定が prefers-color-scheme より優先される
+      expect(result.current.theme).toBe("dark");
+      expect(result.current.preference).toBe("dark");
     });
 
-    expect(result.current.theme).toBe("dark");
+    it("localStorageに不正値が入っていてもprefers-color-schemeにフォールバックする", () => {
+      localStorage.setItem("theme", "neon");
+      setupMatchMedia(true);
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.theme).toBe("light");
+      expect(result.current.preference).toBe("system");
+    });
   });
 
-  it("setThemeがlocalStorageに値を保存する", () => {
-    const { result } = renderHook(() => useTheme());
+  describe("setTheme / setPreference", () => {
+    it("setThemeでテーマをlightに切替できる", () => {
+      const { result } = renderHook(() => useTheme());
 
-    act(() => {
-      result.current.setTheme("light");
+      act(() => {
+        result.current.setTheme("light");
+      });
+
+      expect(result.current.theme).toBe("light");
+      expect(result.current.preference).toBe("light");
     });
 
-    expect(localStorage.getItem("theme")).toBe("light");
+    it("setThemeがlocalStorageに値を保存する", () => {
+      const { result } = renderHook(() => useTheme());
+
+      act(() => {
+        result.current.setTheme("light");
+      });
+
+      expect(localStorage.getItem("theme")).toBe("light");
+    });
+
+    it("setThemeがdocument.documentElement.dataset.themeを更新する", () => {
+      const { result } = renderHook(() => useTheme());
+
+      act(() => {
+        result.current.setTheme("light");
+      });
+
+      expect(document.documentElement.dataset.theme).toBe("light");
+    });
+
+    it("setPreferenceで'system'を指定するとlocalStorageから削除されprefers-color-schemeに追従する", () => {
+      const { dispatchChange } = setupMatchMedia(false);
+      localStorage.setItem("theme", "light");
+      const { result } = renderHook(() => useTheme());
+
+      act(() => {
+        result.current.setPreference("system");
+      });
+
+      expect(localStorage.getItem("theme")).toBeNull();
+      expect(result.current.preference).toBe("system");
+      expect(result.current.theme).toBe("dark");
+
+      // system 追従中は prefers-color-scheme 変更が反映される
+      act(() => {
+        dispatchChange(true);
+      });
+      expect(result.current.theme).toBe("light");
+    });
   });
 
-  it("setThemeがdocument.documentElement.dataset.themeを更新する", () => {
-    const { result } = renderHook(() => useTheme());
+  describe("toggleTheme", () => {
+    it("toggleThemeでdarkからlightに切替できる", () => {
+      localStorage.setItem("theme", "dark");
+      const { result } = renderHook(() => useTheme());
 
-    act(() => {
-      result.current.setTheme("light");
+      act(() => {
+        result.current.toggleTheme();
+      });
+
+      expect(result.current.theme).toBe("light");
+      expect(result.current.preference).toBe("light");
     });
 
-    expect(document.documentElement.dataset.theme).toBe("light");
+    it("toggleThemeでlightからdarkに切替できる", () => {
+      localStorage.setItem("theme", "light");
+      const { result } = renderHook(() => useTheme());
+
+      act(() => {
+        result.current.toggleTheme();
+      });
+
+      expect(result.current.theme).toBe("dark");
+      expect(result.current.preference).toBe("dark");
+    });
+
+    it("system追従中にtoggleThemeすると現在の解決済みテーマを反転して手動設定にする", () => {
+      setupMatchMedia(false); // system = dark
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.preference).toBe("system");
+      expect(result.current.theme).toBe("dark");
+
+      act(() => {
+        result.current.toggleTheme();
+      });
+
+      expect(result.current.theme).toBe("light");
+      expect(result.current.preference).toBe("light");
+      expect(localStorage.getItem("theme")).toBe("light");
+    });
+  });
+
+  describe("prefers-color-scheme 追従", () => {
+    it("system設定時にprefers-color-scheme変更で自動追従する", () => {
+      const { dispatchChange } = setupMatchMedia(false);
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.theme).toBe("dark");
+
+      act(() => {
+        dispatchChange(true);
+      });
+
+      expect(result.current.theme).toBe("light");
+    });
+
+    it("手動設定時はprefers-color-scheme変更を無視する", () => {
+      const { dispatchChange } = setupMatchMedia(false);
+      localStorage.setItem("theme", "dark");
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.theme).toBe("dark");
+      expect(result.current.preference).toBe("dark");
+
+      act(() => {
+        dispatchChange(true);
+      });
+
+      // localStorage の手動設定が優先されるため dark のまま
+      expect(result.current.theme).toBe("dark");
+    });
+  });
+
+  describe("localStorage の堅牢性", () => {
+    it("localStorage.getItem が例外を投げてもprefers-color-schemeから解決できる", () => {
+      setupMatchMedia(true);
+      const original = Storage.prototype.getItem;
+      Storage.prototype.getItem = vi.fn(() => {
+        throw new Error("blocked");
+      });
+
+      try {
+        const { result } = renderHook(() => useTheme());
+        expect(result.current.theme).toBe("light");
+        expect(result.current.preference).toBe("system");
+      } finally {
+        Storage.prototype.getItem = original;
+      }
+    });
+
+    it("localStorage.setItem が例外を投げてもDOMには反映される", () => {
+      const original = Storage.prototype.setItem;
+      Storage.prototype.setItem = vi.fn(() => {
+        throw new Error("quota");
+      });
+
+      try {
+        const { result } = renderHook(() => useTheme());
+        act(() => {
+          result.current.setTheme("light");
+        });
+        expect(document.documentElement.dataset.theme).toBe("light");
+      } finally {
+        Storage.prototype.setItem = original;
+      }
+    });
   });
 });

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,53 +1,164 @@
 import { useCallback, useSyncExternalStore } from "react";
 
-type Theme = "dark" | "light";
-const STORAGE_KEY = "theme";
+/**
+ * 解決済みのテーマ (DOM に適用される実体)。
+ */
+type ResolvedTheme = "dark" | "light";
 
-const getThemeSnapshot = (): Theme => {
+/**
+ * ユーザーの嗜好。"system" は prefers-color-scheme に追従する状態を指す。
+ */
+type ThemePreference = ResolvedTheme | "system";
+
+const STORAGE_KEY = "theme";
+const MEDIA_QUERY = "(prefers-color-scheme: light)";
+
+/**
+ * localStorage から手動上書きされたテーマを取得する。
+ * 値が "light" / "dark" 以外 (未設定や不正値) は null を返し、system 追従となる。
+ */
+const readStoredPreference = (): ResolvedTheme | null => {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored === "light" || stored === "dark") {
       return stored;
     }
   } catch {
-    /* localStorageにアクセスできない場合はフォールバック */
+    /* localStorage にアクセスできない環境では system 追従にフォールバック */
   }
-  const domTheme = document.documentElement.dataset.theme;
-  if (domTheme === "light" || domTheme === "dark") {
-    return domTheme;
+  return null;
+};
+
+/**
+ * prefers-color-scheme から system のテーマを解決する。
+ * matchMedia が利用できない環境では "dark" にフォールバックする。
+ */
+const readSystemTheme = (): ResolvedTheme => {
+  try {
+    if (typeof window !== "undefined" && typeof window.matchMedia === "function") {
+      return window.matchMedia(MEDIA_QUERY).matches ? "light" : "dark";
+    }
+  } catch {
+    /* matchMedia が利用不可の環境ではフォールバック */
   }
   return "dark";
 };
 
-const getServerSnapshot = (): Theme => "dark";
+/**
+ * 現在 DOM に適用されているテーマを解決する。
+ * 優先順位: localStorage の手動設定 > prefers-color-scheme > "dark" フォールバック。
+ */
+const getResolvedTheme = (): ResolvedTheme => {
+  const stored = readStoredPreference();
+  if (stored !== null) {
+    return stored;
+  }
+  return readSystemTheme();
+};
 
+/**
+ * ユーザーの嗜好を取得する。手動設定がなければ "system" を返す。
+ */
+const getPreference = (): ThemePreference => readStoredPreference() ?? "system";
+
+const getServerSnapshot = (): ResolvedTheme => "dark";
+
+/**
+ * useSyncExternalStore 用の subscribe。
+ * - storage イベント (他タブの変更, 自タブからの dispatch)
+ * - prefers-color-scheme の change (system 追従中の OS 設定変化)
+ * の両方を購読する。
+ */
 const subscribe = (callback: () => void): (() => void) => {
   const handleStorage = (e: StorageEvent) => {
-    if (e.key === STORAGE_KEY) {
+    if (e.key === STORAGE_KEY || e.key === null) {
       callback();
     }
   };
   window.addEventListener("storage", handleStorage);
-  return () => window.removeEventListener("storage", handleStorage);
+
+  let mediaQuery: MediaQueryList | null = null;
+  const handleMedia = () => callback();
+  try {
+    if (typeof window.matchMedia === "function") {
+      mediaQuery = window.matchMedia(MEDIA_QUERY);
+      mediaQuery.addEventListener("change", handleMedia);
+    }
+  } catch {
+    /* matchMedia 未対応環境では追従購読をスキップ */
+  }
+
+  return () => {
+    window.removeEventListener("storage", handleStorage);
+    mediaQuery?.removeEventListener("change", handleMedia);
+  };
 };
 
+/**
+ * DOM とユーザー嗜好の同期を行うカスタムフック。
+ *
+ * - `theme`: 現在 DOM に適用されているテーマ ("light" | "dark")
+ * - `preference`: ユーザーの嗜好 ("light" | "dark" | "system")
+ * - `setTheme(t)`: "light" / "dark" を手動指定する (localStorage 永続化)
+ * - `setPreference(p)`: "system" を含めた嗜好を設定する
+ *   - "system" を渡すと localStorage を削除し prefers-color-scheme 追従に戻す
+ * - `toggleTheme()`: 現在の解決済みテーマを反転して手動設定する
+ */
 export const useTheme = () => {
   const theme = useSyncExternalStore(
     subscribe,
-    getThemeSnapshot,
+    getResolvedTheme,
     getServerSnapshot,
   );
+  const preference = useSyncExternalStore(
+    subscribe,
+    getPreference,
+    () => "system" as ThemePreference,
+  );
 
-  const setTheme = useCallback((newTheme: Theme) => {
-    localStorage.setItem(STORAGE_KEY, newTheme);
-    document.documentElement.dataset.theme = newTheme;
+  /**
+   * storage イベントを発火して useSyncExternalStore に再評価を促す。
+   * 同タブ内の変更は本来 storage イベントが発火しないため、明示的に dispatch する。
+   */
+  const notifyChange = useCallback(() => {
     window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
   }, []);
 
-  const toggleTheme = useCallback(() => {
-    const current = getThemeSnapshot();
-    setTheme(current === "dark" ? "light" : "dark");
-  }, [setTheme]);
+  const applyTheme = useCallback((resolved: ResolvedTheme) => {
+    document.documentElement.dataset.theme = resolved;
+  }, []);
 
-  return { theme, setTheme, toggleTheme };
+  const setPreference = useCallback(
+    (next: ThemePreference) => {
+      try {
+        if (next === "system") {
+          localStorage.removeItem(STORAGE_KEY);
+          applyTheme(readSystemTheme());
+        } else {
+          localStorage.setItem(STORAGE_KEY, next);
+          applyTheme(next);
+        }
+      } catch {
+        /* localStorage 書き込み失敗時も DOM だけは反映する */
+        if (next !== "system") {
+          applyTheme(next);
+        }
+      }
+      notifyChange();
+    },
+    [applyTheme, notifyChange],
+  );
+
+  const setTheme = useCallback(
+    (next: ResolvedTheme) => {
+      setPreference(next);
+    },
+    [setPreference],
+  );
+
+  const toggleTheme = useCallback(() => {
+    setPreference(getResolvedTheme() === "dark" ? "light" : "dark");
+  }, [setPreference]);
+
+  return { theme, preference, setTheme, setPreference, toggleTheme };
 };


### PR DESCRIPTION
## 概要

Issue #368 (Ext-5) の実装。既存のダークモード切替機能を a11y 強化し、`prefers-color-scheme` への自動追従を追加。

Closes #368

## 主な変更

- `ThemeToggle` に `aria-label` の動的更新、フォーカスリング (`:focus-visible` で citrus-500)、Headless UI `Switch` によるキーボード操作 (Space) を整備。タッチターゲットは 56x28px (WCAG 2.5.8 AA を満たす / 2.5.5 AAA は将来拡張)
- `useTheme` で `prefers-color-scheme` 自動追従を実装し、`localStorage` を優先
- 同タブ内変更通知のため `StorageEvent` を `dispatchEvent` で発火し `useSyncExternalStore` を再評価
- `index.html` の inline script を `prefers-color-scheme` 尊重に更新 (FOUC 防止)

## 変更ファイル

- `index.html`: 初期テーマ判定の inline script 更新
- `src/components/common/ThemeToggle.tsx`: a11y 属性 / フォーカス可視性
- `src/components/common/__tests__/ThemeToggle.test.tsx`: 振る舞いベースのテスト拡充
- `src/hooks/useTheme.ts`: `prefers-color-scheme` 追従とイベント連携
- `src/hooks/__tests__/useTheme.test.ts`: メディアクエリ追従と localStorage 優先のテスト

## ローカル検証

- `pnpm install --frozen-lockfile` 成功
- `pnpm prepare` 成功
- `pnpm lint` 成功 (Checked 77 files)
- `pnpm test:run` 成功 (35 ファイル / 361 テスト all green)
- `pnpm exec tsc --noEmit` 成功

## 関連設計

- `docs/rfc/editorial-citrus/02-color-system.md`
- `docs/rfc/editorial-citrus/07-accessibility-and-performance.md`
- `docs/rfc/editorial-citrus/08-roadmap.md` (Ext-5)