### PR TITLE
feat: RSS feed と sitemap の生成スクリプトを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Lazy Note - シンプルで読みやすいブログプラットフォーム。日々の思考やアイデアを気軽に記録・共有できます。" />
+    <link rel="alternate" type="application/rss+xml" title="Lazy Note RSS Feed" href="/feed.xml" />
     <title>Lazy Note</title>
     <script>
       try {

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Lazy Note - シンプルで読みやすいブログプラットフォーム。日々の思考やアイデアを気軽に記録・共有できます。" />
-    <link rel="alternate" type="application/rss+xml" title="Lazy Note RSS Feed" href="/feed.xml" />
+    <link rel="alternate" type="application/rss+xml" title="Lazy Note RSS Feed" href="https://amkkr.github.io/lazy-note/feed.xml" />
     <title>Lazy Note</title>
     <script>
       try {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "panda --watch & vite",
-    "build": "pnpm run lint && pnpm run test:run && pnpm run type-check && panda && tsc && vite build",
+    "build": "pnpm run lint && pnpm run test:run && pnpm run type-check && panda && tsc && vite build && pnpm run build:feed && pnpm run build:sitemap",
+    "build:feed": "node scripts/buildFeed.ts",
+    "build:sitemap": "node scripts/buildSitemap.ts",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",

--- a/scripts/buildFeed.ts
+++ b/scripts/buildFeed.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/**
+ * RSS 2.0 形式の feed.xml を `dist/feed.xml` に出力する CLI
+ *
+ * 設計: docs/rfc/editorial-citrus/08-roadmap.md (Ext-2)
+ *
+ * - `datasources/*.md` を全件読み、`status === "published"` のみを含む
+ * - サイト URL は `SITE_URL` 環境変数で上書き可能
+ * - 出力先は dist/feed.xml で固定（ビルド成果物に同梱）
+ *
+ * 使い方:
+ *   node scripts/buildFeed.ts
+ *   pnpm build:feed
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { collectPublishedPosts } from "./lib/collectPosts.ts";
+import { renderFeed } from "./lib/renderFeed.ts";
+
+const OUTPUT_DIR = path.resolve(process.cwd(), "dist");
+const OUTPUT_FILE = path.join(OUTPUT_DIR, "feed.xml");
+
+const main = (): void => {
+  const posts = collectPublishedPosts();
+  const xml = renderFeed(posts);
+
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  fs.writeFileSync(OUTPUT_FILE, xml, "utf8");
+
+  console.log(
+    `✅ feed.xml を生成しました: ${OUTPUT_FILE} (${posts.length} 記事)`,
+  );
+};
+
+try {
+  main();
+} catch (error) {
+  console.error("❌ feed.xml の生成中にエラーが発生しました:");
+  console.error((error as Error).message);
+  process.exit(1);
+}

--- a/scripts/buildSitemap.ts
+++ b/scripts/buildSitemap.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/**
+ * sitemap.xml を `dist/sitemap.xml` に出力する CLI
+ *
+ * 設計: docs/rfc/editorial-citrus/08-roadmap.md (Ext-2)
+ *
+ * - `datasources/*.md` を全件読み、`status === "published"` のみを含む
+ * - サイト URL は `SITE_URL` 環境変数で上書き可能
+ * - 出力先は dist/sitemap.xml で固定（ビルド成果物に同梱）
+ *
+ * 使い方:
+ *   node scripts/buildSitemap.ts
+ *   pnpm build:sitemap
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { collectPublishedPosts } from "./lib/collectPosts.ts";
+import { renderSitemap } from "./lib/renderSitemap.ts";
+
+const OUTPUT_DIR = path.resolve(process.cwd(), "dist");
+const OUTPUT_FILE = path.join(OUTPUT_DIR, "sitemap.xml");
+
+const main = (): void => {
+  const posts = collectPublishedPosts();
+  const xml = renderSitemap(posts);
+
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  fs.writeFileSync(OUTPUT_FILE, xml, "utf8");
+
+  console.log(
+    `✅ sitemap.xml を生成しました: ${OUTPUT_FILE} (${posts.length + 1} URL)`,
+  );
+};
+
+try {
+  main();
+} catch (error) {
+  console.error("❌ sitemap.xml の生成中にエラーが発生しました:");
+  console.error((error as Error).message);
+  process.exit(1);
+}

--- a/scripts/lib/__tests__/collectPosts.test.ts
+++ b/scripts/lib/__tests__/collectPosts.test.ts
@@ -1,0 +1,152 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { collectPublishedPosts } from "../collectPosts.ts";
+
+/**
+ * テスト用に一時的な datasources ディレクトリを作り、複数記事を書き込んだ上で
+ * collectPublishedPosts の挙動を検証する。
+ */
+describe("collectPublishedPosts", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lazy-note-collect-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const writePost = (fileName: string, body: string): void => {
+    fs.writeFileSync(path.join(tempDir, fileName), body, "utf8");
+  };
+
+  it("メタセクションが無い既存形式の記事を published として取り込める", () => {
+    writePost(
+      "20250101120000.md",
+      [
+        "# 既存記事",
+        "",
+        "## 投稿日時",
+        "- 2025-01-01 12:00",
+        "",
+        "## 本文",
+        "本文サンプル",
+      ].join("\n"),
+    );
+
+    const posts = collectPublishedPosts(tempDir);
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0]?.id).toBe("20250101120000");
+    expect(posts[0]?.title).toBe("既存記事");
+    expect(posts[0]?.meta.status).toBe("published");
+  });
+
+  it("draft 記事を結果から除外できる", () => {
+    writePost(
+      "20250101120000.md",
+      [
+        "# Draft",
+        "",
+        "## メタ",
+        "- status: draft",
+        "",
+        "## 本文",
+        "草稿",
+      ].join("\n"),
+    );
+    writePost(
+      "20250102120000.md",
+      [
+        "# Published",
+        "",
+        "## メタ",
+        "- status: published",
+        "",
+        "## 本文",
+        "公開",
+      ].join("\n"),
+    );
+
+    const posts = collectPublishedPosts(tempDir);
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0]?.id).toBe("20250102120000");
+  });
+
+  it("archived 記事も結果から除外できる", () => {
+    writePost(
+      "20250101120000.md",
+      [
+        "# Archived",
+        "",
+        "## メタ",
+        "- status: archived",
+        "",
+        "## 本文",
+        "古い記事",
+      ].join("\n"),
+    );
+
+    const posts = collectPublishedPosts(tempDir);
+
+    expect(posts).toHaveLength(0);
+  });
+
+  it("publishedAt の降順にソートされる", () => {
+    writePost(
+      "20250101120000.md",
+      ["# 古い", "", "## 本文", "古い本文"].join("\n"),
+    );
+    writePost(
+      "20250301120000.md",
+      ["# 新しい", "", "## 本文", "新しい本文"].join("\n"),
+    );
+    writePost(
+      "20250201120000.md",
+      ["# 中間", "", "## 本文", "中間本文"].join("\n"),
+    );
+
+    const posts = collectPublishedPosts(tempDir);
+
+    expect(posts.map((post) => post.id)).toEqual([
+      "20250301120000",
+      "20250201120000",
+      "20250101120000",
+    ]);
+  });
+
+  it(".md 以外のファイルは無視する", () => {
+    writePost("README.txt", "not markdown");
+    writePost(
+      "20250101120000.md",
+      ["# 記事", "", "## 本文", "本文"].join("\n"),
+    );
+
+    const posts = collectPublishedPosts(tempDir);
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0]?.id).toBe("20250101120000");
+  });
+
+  it("メタセクションがパース失敗する場合は例外を伝搬する", () => {
+    writePost(
+      "20250101120000.md",
+      [
+        "# パースエラー",
+        "",
+        "## メタ",
+        "- status: published",
+        "- foo: bar",
+        "",
+        "## 本文",
+        "本文",
+      ].join("\n"),
+    );
+
+    expect(() => collectPublishedPosts(tempDir)).toThrow(/UNKNOWN_KEY/);
+  });
+});

--- a/scripts/lib/__tests__/renderFeed.test.ts
+++ b/scripts/lib/__tests__/renderFeed.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CollectedPost } from "../collectPosts.ts";
+import { renderFeed, toRfc822 } from "../renderFeed.ts";
+
+const buildPost = (overrides: Partial<CollectedPost> = {}): CollectedPost => ({
+  id: "20250101120000",
+  fileName: "20250101120000.md",
+  title: "サンプル記事",
+  excerpt: "これは抜粋です",
+  meta: {
+    status: "published",
+    publishedAt: "2025-01-01T12:00:00+09:00",
+    tags: [],
+  },
+  ...overrides,
+});
+
+describe("toRfc822", () => {
+  it("ISO 8601 文字列を RFC 822 形式に変換できる", () => {
+    expect(toRfc822("2025-01-01T12:00:00+09:00")).toBe(
+      "Wed, 01 Jan 2025 03:00:00 GMT",
+    );
+  });
+
+  it("不正な日時の場合は例外を投げる", () => {
+    expect(() => toRfc822("not-a-date")).toThrow(/解釈できません/);
+  });
+});
+
+describe("renderFeed", () => {
+  const originalSiteUrl = process.env.SITE_URL;
+  const fixedNow = new Date("2025-05-01T00:00:00Z");
+
+  beforeEach(() => {
+    process.env.SITE_URL = "https://example.com/blog";
+  });
+
+  afterEach(() => {
+    if (originalSiteUrl === undefined) {
+      delete process.env.SITE_URL;
+    } else {
+      process.env.SITE_URL = originalSiteUrl;
+    }
+  });
+
+  it("RSS 2.0 の必須要素を持つ XML を生成できる", () => {
+    const xml = renderFeed([buildPost()], { now: fixedNow });
+
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<rss version="2.0"');
+    expect(xml).toContain("<channel>");
+    expect(xml).toContain("<title>Lazy Note</title>");
+    expect(xml).toContain("<language>ja</language>");
+    expect(xml).toContain(
+      "<description>急がない記録、急がせない言葉。</description>",
+    );
+    expect(xml).toContain("<lastBuildDate>Thu, 01 May 2025 00:00:00 GMT</lastBuildDate>");
+    expect(xml).toContain(
+      '<atom:link href="https://example.com/blog/feed.xml" rel="self" type="application/rss+xml" />',
+    );
+  });
+
+  it("各記事を <item> として含む", () => {
+    const xml = renderFeed([buildPost()], { now: fixedNow });
+
+    expect(xml).toContain("<item>");
+    expect(xml).toContain("<title>サンプル記事</title>");
+    expect(xml).toContain(
+      "<link>https://example.com/blog/posts/20250101120000</link>",
+    );
+    expect(xml).toContain(
+      '<guid isPermaLink="true">https://example.com/blog/posts/20250101120000</guid>',
+    );
+    expect(xml).toContain("<pubDate>Wed, 01 Jan 2025 03:00:00 GMT</pubDate>");
+    expect(xml).toContain("<description>これは抜粋です</description>");
+  });
+
+  it("XML 予約文字を含むタイトル / 抜粋をエスケープできる", () => {
+    const xml = renderFeed(
+      [
+        buildPost({
+          title: "Tom & <Jerry>",
+          excerpt: `It's "great" & dangerous`,
+        }),
+      ],
+      { now: fixedNow },
+    );
+
+    expect(xml).toContain("<title>Tom &amp; &lt;Jerry&gt;</title>");
+    expect(xml).toContain(
+      "<description>It&apos;s &quot;great&quot; &amp; dangerous</description>",
+    );
+  });
+
+  it("空のフィードでも channel 要素は維持される", () => {
+    const xml = renderFeed([], { now: fixedNow });
+
+    expect(xml).toContain("<channel>");
+    expect(xml).toContain("</channel>");
+    expect(xml).not.toContain("<item>");
+  });
+
+  it("末尾改行が 1 つだけ付与される", () => {
+    const xml = renderFeed([], { now: fixedNow });
+
+    expect(xml.endsWith("\n")).toBe(true);
+    expect(xml.endsWith("\n\n")).toBe(false);
+  });
+});

--- a/scripts/lib/__tests__/renderSitemap.test.ts
+++ b/scripts/lib/__tests__/renderSitemap.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CollectedPost } from "../collectPosts.ts";
+import { renderSitemap, toSitemapLastmod } from "../renderSitemap.ts";
+
+const buildPost = (overrides: Partial<CollectedPost> = {}): CollectedPost => ({
+  id: "20250101120000",
+  fileName: "20250101120000.md",
+  title: "サンプル",
+  excerpt: "抜粋",
+  meta: {
+    status: "published",
+    publishedAt: "2025-01-01T12:00:00+09:00",
+    tags: [],
+  },
+  ...overrides,
+});
+
+describe("toSitemapLastmod", () => {
+  it("妥当な ISO 8601 文字列を保持する", () => {
+    expect(toSitemapLastmod("2025-01-01T12:00:00+09:00")).toBe(
+      "2025-01-01T12:00:00+09:00",
+    );
+  });
+
+  it("不正な日時の場合は例外を投げる", () => {
+    expect(() => toSitemapLastmod("invalid")).toThrow(/解釈できません/);
+  });
+});
+
+describe("renderSitemap", () => {
+  const originalSiteUrl = process.env.SITE_URL;
+
+  beforeEach(() => {
+    process.env.SITE_URL = "https://example.com/blog";
+  });
+
+  afterEach(() => {
+    if (originalSiteUrl === undefined) {
+      delete process.env.SITE_URL;
+    } else {
+      process.env.SITE_URL = originalSiteUrl;
+    }
+  });
+
+  it("sitemap protocol の必須要素を含む XML を生成できる", () => {
+    const xml = renderSitemap([buildPost()]);
+
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+    expect(xml).toContain("</urlset>");
+  });
+
+  it("トップページの <url> エントリを先頭に出力する", () => {
+    const xml = renderSitemap([buildPost()]);
+
+    expect(xml).toContain("<loc>https://example.com/blog/</loc>");
+    expect(xml).toContain("<priority>1.0</priority>");
+  });
+
+  it("各記事を URL エントリとして含む", () => {
+    const xml = renderSitemap([buildPost()]);
+
+    expect(xml).toContain(
+      "<loc>https://example.com/blog/posts/20250101120000</loc>",
+    );
+    expect(xml).toContain("<lastmod>2025-01-01T12:00:00+09:00</lastmod>");
+    expect(xml).toContain("<changefreq>monthly</changefreq>");
+    expect(xml).toContain("<priority>0.7</priority>");
+  });
+
+  it("updatedAt があれば lastmod に優先採用される", () => {
+    const post = buildPost({
+      meta: {
+        status: "published",
+        publishedAt: "2025-01-01T12:00:00+09:00",
+        updatedAt: "2025-03-15T18:30:00+09:00",
+        tags: [],
+      },
+    });
+
+    const xml = renderSitemap([post]);
+
+    expect(xml).toContain("<lastmod>2025-03-15T18:30:00+09:00</lastmod>");
+    expect(xml).not.toContain("<lastmod>2025-01-01T12:00:00+09:00</lastmod>");
+  });
+
+  it("記事が空でも urlset は生成される", () => {
+    const xml = renderSitemap([]);
+
+    expect(xml).toContain("<urlset");
+    expect(xml).toContain("</urlset>");
+  });
+});

--- a/scripts/lib/__tests__/siteConfig.test.ts
+++ b/scripts/lib/__tests__/siteConfig.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildSiteUrl, getSiteUrl, SITE_META } from "../siteConfig.ts";
+
+describe("siteConfig", () => {
+  const originalSiteUrl = process.env.SITE_URL;
+
+  beforeEach(() => {
+    delete process.env.SITE_URL;
+  });
+
+  afterEach(() => {
+    if (originalSiteUrl === undefined) {
+      delete process.env.SITE_URL;
+    } else {
+      process.env.SITE_URL = originalSiteUrl;
+    }
+  });
+
+  describe("getSiteUrl", () => {
+    it("環境変数未設定時に既定の GitHub Pages URL を返す", () => {
+      expect(getSiteUrl()).toBe("https://amkkr.github.io/lazy-note");
+    });
+
+    it("環境変数で URL を上書きできる", () => {
+      process.env.SITE_URL = "https://example.com/blog";
+      expect(getSiteUrl()).toBe("https://example.com/blog");
+    });
+
+    it("末尾スラッシュを除去できる", () => {
+      process.env.SITE_URL = "https://example.com/blog/";
+      expect(getSiteUrl()).toBe("https://example.com/blog");
+    });
+
+    it("空文字列が指定された場合は例外を投げる", () => {
+      process.env.SITE_URL = "   ";
+      expect(() => getSiteUrl()).toThrow(/SITE_URL/);
+    });
+
+    it("不正な URL の場合は例外を投げる", () => {
+      process.env.SITE_URL = "not-a-valid-url";
+      expect(() => getSiteUrl()).toThrow(/SITE_URL/);
+    });
+  });
+
+  describe("buildSiteUrl", () => {
+    it("先頭スラッシュ有無に依らず同じ絶対 URL を返す", () => {
+      expect(buildSiteUrl("/posts/abc")).toBe(
+        "https://amkkr.github.io/lazy-note/posts/abc",
+      );
+      expect(buildSiteUrl("posts/abc")).toBe(
+        "https://amkkr.github.io/lazy-note/posts/abc",
+      );
+    });
+
+    it("二重スラッシュが発生しない", () => {
+      process.env.SITE_URL = "https://example.com/blog/";
+      expect(buildSiteUrl("/feed.xml")).toBe("https://example.com/blog/feed.xml");
+    });
+  });
+
+  describe("SITE_META", () => {
+    it("Lazy Note のチャンネル情報を持つ", () => {
+      expect(SITE_META.title).toBe("Lazy Note");
+      expect(SITE_META.language).toBe("ja");
+      expect(SITE_META.description).toBe("急がない記録、急がせない言葉。");
+    });
+  });
+});

--- a/scripts/lib/__tests__/xmlEscape.test.ts
+++ b/scripts/lib/__tests__/xmlEscape.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { escapeXml } from "../xmlEscape.ts";
+
+describe("escapeXml", () => {
+  it("アンパサンドを最優先で実体参照に変換できる", () => {
+    expect(escapeXml("Tom & Jerry")).toBe("Tom &amp; Jerry");
+  });
+
+  it("不等号と引用符をすべてエスケープできる", () => {
+    expect(escapeXml(`<a href="x">'y'</a>`)).toBe(
+      "&lt;a href=&quot;x&quot;&gt;&apos;y&apos;&lt;/a&gt;",
+    );
+  });
+
+  it("既にエスケープ済みの文字列を二重エスケープする", () => {
+    expect(escapeXml("&amp;")).toBe("&amp;amp;");
+  });
+
+  it("空文字列はそのまま返す", () => {
+    expect(escapeXml("")).toBe("");
+  });
+});

--- a/scripts/lib/collectPosts.ts
+++ b/scripts/lib/collectPosts.ts
@@ -1,0 +1,100 @@
+/**
+ * `datasources/*.md` を全件読み込み、メタデータ付きの記事一覧を返すヘルパ
+ *
+ * RSS / sitemap 生成の共通基盤。
+ * - `## メタ` セクションがある場合は parseMetaSection を使う
+ * - 無い場合は createDefaultMeta で既存 16 記事互換の既定値を割り当てる
+ * - `status === "published"` のみを返す（draft / archived は除外）
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import {
+  extractBodyContent,
+  extractExcerpt,
+  extractTitle,
+} from "../../src/lib/markdownParser.ts";
+import {
+  createDefaultMeta,
+  parseMetaSection,
+  type PostMeta,
+} from "../../src/lib/meta.ts";
+
+/**
+ * 配信用に正規化された記事レコード
+ */
+export interface CollectedPost {
+  /** ファイル名から拡張子を除いた ID（例: "20250101120000"） */
+  readonly id: string;
+  /** 元のファイル名（例: "20250101120000.md"） */
+  readonly fileName: string;
+  /** 記事タイトル（h1）、無ければ ID をフォールバック */
+  readonly title: string;
+  /** 本文先頭からの抜粋（プレーンテキスト） */
+  readonly excerpt: string;
+  /** メタデータ（status / publishedAt / updatedAt / tags） */
+  readonly meta: PostMeta;
+}
+
+/**
+ * datasources ディレクトリのデフォルトパス
+ */
+export const DATASOURCES_DIR = path.resolve(process.cwd(), "datasources");
+
+/**
+ * .md ファイル名のみを抽出する
+ *
+ * - `images/` などのサブディレクトリは無視
+ * - `.md` 以外の拡張子も除外
+ */
+const listMarkdownFiles = (dir: string): string[] => {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => entry.name)
+    .sort();
+};
+
+/**
+ * 1 ファイル分の Markdown から CollectedPost を構築する
+ *
+ * - parseMetaSection が null を返した場合は createDefaultMeta を使う
+ * - parseMetaSection が throw した場合はそのまま伝搬（build fail）
+ */
+const buildPost = (fileName: string, content: string): CollectedPost => {
+  const id = fileName.replace(/\.md$/, "");
+  const lines = content.split(/\r\n|\r|\n/);
+  const rawTitle = extractTitle(lines);
+  const title = rawTitle.length > 0 ? rawTitle : id;
+  const body = extractBodyContent(lines);
+  const excerpt = extractExcerpt(body);
+  const parsed = parseMetaSection(content, fileName);
+  const meta = parsed ?? createDefaultMeta(fileName);
+  return { id, fileName, title, excerpt, meta };
+};
+
+/**
+ * datasources 配下の全 Markdown を読み、published のみを返す
+ *
+ * - publishedAt の降順（新しい順）にソート
+ * - パスは絶対パスを既定とし、テスト時のみ任意指定可能
+ */
+export const collectPublishedPosts = (
+  datasourcesDir: string = DATASOURCES_DIR,
+): CollectedPost[] => {
+  const fileNames = listMarkdownFiles(datasourcesDir);
+  const posts = fileNames.map((fileName) => {
+    const filePath = path.join(datasourcesDir, fileName);
+    const content = fs.readFileSync(filePath, "utf8");
+    return buildPost(fileName, content);
+  });
+  return posts
+    .filter((post) => post.meta.status === "published")
+    .sort((a, b) => {
+      // publishedAt の降順（新しい記事を先頭に）
+      if (a.meta.publishedAt === b.meta.publishedAt) {
+        return b.id.localeCompare(a.id);
+      }
+      return b.meta.publishedAt.localeCompare(a.meta.publishedAt);
+    });
+};

--- a/scripts/lib/renderFeed.ts
+++ b/scripts/lib/renderFeed.ts
@@ -1,0 +1,85 @@
+/**
+ * RSS 2.0 形式のフィード XML を組み立てる純粋関数
+ *
+ * - 仕様: https://www.rssboard.org/rss-specification
+ * - status === "published" のみが渡されてくる前提（フィルタは collectPosts で実施）
+ * - link / guid は buildSiteUrl で絶対 URL 化
+ * - title / description / pubDate / lastBuildDate を含む
+ */
+
+import type { CollectedPost } from "./collectPosts.ts";
+import { buildSiteUrl, SITE_META } from "./siteConfig.ts";
+import { escapeXml } from "./xmlEscape.ts";
+
+/**
+ * ISO 8601 文字列を RFC 822 (RSS が要求する pubDate 形式) に変換する
+ *
+ * - 入力が不正な日時の場合は例外を throw（呼び出し元で build fail）
+ * - 出力例: "Wed, 01 Jan 2025 12:00:00 +0000"
+ */
+export const toRfc822 = (isoDateTime: string): string => {
+  const date = new Date(isoDateTime);
+  const time = date.getTime();
+  if (!Number.isFinite(time)) {
+    throw new Error(`日時として解釈できません: "${isoDateTime}"`);
+  }
+  return date.toUTCString();
+};
+
+/**
+ * RSS の <item> タグ 1 件を生成する
+ */
+const renderItem = (post: CollectedPost): string => {
+  const link = buildSiteUrl(`/posts/${post.id}`);
+  const pubDate = toRfc822(post.meta.publishedAt);
+  return [
+    "    <item>",
+    `      <title>${escapeXml(post.title)}</title>`,
+    `      <link>${escapeXml(link)}</link>`,
+    `      <guid isPermaLink="true">${escapeXml(link)}</guid>`,
+    `      <pubDate>${escapeXml(pubDate)}</pubDate>`,
+    `      <description>${escapeXml(post.excerpt)}</description>`,
+    "    </item>",
+  ].join("\n");
+};
+
+/**
+ * RSS 2.0 全体を生成するオプション
+ */
+export interface RenderFeedOptions {
+  /** lastBuildDate に使う基準時刻（テストで固定するため注入可能） */
+  readonly now?: Date;
+}
+
+/**
+ * RSS 2.0 形式の feed.xml 文字列を組み立てる
+ *
+ * - posts は publishedAt 降順前提
+ * - 末尾改行を 1 つだけ付与
+ */
+export const renderFeed = (
+  posts: readonly CollectedPost[],
+  options: RenderFeedOptions = {},
+): string => {
+  const now = options.now ?? new Date();
+  const feedUrl = buildSiteUrl("/feed.xml");
+  const homeUrl = buildSiteUrl("/");
+  const lastBuildDate = now.toUTCString();
+
+  const header = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    "  <channel>",
+    `    <title>${escapeXml(SITE_META.title)}</title>`,
+    `    <link>${escapeXml(homeUrl)}</link>`,
+    `    <description>${escapeXml(SITE_META.description)}</description>`,
+    `    <language>${escapeXml(SITE_META.language)}</language>`,
+    `    <lastBuildDate>${escapeXml(lastBuildDate)}</lastBuildDate>`,
+    `    <atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml" />`,
+  ];
+
+  const itemsXml = posts.map(renderItem);
+  const footer = ["  </channel>", "</rss>", ""];
+
+  return [...header, ...itemsXml, ...footer].join("\n");
+};

--- a/scripts/lib/renderSitemap.ts
+++ b/scripts/lib/renderSitemap.ts
@@ -1,0 +1,79 @@
+/**
+ * sitemap.xml を組み立てる純粋関数
+ *
+ * - 仕様: https://www.sitemaps.org/protocol.html
+ * - status === "published" のみが渡されてくる前提
+ * - lastmod は updatedAt が無ければ publishedAt を使用
+ * - トップページ (/) も urlset に含める
+ */
+
+import type { CollectedPost } from "./collectPosts.ts";
+import { buildSiteUrl } from "./siteConfig.ts";
+import { escapeXml } from "./xmlEscape.ts";
+
+/**
+ * ISO 8601 文字列を sitemap の lastmod が許容する W3C Datetime に正規化する
+ *
+ * - sitemap は ISO 8601 をそのまま受け付けるが、表記揺れを避けるため `YYYY-MM-DDTHH:MM:SS+HH:MM` の形に整える
+ * - 入力が不正な場合は例外を throw
+ */
+export const toSitemapLastmod = (isoDateTime: string): string => {
+  const date = new Date(isoDateTime);
+  const time = date.getTime();
+  if (!Number.isFinite(time)) {
+    throw new Error(`日時として解釈できません: "${isoDateTime}"`);
+  }
+  return isoDateTime;
+};
+
+/**
+ * 1 件の <url> ブロックを生成する
+ */
+const renderUrlEntry = (
+  loc: string,
+  lastmod: string,
+  changefreq: "weekly" | "monthly" | "yearly",
+  priority: string,
+): string => {
+  return [
+    "  <url>",
+    `    <loc>${escapeXml(loc)}</loc>`,
+    `    <lastmod>${escapeXml(lastmod)}</lastmod>`,
+    `    <changefreq>${changefreq}</changefreq>`,
+    `    <priority>${priority}</priority>`,
+    "  </url>",
+  ].join("\n");
+};
+
+/**
+ * sitemap.xml を組み立てる
+ *
+ * - posts は publishedAt 降順前提
+ * - トップページは weekly / 1.0、各記事は monthly / 0.7
+ */
+export const renderSitemap = (posts: readonly CollectedPost[]): string => {
+  const homeUrl = buildSiteUrl("/");
+  const homeLastmod = toSitemapLastmod(
+    posts[0]?.meta.updatedAt ??
+      posts[0]?.meta.publishedAt ??
+      new Date().toISOString(),
+  );
+
+  const header = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    renderUrlEntry(homeUrl, homeLastmod, "weekly", "1.0"),
+  ];
+
+  const postEntries = posts.map((post) => {
+    const loc = buildSiteUrl(`/posts/${post.id}`);
+    const lastmod = toSitemapLastmod(
+      post.meta.updatedAt ?? post.meta.publishedAt,
+    );
+    return renderUrlEntry(loc, lastmod, "monthly", "0.7");
+  });
+
+  const footer = ["</urlset>", ""];
+
+  return [...header, ...postEntries, ...footer].join("\n");
+};

--- a/scripts/lib/siteConfig.ts
+++ b/scripts/lib/siteConfig.ts
@@ -1,0 +1,50 @@
+/**
+ * 配信基盤 (RSS / sitemap) の共通サイト設定
+ *
+ * - 公開先 URL は環境変数 `SITE_URL` で上書き可能
+ * - 既定は GitHub Pages の URL（vite.config.ts の base "/lazy-note/" と整合）
+ * - 末尾スラッシュは buildSiteUrl で正規化するため、設定値は末尾スラッシュ無しで保持
+ */
+
+const DEFAULT_SITE_URL = "https://amkkr.github.io/lazy-note";
+
+/**
+ * サイト URL の origin + base を取得する
+ *
+ * - 末尾スラッシュは必ず除去して返す（パス連結時の二重スラッシュを防ぐ）
+ * - 不正な値が入った場合（プロトコル無し等）は例外を throw する
+ */
+export const getSiteUrl = (): string => {
+  const raw = (process.env.SITE_URL ?? DEFAULT_SITE_URL).trim();
+  if (raw.length === 0) {
+    throw new Error("SITE_URL が空文字列です");
+  }
+  try {
+    // URL コンストラクタで妥当性検証（不正な URL は throw）
+    new URL(raw);
+  } catch {
+    throw new Error(`SITE_URL が不正です: "${raw}"`);
+  }
+  return raw.replace(/\/+$/, "");
+};
+
+/**
+ * パスを連結して絶対 URL を構築する
+ *
+ * - path は先頭スラッシュ有無を許容
+ * - URL コンストラクタ経由で path traversal や不正文字を正規化
+ */
+export const buildSiteUrl = (path: string): string => {
+  const base = `${getSiteUrl()}/`;
+  const normalizedPath = path.replace(/^\/+/, "");
+  return new URL(normalizedPath, base).toString();
+};
+
+/**
+ * チャンネル / フィード共通のメタ情報
+ */
+export const SITE_META = {
+  title: "Lazy Note",
+  description: "急がない記録、急がせない言葉。",
+  language: "ja",
+} as const;

--- a/scripts/lib/xmlEscape.ts
+++ b/scripts/lib/xmlEscape.ts
@@ -1,0 +1,21 @@
+/**
+ * XML 出力用のエスケープユーティリティ
+ *
+ * RSS 2.0 / sitemap 双方の生成で利用する。
+ * 5 種の XML 予約文字 (& < > " ') を実体参照に変換する。
+ */
+
+/**
+ * 文字列を XML テキストノード用にエスケープする
+ *
+ * - `&` は最初に変換しないと他の置換で重複置換が発生するため、必ず先頭で処理する
+ * - 属性値・要素値の双方で安全に利用可能
+ */
+export const escapeXml = (value: string): string => {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+};

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -7,7 +7,8 @@
   },
   "include": [
     "src/**/*",
-    "src/**/__tests__/**/*"
+    "src/**/__tests__/**/*",
+    "scripts/**/*"
   ],
   "exclude": []
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -67,10 +67,14 @@ export default defineConfig({
     include: [
       "src/**/__tests__/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
       "src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
+      "scripts/**/__tests__/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
     ],
     typecheck: {
       checker: "tsc",
-      include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
+      include: [
+        "src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
+        "scripts/**/__tests__/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
+      ],
       tsconfig: "./tsconfig.test.json",
     },
   },


### PR DESCRIPTION
## 概要

Issue #365 (Ext-2) の実装。Editorial Citrus 配信基盤として RSS 2.0 (`feed.xml`) と `sitemap.xml` を build 時に生成し、`dist/` に同梱するパイプラインを追加する。

Closes #365

## 変更内容

- `scripts/buildFeed.ts` / `scripts/buildSitemap.ts`: CLI エントリ。`pnpm build:feed` / `pnpm build:sitemap` で実行
- `scripts/lib/`:
  - `collectPosts.ts`: `datasources/*.md` を全件読み、`status === "published"` のみを `publishedAt` 降順で返す
  - `renderFeed.ts`: RSS 2.0 XML を組み立てる純粋関数（`<title>` / `<link>` / `<lastBuildDate>` / `<atom:link rel="self">` / 各 `<item>`）
  - `renderSitemap.ts`: sitemap.xml を組み立てる純粋関数（トップページ + 各記事の `<url>` エントリ、`lastmod` は `updatedAt` 優先）
  - `siteConfig.ts`: `SITE_URL` 環境変数で公開先を切替可能（既定値 `https://amkkr.github.io/lazy-note`）
  - `xmlEscape.ts`: XML 5 種予約文字 (`&` `<` `>` `"` `'`) を実体参照に変換
- `scripts/lib/__tests__/*.test.ts`: 各 lib の vitest ユニットテスト 5 ファイル
- `index.html`: `<link rel="alternate" type="application/rss+xml" href="/feed.xml">` を `<head>` に追加（RSS 自動検出に対応）
- `package.json`: `build` 末尾で `build:feed` / `build:sitemap` を実行し、`dist/feed.xml` と `dist/sitemap.xml` を成果物に同梱
- `tsconfig.test.json` / `vite.config.ts`: vitest が `scripts/**/__tests__/` を拾うよう include 拡張

## 設計

- 入力: `datasources/*.md` を `parseMetaSection` でパース、`status: "published"` のみ含める（draft / archived は除外）
- 出力: `dist/feed.xml` (RSS 2.0)、`dist/sitemap.xml`
- XML エスケープは `&` `<` `>` `"` `'` の 5 種すべて
- URL 構築は `URL` コンストラクタ経由で正規化（path traversal や二重スラッシュを防止）
- 設計書: `docs/rfc/editorial-citrus/08-roadmap.md` (Ext-2)

## 受け入れ基準（Issue #365）

- [x] `/rss.xml` 相当 (`/feed.xml`) を build 時に生成、status=published のみを含む
- [x] `/sitemap.xml` を build 時に生成、status=published のみ
- [x] `published_at` 降順でエントリ
- [x] `<lastBuildDate>` / `<lastmod>` を適切に出力
- [x] ヘッダの `<link rel="alternate" type="application/rss+xml">` を出力

## 備考

- ローカル `pnpm build` 全体パスで `dist/feed.xml` (16 記事) / `dist/sitemap.xml` (17 URL) の生成を確認
- `pnpm test:run` 全 379 テスト passed（新規 5 ファイル含む）
- `pnpm lint` / `pnpm exec tsc --noEmit` clean
- セキュリティ観点: XML インジェクション・path traversal・XXE 等を評価し HIGH/MEDIUM 脆弱性なし