### PR TITLE
feat: View Transitions API による Hero morph (Issue #397)

### DIFF
--- a/src/components/atoms/BentoCard.tsx
+++ b/src/components/atoms/BentoCard.tsx
@@ -1,6 +1,7 @@
 import { type CSSProperties, memo } from "react";
 import { css } from "../../../styled-system/css";
 import type { PostSummary } from "../../lib/markdown";
+import { buildPostHeroTransitionName } from "../../lib/viewTransition";
 import { MetaInfo } from "../common/MetaInfo";
 import { Link } from "./Link";
 
@@ -180,6 +181,14 @@ export const BentoCard = memo(
           ? bentoSizeWideStyles
           : bentoSizeDefaultStyles;
 
+    // Hero morph (Issue #397): Bento タイトル H3 に
+    // `view-transition-name: post-{id}` を付与し、記事詳細 (PostDetailPage) の
+    // H1 と morph させる。Featured と Bento は同時に表示されないペアなので
+    // 名前衝突は発生しない (HomePage の Featured = posts[0] / Bento = posts[1..6])。
+    const heroNameStyle: CSSProperties = {
+      viewTransitionName: buildPostHeroTransitionName(String(post.id)),
+    };
+
     return (
       <article className={`${bentoWrapperBaseStyles} ${sizeStyles}`}>
         <div className={bentoMetaStyles}>
@@ -190,11 +199,15 @@ export const BentoCard = memo(
             variant="bento"
           />
         </div>
-        <h3 className={`bento-title ${bentoTitleStyles}`}>
+        <h3
+          className={`bento-title ${bentoTitleStyles}`}
+          style={heroNameStyle}
+        >
           <Link
             to={`/posts/${post.id}`}
             variant="card"
             className={bentoStretchedLinkStyles}
+            viewTransition
           >
             {post.title || "無題の記事"}
           </Link>

--- a/src/components/atoms/FeaturedCard.tsx
+++ b/src/components/atoms/FeaturedCard.tsx
@@ -1,6 +1,7 @@
-import { memo } from "react";
+import { type CSSProperties, memo } from "react";
 import { css } from "../../../styled-system/css";
 import type { PostSummary } from "../../lib/markdown";
+import { buildPostHeroTransitionName } from "../../lib/viewTransition";
 import { MetaInfo } from "../common/MetaInfo";
 import { Link } from "./Link";
 
@@ -134,6 +135,14 @@ const featuredLinkStyles = css({
 });
 
 export const FeaturedCard = memo(({ post }: FeaturedCardProps) => {
+  // Hero morph (Issue #397): タイトル H2 に `view-transition-name: post-{id}` を
+  // 付与し、記事詳細 (PostDetailPage) の H1 と morph させる。
+  // CSSProperties に view-transition-name は未収録のため、index signature で
+  // 受け付けるよう CSSProperties をベースに拡張した型として inline 指定する。
+  const heroNameStyle: CSSProperties = {
+    viewTransitionName: buildPostHeroTransitionName(String(post.id)),
+  };
+
   return (
     <article className={featuredWrapperStyles}>
       <span className={featuredLabelStyles}>Featured</span>
@@ -149,8 +158,11 @@ export const FeaturedCard = memo(({ post }: FeaturedCardProps) => {
         to={`/posts/${post.id}`}
         variant="card"
         className={featuredLinkStyles}
+        viewTransition
       >
-        <h2 className={featuredTitleStyles}>{post.title || "無題の記事"}</h2>
+        <h2 className={featuredTitleStyles} style={heroNameStyle}>
+          {post.title || "無題の記事"}
+        </h2>
       </Link>
       {post.excerpt && <p className={featuredExcerptStyles}>{post.excerpt}</p>}
     </article>

--- a/src/components/atoms/IndexRow.tsx
+++ b/src/components/atoms/IndexRow.tsx
@@ -1,6 +1,7 @@
-import { memo } from "react";
+import { type CSSProperties, memo } from "react";
 import { css } from "../../../styled-system/css";
 import type { PostSummary } from "../../lib/markdown";
+import { buildPostHeroTransitionName } from "../../lib/viewTransition";
 import { Link } from "./Link";
 
 interface IndexRowProps {
@@ -172,16 +173,28 @@ export const IndexRow = memo(({ post, index }: IndexRowProps) => {
   // zero-padded 2 桁。100 を超える場合は 3 桁になっても許容。
   const numberLabel = String(index + 1).padStart(2, "0");
 
+  // Hero morph (Issue #397): Index 行のタイトルにも `view-transition-name`
+  // を付与し、記事詳細の H1 と morph させる。Featured / Bento は posts[0..6]
+  // で表示され Index は posts[7..] のため、同一ページ内での name 衝突はない
+  // (HomePage 1 ページに収まる最大 16 件で重複 ID を持つ post は存在しない)。
+  const heroNameStyle: CSSProperties = {
+    viewTransitionName: buildPostHeroTransitionName(String(post.id)),
+  };
+
   return (
     <li className={indexRowStyles}>
       <span className={`index-row-number ${indexNumberStyles}`}>
         {numberLabel}
       </span>
-      <span className={`index-row-title ${indexTitleStyles}`}>
+      <span
+        className={`index-row-title ${indexTitleStyles}`}
+        style={heroNameStyle}
+      >
         <Link
           to={`/posts/${post.id}`}
           variant="card"
           className={indexStretchedLinkStyles}
+          viewTransition
         >
           {post.title || "無題の記事"}
         </Link>

--- a/src/components/atoms/Link.tsx
+++ b/src/components/atoms/Link.tsx
@@ -1,6 +1,7 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, MouseEvent, ReactNode } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import { css } from "../../../styled-system/css";
+import { useViewTransitionNavigate } from "../../hooks/useViewTransitionNavigate";
 
 interface LinkProps {
   children: ReactNode;
@@ -8,18 +9,40 @@ interface LinkProps {
   variant?: "default" | "navigation" | "button" | "card";
   external?: boolean;
   className?: string;
+  /**
+   * SPA 遷移時に View Transitions API でラップするかどうか (Issue #397)。
+   *
+   * Editorial Bento の Featured / Bento / Index から記事詳細に遷移する際に
+   * `view-transition-name: post-{id}` 同士を morph させるために使用する。
+   * 未対応ブラウザ / prefers-reduced-motion の場合は通常遷移にフォールバック
+   * する (`useViewTransitionNavigate` 内で graceful degrade)。
+   *
+   * external=true (外部リンク) の場合はブラウザ既定遷移となるため無視される。
+   *
+   * 実装上の注意: viewTransition=true は内部で `useNavigate` を呼ぶため、
+   * 必ず Router context (BrowserRouter / MemoryRouter 等) の下で render される
+   * 必要がある。Router 外で使う Link は viewTransition を指定しないこと。
+   */
+  viewTransition?: boolean;
+  /**
+   * インラインスタイル。Hero morph 用に `view-transition-name` (CSSProperties に
+   * まだ収録されていない) を渡すケースに対応するため、CSSProperties を許容する。
+   * Panda CSS の className では view-transition-name を動的に注入しづらいため、
+   * 限定的に inline style での指定を許可する。
+   */
+  style?: CSSProperties;
 }
 
 /**
- * リンクコンポーネント
+ * Link 共通スタイル定義。
+ *
+ * 表示用の hook (Panda の css() 呼び出し) に副作用は無いので、コンポーネント
+ * 外側 (関数内 module-scope) で組み立てて全ての Link variant が共有する。
  */
-export const Link = ({
-  children,
-  to,
-  variant = "default",
-  external = false,
-  className,
-}: LinkProps) => {
+const buildLinkClassName = (
+  variant: NonNullable<LinkProps["variant"]>,
+  className: string | undefined,
+): string => {
   const baseStyles = css({
     textDecoration: "none",
     transition: "all 0.2s ease",
@@ -72,7 +95,81 @@ export const Link = ({
     }),
   };
 
-  const combinedClassName = `${baseStyles} ${variantStyles[variant]} ${className || ""}`;
+  return `${baseStyles} ${variantStyles[variant]} ${className || ""}`;
+};
+
+/**
+ * View Transitions 対応版の Internal Link。
+ *
+ * 内部で `useNavigate` を使うため、必ず Router context の下でのみ render
+ * される (= viewTransition=true の Link 利用箇所限定)。Router 外で使う Link
+ * (PostNavigation テスト等で `react-router-dom` mock 下で render されるなど) は
+ * 上位の Link コンポーネント側で本コンポーネントを呼び出さない分岐とする。
+ */
+const ViewTransitionLink = ({
+  children,
+  to,
+  className,
+  style,
+}: {
+  children: ReactNode;
+  to: string;
+  className: string;
+  style?: CSSProperties;
+}) => {
+  const vtNavigate = useViewTransitionNavigate();
+
+  // View Transitions 利用時のクリックハンドラ。
+  // - 修飾キー併用 (Cmd/Ctrl/Shift/Alt クリック / 中クリック) は新規タブやウィンドウ
+  //   操作のため preventDefault せず、ブラウザ既定挙動に委ねる。
+  // - target=_blank なども想定されるが、本コンポーネントは internal Link なので
+  //   そのケースは external prop 側を使う前提。
+  // - 通常クリックのみ preventDefault → vtNavigate でラップ navigate を実行する。
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    vtNavigate(to);
+  };
+
+  return (
+    <RouterLink
+      to={to}
+      className={className}
+      style={style}
+      onClick={handleClick}
+    >
+      {children}
+    </RouterLink>
+  );
+};
+
+/**
+ * リンクコンポーネント
+ *
+ * - external=true: 新規タブで開く外部 anchor
+ * - viewTransition=true: SPA 遷移を View Transitions API でラップする
+ *   (Hero morph 用、Issue #397)。Router context 必須。
+ * - 上記いずれでもない場合: 通常の RouterLink (React Router DOM)
+ */
+export const Link = ({
+  children,
+  to,
+  variant = "default",
+  external = false,
+  className,
+  viewTransition = false,
+  style,
+}: LinkProps) => {
+  const combinedClassName = buildLinkClassName(variant, className);
 
   if (external) {
     return (
@@ -81,14 +178,23 @@ export const Link = ({
         target="_blank"
         rel="noopener noreferrer"
         className={combinedClassName}
+        style={style}
       >
         {children}
       </a>
     );
   }
 
+  if (viewTransition) {
+    return (
+      <ViewTransitionLink to={to} className={combinedClassName} style={style}>
+        {children}
+      </ViewTransitionLink>
+    );
+  }
+
   return (
-    <RouterLink to={to} className={combinedClassName}>
+    <RouterLink to={to} className={combinedClassName} style={style}>
       {children}
     </RouterLink>
   );

--- a/src/components/atoms/Typography.tsx
+++ b/src/components/atoms/Typography.tsx
@@ -1,9 +1,15 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { css } from "../../../styled-system/css";
 
 interface BaseTypographyProps {
   children: ReactNode;
   className?: string;
+  /**
+   * インラインスタイル。Hero morph (Issue #397) で `view-transition-name` を
+   * 動的に注入するなど、Panda CSS の className では扱いづらい CSS プロパティを
+   * 限定的に受けるために許容する。通常スタイリングは className 経由が望ましい。
+   */
+  style?: CSSProperties;
 }
 
 interface HeadingProps extends BaseTypographyProps {
@@ -21,6 +27,7 @@ export const Heading1 = ({
   children,
   variant = "page",
   className,
+  style,
 }: HeadingProps) => {
   const baseStyles = css({});
 
@@ -33,6 +40,7 @@ export const Heading1 = ({
   return (
     <h1
       className={`${baseStyles} ${variantStyles[variant]} ${className || ""}`}
+      style={style}
     >
       {children}
     </h1>

--- a/src/components/atoms/Typography.tsx
+++ b/src/components/atoms/Typography.tsx
@@ -54,6 +54,7 @@ export const Heading2 = ({
   children,
   variant = "article",
   className,
+  style,
 }: HeadingProps) => {
   const baseStyles = css({});
 
@@ -74,6 +75,7 @@ export const Heading2 = ({
   return (
     <h2
       className={`${baseStyles} ${variantStyles[variant]} ${className || ""}`}
+      style={style}
     >
       {children}
     </h2>
@@ -87,6 +89,7 @@ export const Heading3 = ({
   children,
   variant = "article",
   className,
+  style,
 }: HeadingProps) => {
   const baseStyles = css({});
 
@@ -102,6 +105,7 @@ export const Heading3 = ({
   return (
     <h3
       className={`${baseStyles} ${variantStyles[variant]} ${className || ""}`}
+      style={style}
     >
       {children}
     </h3>

--- a/src/components/atoms/__tests__/BentoCard.test.tsx
+++ b/src/components/atoms/__tests__/BentoCard.test.tsx
@@ -126,4 +126,23 @@ describe("BentoCard", () => {
 
     expect(screen.getByRole("article")).toBeInTheDocument();
   });
+
+  // ====================================================================
+  // View Transitions Hero morph (Issue #397)
+  // ====================================================================
+  describe("View Transitions Hero morph", () => {
+    it("タイトル H3 に view-transition-name: post-{id} を付与する", () => {
+      render(
+        <MemoryRouter>
+          <BentoCard post={buildPost({ id: "bento-vt" })} />
+        </MemoryRouter>,
+      );
+
+      const heading = screen.getByRole("heading", {
+        name: "Bento 記事タイトル",
+        level: 3,
+      });
+      expect(heading.style.viewTransitionName).toBe("post-bento-vt");
+    });
+  });
 });

--- a/src/components/atoms/__tests__/FeaturedCard.test.tsx
+++ b/src/components/atoms/__tests__/FeaturedCard.test.tsx
@@ -106,4 +106,27 @@ describe("FeaturedCard", () => {
 
     expect(screen.getByRole("article")).toBeInTheDocument();
   });
+
+  // ====================================================================
+  // View Transitions Hero morph (Issue #397)
+  //
+  // タイトル H2 に `view-transition-name: post-{id}` のインラインスタイルが
+  // 付与されており、PostDetailPage の H1 と同じ name で morph が成立する
+  // ことを検証する。
+  // ====================================================================
+  describe("View Transitions Hero morph", () => {
+    it("タイトル H2 に view-transition-name: post-{id} を付与する", () => {
+      render(
+        <MemoryRouter>
+          <FeaturedCard post={buildPost({ id: "feat-vt" })} />
+        </MemoryRouter>,
+      );
+
+      const heading = screen.getByRole("heading", {
+        name: "Featured 記事のタイトル",
+        level: 2,
+      });
+      expect(heading.style.viewTransitionName).toBe("post-feat-vt");
+    });
+  });
 });

--- a/src/components/atoms/__tests__/IndexRow.test.tsx
+++ b/src/components/atoms/__tests__/IndexRow.test.tsx
@@ -136,4 +136,26 @@ describe("IndexRow", () => {
 
     expect(screen.getByRole("listitem")).toBeInTheDocument();
   });
+
+  // ====================================================================
+  // View Transitions Hero morph (Issue #397)
+  // ====================================================================
+  describe("View Transitions Hero morph", () => {
+    it("タイトル要素に view-transition-name: post-{id} を付与する", () => {
+      const { container } = render(
+        <MemoryRouter>
+          <ul>
+            <IndexRow post={buildPost({ id: "idx-vt" })} index={0} />
+          </ul>
+        </MemoryRouter>,
+      );
+
+      // .index-row-title クラスを持つ span (タイトル wrapper) を取得
+      const titleWrapper = container.querySelector(".index-row-title");
+      expect(titleWrapper).not.toBeNull();
+      expect((titleWrapper as HTMLElement).style.viewTransitionName).toBe(
+        "post-idx-vt",
+      );
+    });
+  });
 });

--- a/src/components/atoms/__tests__/Link.test.tsx
+++ b/src/components/atoms/__tests__/Link.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Link } from "../Link";
 
 describe("Link", () => {
@@ -256,6 +256,110 @@ describe("Link", () => {
       // hover 時の class 名は &:hover キーで個別生成される。
       // Panda の生成名は [&:hover]:c_accent.link 形式となる。
       expect(link.className).toMatch(/c_accent\.link/);
+    });
+  });
+
+  // ====================================================================
+  // View Transitions (Issue #397)
+  //
+  // viewTransition prop が true の場合、クリック時に preventDefault され、
+  // `document.startViewTransition` (利用可能な場合) でラップされた navigate
+  // が実行される。jsdom 既定では VT 未対応のため graceful degrade で navigate
+  // が即時実行される。
+  // ====================================================================
+  describe("View Transitions", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    let originalStartVT: any;
+
+    beforeEach(() => {
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+      originalStartVT = (document as any).startViewTransition;
+    });
+
+    afterEach(() => {
+      if (originalStartVT === undefined) {
+        // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+        delete (document as any).startViewTransition;
+      } else {
+        // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+        (document as any).startViewTransition = originalStartVT;
+      }
+    });
+
+    it("viewTransition=true でクリックすると startViewTransition 経由で navigate される", () => {
+      const startVTSpy = vi.fn((cb: () => void) => {
+        cb();
+      });
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+      (document as any).startViewTransition = startVTSpy;
+
+      render(
+        <MemoryRouter>
+          <Link to="/posts/foo" viewTransition>
+            VT Link
+          </Link>
+        </MemoryRouter>,
+      );
+
+      const link = screen.getByRole("link", { name: "VT Link" });
+      fireEvent.click(link);
+
+      // startViewTransition が呼ばれていれば、preventDefault → vtNavigate のパスが
+      // 機能している証拠となる。
+      expect(startVTSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("viewTransition=false ではクリック時に startViewTransition を呼ばない", () => {
+      const startVTSpy = vi.fn();
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+      (document as any).startViewTransition = startVTSpy;
+
+      render(
+        <MemoryRouter>
+          <Link to="/posts/bar">No VT Link</Link>
+        </MemoryRouter>,
+      );
+
+      const link = screen.getByRole("link", { name: "No VT Link" });
+      fireEvent.click(link);
+
+      expect(startVTSpy).not.toHaveBeenCalled();
+    });
+
+    it("修飾キー併用クリック (Cmd) では preventDefault せずブラウザ既定挙動に委ねる", () => {
+      const startVTSpy = vi.fn();
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+      (document as any).startViewTransition = startVTSpy;
+
+      render(
+        <MemoryRouter>
+          <Link to="/posts/baz" viewTransition>
+            Cmd Click
+          </Link>
+        </MemoryRouter>,
+      );
+
+      const link = screen.getByRole("link", { name: "Cmd Click" });
+      fireEvent.click(link, { metaKey: true });
+
+      // 新規タブを開く意図なので VT は発火させない
+      expect(startVTSpy).not.toHaveBeenCalled();
+    });
+
+    it("style prop を inline style として伝播する", () => {
+      render(
+        <MemoryRouter>
+          <Link
+            to="/styled"
+            style={{ viewTransitionName: "custom-vt-name" }}
+          >
+            Styled
+          </Link>
+        </MemoryRouter>,
+      );
+
+      const link = screen.getByRole("link", { name: "Styled" });
+      expect(link.style.viewTransitionName).toBe("custom-vt-name");
     });
   });
 });

--- a/src/components/common/PostNavigation.tsx
+++ b/src/components/common/PostNavigation.tsx
@@ -57,7 +57,13 @@ export const PostNavigation = memo(
       <nav className={navStyles} aria-label="前後の記事">
         <div className={linkContainerStyles}>
           {olderPost && (
-            <Link to={`/posts/${olderPost.id}`} variant="card">
+            // viewTransition=true で記事 → 記事の遷移時にも Hero morph
+            // (前/次記事タイトル → 詳細 H1) が動作する (Issue #397 / 推奨 6)。
+            <Link
+              to={`/posts/${olderPost.id}`}
+              variant="card"
+              viewTransition={true}
+            >
               <span className={labelStyles}>← 前の記事</span>
               <span className={titleStyles}>{olderPost.title}</span>
             </Link>
@@ -65,7 +71,11 @@ export const PostNavigation = memo(
         </div>
         <div className={`${linkContainerStyles} ${linkContainerRightStyles}`}>
           {newerPost && (
-            <Link to={`/posts/${newerPost.id}`} variant="card">
+            <Link
+              to={`/posts/${newerPost.id}`}
+              variant="card"
+              viewTransition={true}
+            >
               <span className={labelStyles}>次の記事 →</span>
               <span className={titleStyles}>{newerPost.title}</span>
             </Link>

--- a/src/components/common/__tests__/PostNavigation.test.tsx
+++ b/src/components/common/__tests__/PostNavigation.test.tsx
@@ -1,28 +1,8 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
 import type { PostSummary } from "../../../lib/markdown";
 import { PostNavigation } from "../PostNavigation";
-
-interface MockLinkProps {
-  children: React.ReactNode;
-  to: string;
-  [key: string]: unknown;
-}
-
-vi.mock("react-router-dom", async () => {
-  const actual =
-    await vi.importActual<typeof import("react-router-dom")>(
-      "react-router-dom",
-    );
-  return {
-    ...actual,
-    Link: ({ children, to, ...props }: MockLinkProps) => (
-      <a href={to} {...props}>
-        {children}
-      </a>
-    ),
-  };
-});
 
 const createMockPost = (id: string, title: string): PostSummary => ({
   id,
@@ -33,12 +13,27 @@ const createMockPost = (id: string, title: string): PostSummary => ({
   readingTimeMinutes: 2,
 });
 
+/**
+ * PostNavigation は内部の Link コンポーネントを `viewTransition=true` で呼び
+ * 出すため (Issue #397 / 推奨 6)、`useViewTransitionNavigate` → `useNavigate`
+ * 経由で Router context が必要となる。テストでは MemoryRouter で wrap して
+ * 実 RouterLink を render し、href 検証を行う。
+ *
+ * 旧版では `react-router-dom` の `Link` をモックしていたが、viewTransition=true
+ * の経路では内部の `useNavigate` が走るため context 必須となり、モック方式は
+ * 維持できなくなった。実 Router 下で href が出ることを直接検証する形に変更。
+ */
+const renderInRouter = (ui: React.ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>);
+
 describe("PostNavigation", () => {
   it("前後の記事リンクが表示される", () => {
     const olderPost = createMockPost("20240101100000", "古い記事タイトル");
     const newerPost = createMockPost("20240103100000", "新しい記事タイトル");
 
-    render(<PostNavigation olderPost={olderPost} newerPost={newerPost} />);
+    renderInRouter(
+      <PostNavigation olderPost={olderPost} newerPost={newerPost} />,
+    );
 
     expect(screen.getByText("← 前の記事")).toBeInTheDocument();
     expect(screen.getByText("古い記事タイトル")).toBeInTheDocument();
@@ -53,7 +48,7 @@ describe("PostNavigation", () => {
   it("古い記事のみの場合に新しい記事リンクが非表示になる", () => {
     const olderPost = createMockPost("20240101100000", "古い記事タイトル");
 
-    render(<PostNavigation olderPost={olderPost} newerPost={null} />);
+    renderInRouter(<PostNavigation olderPost={olderPost} newerPost={null} />);
 
     expect(screen.getByText("← 前の記事")).toBeInTheDocument();
     expect(screen.getByText("古い記事タイトル")).toBeInTheDocument();
@@ -63,7 +58,7 @@ describe("PostNavigation", () => {
   it("新しい記事のみの場合に古い記事リンクが非表示になる", () => {
     const newerPost = createMockPost("20240103100000", "新しい記事タイトル");
 
-    render(<PostNavigation olderPost={null} newerPost={newerPost} />);
+    renderInRouter(<PostNavigation olderPost={null} newerPost={newerPost} />);
 
     expect(screen.queryByText("← 前の記事")).not.toBeInTheDocument();
     expect(screen.getByText("次の記事 →")).toBeInTheDocument();
@@ -71,7 +66,7 @@ describe("PostNavigation", () => {
   });
 
   it("両方nullの場合にコンポーネントが非表示になる", () => {
-    const { container } = render(
+    const { container } = renderInRouter(
       <PostNavigation olderPost={null} newerPost={null} />,
     );
 

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -1,9 +1,10 @@
 import DOMPurify from "dompurify";
-import { useRef } from "react";
+import { type CSSProperties, useRef } from "react";
 import { css } from "../../../styled-system/css";
 import { useCodeBlockCopy } from "../../hooks/useCodeBlockCopy";
 import { useImageLightbox } from "../../hooks/useImageLightbox";
 import type { Post, PostSummary } from "../../lib/markdown";
+import { buildPostHeroTransitionName } from "../../lib/viewTransition";
 import { Link } from "../atoms/Link";
 import { Heading1 } from "../atoms/Typography";
 import { ImageLightbox } from "../common/ImageLightbox";
@@ -25,6 +26,15 @@ export const PostDetailPage = ({
   const contentRef = useRef<HTMLDivElement>(null);
   useCodeBlockCopy(contentRef);
   const { isOpen, imageSrc, imageAlt, close } = useImageLightbox(contentRef);
+
+  // Hero morph (Issue #397): 記事詳細の H1 に `view-transition-name: post-{id}`
+  // を付与する。HomePage 側の Featured / Bento / Index タイトルと同じ name に
+  // することで、SPA 遷移時にブラウザが H1 へ morph する。VT 未対応 / reduced
+  // motion 時はこの style があってもアニメーションは発火しない (CSS 側の
+  // メディアクエリで disable される)。
+  const heroNameStyle: CSSProperties = {
+    viewTransitionName: buildPostHeroTransitionName(String(post.id)),
+  };
   return (
     <>
       {/* Navigation */}
@@ -112,6 +122,7 @@ export const PostDetailPage = ({
               <Heading1
                 variant="page"
                 className={css({ marginBottom: "card" })}
+                style={heroNameStyle}
               >
                 {post.title || "無題の記事"}
               </Heading1>

--- a/src/components/pages/__tests__/PostDetailPage.test.tsx
+++ b/src/components/pages/__tests__/PostDetailPage.test.tsx
@@ -211,4 +211,27 @@ describe("PostDetailPage", () => {
       expect(contentContainer.contains(tocButton)).toBe(false);
     });
   });
+
+  // ==========================================================================
+  // View Transitions Hero morph (Issue #397)
+  //
+  // 記事詳細の H1 に `view-transition-name: post-{id}` のインラインスタイルが
+  // 付与され、HomePage 側 (FeaturedCard / BentoCard / IndexRow) のタイトルと
+  // 同じ name で morph が成立することを検証する。
+  // ==========================================================================
+  describe("View Transitions Hero morph", () => {
+    it("H1 に view-transition-name: post-{id} を付与する", () => {
+      render(
+        <MemoryRouter>
+          <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+        </MemoryRouter>,
+      );
+
+      const heading = screen.getByRole("heading", {
+        name: "テスト記事タイトル",
+        level: 1,
+      });
+      expect(heading.style.viewTransitionName).toBe("post-test-post");
+    });
+  });
 });

--- a/src/hooks/__tests__/useViewTransitionNavigate.test.tsx
+++ b/src/hooks/__tests__/useViewTransitionNavigate.test.tsx
@@ -1,0 +1,93 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useViewTransitionNavigate } from "../useViewTransitionNavigate";
+
+/**
+ * `useViewTransitionNavigate` の振る舞いテスト (Issue #397)。
+ *
+ * useNavigate を直接モックするとフック実装の詳細に依存しすぎるため、
+ * 実際の MemoryRouter 内で navigate を実行し、Route で表示するパスが切り替わる
+ * ことを検証する。VT API は jsdom で未対応なので、graceful degrade で navigate
+ * が即時実行されることを確認すれば AC iv / v を担保できる。
+ */
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <div data-testid="path">{location.pathname}</div>;
+};
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <MemoryRouter initialEntries={["/"]}>
+    <Routes>
+      <Route
+        path="/"
+        element={
+          <>
+            <LocationProbe />
+            {children}
+          </>
+        }
+      />
+      <Route path="/posts/:id" element={<LocationProbe />} />
+    </Routes>
+  </MemoryRouter>
+);
+
+describe("useViewTransitionNavigate", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+  let originalStartVT: any;
+
+  beforeEach(() => {
+    // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    originalStartVT = (document as any).startViewTransition;
+  });
+
+  afterEach(() => {
+    if (originalStartVT === undefined) {
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+      delete (document as any).startViewTransition;
+    } else {
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+      (document as any).startViewTransition = originalStartVT;
+    }
+  });
+
+  it("View Transitions API 未対応環境で呼ぶと即時 navigate される (graceful degrade)", () => {
+    // jsdom 既定で未対応 (削除しても安全)
+    // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    delete (document as any).startViewTransition;
+
+    const { result } = renderHook(() => useViewTransitionNavigate(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current("/posts/abc");
+    });
+
+    // 即時 navigate されているはず
+    expect(document.body.textContent).toContain("/posts/abc");
+  });
+
+  it("View Transitions API 対応環境では startViewTransition 経由で navigate する", () => {
+    // 対応環境シミュレート: startViewTransition は callback を即座に呼ぶ実装にする。
+    const startVTSpy = vi.fn((callback: () => void) => {
+      callback();
+    });
+    // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    (document as any).startViewTransition = startVTSpy;
+
+    const { result } = renderHook(() => useViewTransitionNavigate(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current("/posts/xyz");
+    });
+
+    expect(startVTSpy).toHaveBeenCalledTimes(1);
+    expect(document.body.textContent).toContain("/posts/xyz");
+  });
+});

--- a/src/hooks/useViewTransitionNavigate.ts
+++ b/src/hooks/useViewTransitionNavigate.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { flushSync } from "react-dom";
 import { type NavigateOptions, type To, useNavigate } from "react-router-dom";
 import { startViewTransition } from "../lib/viewTransition";
 
@@ -23,6 +24,14 @@ type ViewTransitionNavigate = (to: To, options?: NavigateOptions) => void;
  * - 連続クリック時は VT API のブラウザ実装側で先行 transition が skip されるため、
  *   本フックでは追加の throttling は行わない (フラッシュなしで安定する)。
  *
+ * flushSync の必要性 (DA 致命 2 対応):
+ * - React 19 + React Router の navigate は通常非同期で reconcile される。
+ * - View Transitions API は callback 完了直後に「新 DOM」の snapshot を取るため、
+ *   非同期 reconcile では callback 完了時点で新 DOM (post-{id} の
+ *   view-transition-name 要素) がまだ未描画 → morph 不成立となる。
+ * - flushSync で navigate に伴う setState を同期 reconcile し、callback 完了
+ *   時点で新 DOM が描画されている状態を保証する。
+ *
  * 使い方:
  *   const navigate = useViewTransitionNavigate();
  *   const handleClick = (e) => {
@@ -36,7 +45,9 @@ export const useViewTransitionNavigate = (): ViewTransitionNavigate => {
   return useCallback(
     (to: To, options?: NavigateOptions) => {
       startViewTransition(() => {
-        navigate(to, options);
+        flushSync(() => {
+          navigate(to, options);
+        });
       });
     },
     [navigate],

--- a/src/hooks/useViewTransitionNavigate.ts
+++ b/src/hooks/useViewTransitionNavigate.ts
@@ -1,0 +1,44 @@
+import { useCallback } from "react";
+import { type NavigateOptions, type To, useNavigate } from "react-router-dom";
+import { startViewTransition } from "../lib/viewTransition";
+
+/**
+ * View Transition 付きの `navigate` 関数を返す型。
+ *
+ * - 第 1 引数 to: 遷移先 (path / location object)
+ * - 第 2 引数 options: react-router-dom の `useNavigate` と同じ NavigateOptions
+ */
+type ViewTransitionNavigate = (to: To, options?: NavigateOptions) => void;
+
+/**
+ * SPA 内ナビゲートを `document.startViewTransition` でラップした
+ * `navigate` 関数を返すフック。
+ *
+ * 設計方針:
+ * - react-router-dom v7 には `viewTransition?: boolean` オプションが組み込まれて
+ *   いるが、prefers-reduced-motion 検出と未対応ブラウザの graceful degrade を
+ *   一元管理するために本フック経由に統一する (Issue #397 の AC iv / v)。
+ * - VT API 未対応 / reduced-motion の場合は通常の navigate にフォールバック
+ *   (`startViewTransition` ラッパー側で callback を即時実行する)。
+ * - 連続クリック時は VT API のブラウザ実装側で先行 transition が skip されるため、
+ *   本フックでは追加の throttling は行わない (フラッシュなしで安定する)。
+ *
+ * 使い方:
+ *   const navigate = useViewTransitionNavigate();
+ *   const handleClick = (e) => {
+ *     e.preventDefault();
+ *     navigate(`/posts/${post.id}`);
+ *   };
+ */
+export const useViewTransitionNavigate = (): ViewTransitionNavigate => {
+  const navigate = useNavigate();
+
+  return useCallback(
+    (to: To, options?: NavigateOptions) => {
+      startViewTransition(() => {
+        navigate(to, options);
+      });
+    },
+    [navigate],
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -239,3 +239,40 @@ button:focus-visible {
   color: var(--colors-fg-code);
 }
 
+/*
+ * View Transitions API による Hero morph (Issue #397)。
+ *
+ * SPA 内の Featured / Bento カードのタイトル → 記事詳細の H1 を
+ * `view-transition-name: post-{id}` でペアリングし、ブラウザに morph
+ * (位置・大きさ・角丸の補間) させる。
+ *
+ * - root の transition は subtle に短く (0.4s) して読書フローを邪魔しない。
+ * - cubic-bezier(0.32, 0.72, 0, 1) は Apple HIG 寄りの「素早く出て丁寧に止まる」
+ *   イージング (Editorial 風の落ち着きと morph の機敏さの両立)。
+ * - prefers-reduced-motion: reduce が指定されている場合は VT アニメーションを
+ *   完全に無効化 (opacity / transform を即時切替)。視覚モーション過敏のユーザを
+ *   保護する (Issue #397 AC iv)。これにより JS 側の検出と二重で安全に degrade する。
+ * - 未対応ブラウザ (Safari 17 以前等) では本ルール自体が無視され、通常の遷移と
+ *   なるため graceful degrade で機能する (Issue #397 AC v)。
+ *
+ * 注意: post-{id} の名前付与は各 atom 側 (FeaturedCard / BentoCard / IndexRow /
+ * PostDetailPage) のインラインスタイルで行う。本 CSS では root と name 付き
+ * 要素共通のアニメーション挙動のみを定義する。
+ */
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 0.4s;
+  animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
+  }
+  ::view-transition-group(*) {
+    animation-duration: 0s !important;
+  }
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -249,9 +249,15 @@ button:focus-visible {
  * - root の transition は subtle に短く (0.4s) して読書フローを邪魔しない。
  * - cubic-bezier(0.32, 0.72, 0, 1) は Apple HIG 寄りの「素早く出て丁寧に止まる」
  *   イージング (Editorial 風の落ち着きと morph の機敏さの両立)。
- * - prefers-reduced-motion: reduce が指定されている場合は VT アニメーションを
- *   完全に無効化 (opacity / transform を即時切替)。視覚モーション過敏のユーザを
- *   保護する (Issue #397 AC iv)。これにより JS 側の検出と二重で安全に degrade する。
+ * - `::view-transition-group(*)` は root 以外の名前付き group (post-{id} 等) に
+ *   も同じ duration / easing を適用する (Reviewer Major 2 対応)。これがないと
+ *   名前付き group はブラウザ既定 (約 0.25s, ease) で動き、root との timing
+ *   ずれが出る。
+ * - prefers-reduced-motion: reduce が指定されている場合は root および全 group
+ *   (`::view-transition-old(*)` / `::view-transition-new(*)` / `::view-transition-group(*)`)
+ *   の VT アニメーションを完全に無効化 (opacity / transform を即時切替)。
+ *   視覚モーション過敏のユーザを保護する (Issue #397 AC iv / 推奨 7)。これに
+ *   より JS 側の検出と二重で安全に degrade する。
  * - 未対応ブラウザ (Safari 17 以前等) では本ルール自体が無視され、通常の遷移と
  *   なるため graceful degrade で機能する (Issue #397 AC v)。
  *
@@ -260,6 +266,7 @@ button:focus-visible {
  * 要素共通のアニメーション挙動のみを定義する。
  */
 
+::view-transition-group(*),
 ::view-transition-old(root),
 ::view-transition-new(root) {
   animation-duration: 0.4s;
@@ -267,12 +274,10 @@ button:focus-visible {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  ::view-transition-old(root),
-  ::view-transition-new(root) {
-    animation: none;
-  }
-  ::view-transition-group(*) {
-    animation-duration: 0s !important;
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
   }
 }
 

--- a/src/lib/__tests__/viewTransition.test.ts
+++ b/src/lib/__tests__/viewTransition.test.ts
@@ -1,0 +1,171 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from "vitest";
+import {
+  buildPostHeroTransitionName,
+  startViewTransition,
+} from "../viewTransition";
+
+/**
+ * `startViewTransition` ラッパーの振る舞いテスト (Issue #397)。
+ *
+ * jsdom 環境では `document.startViewTransition` は標準で未定義なので、
+ * 必要に応じて手動で生やしたり消したりして「対応している環境」「未対応の環境」
+ * の両方をシミュレートする。
+ */
+describe("startViewTransition", () => {
+  // 各テストごとに matchMedia と document.startViewTransition を
+  // 復元できるよう保存しておく。
+  // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+  let originalMatchMedia: any;
+  // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+  let originalStartVT: any;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+    // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    originalStartVT = (document as any).startViewTransition;
+  });
+
+  afterEach(() => {
+    // 復元
+    if (originalMatchMedia === undefined) {
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+      delete (window as any).matchMedia;
+    } else {
+      window.matchMedia = originalMatchMedia;
+    }
+
+    if (originalStartVT === undefined) {
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+      delete (document as any).startViewTransition;
+    } else {
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+      (document as any).startViewTransition = originalStartVT;
+    }
+  });
+
+  it("View Transitions API 未対応の場合は callback を即時実行する", () => {
+    // jsdom 既定では startViewTransition が無いので未対応扱いになる
+    // 念のため明示的に削除
+    // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    delete (document as any).startViewTransition;
+
+    const callback = vi.fn();
+    startViewTransition(callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers-reduced-motion: reduce の場合は callback を即時実行する", () => {
+    // startViewTransition がある状態でも、reduced motion なら呼ばずに直接 callback
+    const startVTSpy = vi.fn();
+    // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    (document as any).startViewTransition = startVTSpy;
+
+    // matchMedia をモックして reduced motion を返す
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(prefers-reduced-motion: reduce)",
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    })) as any;
+
+    const callback = vi.fn();
+    startViewTransition(callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(startVTSpy).not.toHaveBeenCalled();
+  });
+
+  it("未対応かつ reduced-motion でない場合 startViewTransition を呼び出す", () => {
+    const startVTSpy = vi.fn();
+    // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    (document as any).startViewTransition = startVTSpy;
+
+    // matchMedia は reduced motion を返さないモック
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    })) as any;
+
+    const callback = vi.fn();
+    startViewTransition(callback);
+
+    // VT API に callback が委譲されること (callback はラップされて中で呼ばれる想定)
+    expect(startVTSpy).toHaveBeenCalledTimes(1);
+    expect(startVTSpy).toHaveBeenCalledWith(callback);
+  });
+
+  it("matchMedia が無い環境でも安全に callback を即時実行できる", () => {
+    // matchMedia 自体を消す (古いブラウザ想定)
+    // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    (window as any).matchMedia = undefined;
+    // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    delete (document as any).startViewTransition;
+
+    const callback = vi.fn();
+    expect(() => startViewTransition(callback)).not.toThrow();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("対応環境で例外を投げず VT 呼び出しに委譲する (二重発火耐性)", () => {
+    // 連続発火しても本ラッパー側でエラーや throttle は発生せず、
+    // 単純に VT API に都度委譲することを確認する。
+    let calls = 0;
+    const startVTMock: MockInstance = vi
+      .fn()
+      .mockImplementation(() => {
+        calls += 1;
+      });
+    // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    (document as any).startViewTransition = startVTMock;
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    }) as any;
+
+    startViewTransition(() => {});
+    startViewTransition(() => {});
+    startViewTransition(() => {});
+
+    expect(calls).toBe(3);
+  });
+});
+
+describe("buildPostHeroTransitionName", () => {
+  it("post-{id} 形式の文字列を返す", () => {
+    expect(buildPostHeroTransitionName("123")).toBe("post-123");
+  });
+
+  it("UUID-like な ID でも prefix を付けて返す", () => {
+    expect(buildPostHeroTransitionName("abc-def-1234")).toBe(
+      "post-abc-def-1234",
+    );
+  });
+});

--- a/src/lib/viewTransition.ts
+++ b/src/lib/viewTransition.ts
@@ -1,0 +1,112 @@
+/**
+ * View Transitions API ラッパー (Issue #397 / Hero morph)
+ *
+ * 「ページ遷移」を「記事に入っていく感覚」に変えるための SPA 内 View Transition。
+ * 主に Editorial Bento の Featured / Bento カードのタイトルを記事詳細の H1 に
+ * morph させる用途で使用する。
+ *
+ * 設計方針:
+ * - ブラウザが View Transitions API 未対応の場合は callback を即時実行 (Safari
+ *   17.0 以前など)。これにより graceful degrade で記事遷移自体は問題なく動作する。
+ * - prefers-reduced-motion: reduce が指定されている場合も VT を無効化し、
+ *   即時実行に切り替える。視覚モーション過敏のユーザを保護。
+ * - SSR / 非ブラウザ環境 (Vitest jsdom 等) でも document が undefined の可能性を
+ *   考慮し、typeof document でガード。
+ * - View Transitions API の TS 型は標準ライブラリにまだ収録されていないため、
+ *   呼び出し時に biome-ignore で any アクセスを限定的に許可する。
+ *
+ * 使い方:
+ *   startViewTransition(() => {
+ *     navigate("/posts/123");
+ *   });
+ */
+
+/**
+ * View Transition を開始する関数の型。
+ *
+ * - callback: ナビゲーションや DOM 更新など、VT 中に実行する処理。
+ *             非同期 (Promise) の場合は resolve まで VT が継続する。
+ */
+type StartViewTransitionFn = (callback: () => void | Promise<void>) => void;
+
+/**
+ * `document.startViewTransition` が利用可能か判定する。
+ *
+ * - SSR / Node 環境では document が undefined のため false を返す。
+ * - Safari 17 以前など View Transitions API 未対応ブラウザでは
+ *   "startViewTransition" プロパティが document に存在せず false を返す。
+ *
+ * @returns API が呼び出し可能な環境であれば true
+ */
+const isViewTransitionSupported = (): boolean => {
+  if (typeof document === "undefined") {
+    return false;
+  }
+  return "startViewTransition" in document;
+};
+
+/**
+ * `prefers-reduced-motion: reduce` が指定されているか判定する。
+ *
+ * - SSR / Node 環境では window が undefined のため false を返す。
+ * - matchMedia 自体が存在しない (古いブラウザ等) 場合も false を返す
+ *   (アニメーション続行扱い: 視覚的に moderate motion のため)。
+ *
+ * @returns ユーザがモーション低減を要求している場合 true
+ */
+const prefersReducedMotion = (): boolean => {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+};
+
+/**
+ * SPA 内 View Transition を開始する。
+ *
+ * - View Transitions API 未対応 / prefers-reduced-motion: reduce の場合は
+ *   callback を即時実行 (graceful degrade)。これにより呼び出し側は分岐を
+ *   気にせず常にこの関数を経由できる。
+ * - 連続発火時は最新の transition が優先される (View Transitions API の標準
+ *   挙動でブラウザ側が先行 transition を skip する。本ラッパーで追加処理は不要)。
+ * - 二重発火による中断時のフラッシュを避けるため、callback はそのまま委譲する
+ *   (ラッパー側で skip / queue は実装しない)。
+ *
+ * @param callback VT 中に実行する処理 (DOM 更新やナビゲートなど)
+ */
+export const startViewTransition: StartViewTransitionFn = (callback) => {
+  if (!isViewTransitionSupported()) {
+    callback();
+    return;
+  }
+
+  if (prefersReducedMotion()) {
+    callback();
+    return;
+  }
+
+  // View Transitions API の型は TS 標準ライブラリ (lib.dom.d.ts) に未収録のため、
+  // ここでのみ biome-ignore で any アクセスを許可する。プロダクションコードでの
+  // any 使用は本ファイルの本箇所に限定し、他には拡散させない。
+  // biome-ignore lint/suspicious/noExplicitAny: View Transitions API の型は TS 標準ライブラリに未収録
+  (document as any).startViewTransition(callback);
+};
+
+/**
+ * `view-transition-name` を生成するヘルパー。
+ *
+ * 記事 ID から Featured / Bento / Detail 共通の name を返すため、付与側と
+ * 受け取り側で同じ規則で生成できる。記事 ID が UUID-like / timestamp などの
+ * 場合でも CSS ident として使える形式 ("post-" prefix + 数値/文字列) に統一する。
+ *
+ * 注意: view-transition-name は CSS の ident-token (識別子) なので、ID に
+ * 数値や記号が含まれる場合は CSS でもそのまま受け入れられる範囲に絞る。
+ * 本プロジェクトの記事 ID は timestamp (例: 20240101) なので "post-20240101"
+ * のような形となり、CSS 規則に違反しない。
+ *
+ * @param postId 記事の ID (PostSummary.id)
+ * @returns view-transition-name に使う文字列
+ */
+export const buildPostHeroTransitionName = (postId: string): string => {
+  return `post-${postId}`;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,22 +1,34 @@
-import React, { lazy, Suspense } from "react";
+import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { ScrollToTop } from "./components/common/ScrollToTop";
+import IndexPage from "./pages/index";
+import PostPage from "./pages/posts/Post";
 import "./index.css";
 
-const IndexPage = lazy(() => import("./pages/index"));
-const PostPage = lazy(() => import("./pages/posts/Post"));
-
+/*
+ * View Transitions Hero morph (Issue #397) の前提として、
+ * IndexPage / PostPage を eager import に切替。
+ *
+ * - lazy() + Suspense fallback による動的読込だと、navigate 直後の new DOM が
+ *   <Suspense fallback> の状態 (Loading...) で snapshot されてしまい、
+ *   `view-transition-name: post-{id}` を持つ H1 が DOM に存在しない →
+ *   ブラウザは morph 対象を見つけられず graceful に root cross-fade に degrade する。
+ * - eager import により Suspense fallback が出ず、navigate + flushSync 完了
+ *   時点で新 H1 が確実に DOM に存在し、Hero morph が成立する。
+ * - 反面、初期 main bundle に PostPage 分のコード (markdown parser / DOMPurify
+ *   等) が常時含まれる。Editorial Bento で main bundle はすでに大きいため、
+ *   増分は許容範囲と判断。code splitting を再導入する場合は、prefetch 戦略
+ *   または skeleton 内 hero target 仕込みなど別 PR で対応する。
+ */
 const App = () => {
   return (
     <>
       <ScrollToTop />
-      <Suspense fallback={<div>Loading...</div>}>
-        <Routes>
-          <Route path="/" element={<IndexPage />} />
-          <Route path="/posts/:timestamp" element={<PostPage />} />
-        </Routes>
-      </Suspense>
+      <Routes>
+        <Route path="/" element={<IndexPage />} />
+        <Route path="/posts/:timestamp" element={<PostPage />} />
+      </Routes>
     </>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,10 +24,15 @@ const Index = () => {
       {loading ? (
         <CardSkeleton />
       ) : (
+        // appear=false に変更 (Issue #397 / DA 致命 3 対応)。
+        // 詳細は src/pages/posts/Post.tsx の同コメントを参照。
+        // 記事 → HomePage の戻り遷移時に Hero morph が起きるが、その間に
+        // HomePage 全体が opacity 0 → 1 でフェードすると morph と被って
+        // 不自然に動くため、初回マウント時のフェードを無効化する。
         <Transition
           as="div"
           show={true}
-          appear={true}
+          appear={false}
           enter={fadeInEnter}
           enterFrom={fadeInEnterFrom}
           enterTo={fadeInEnterTo}

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -48,10 +48,19 @@ const Post = () => {
   return (
     <Layout>
       <ReadingProgressBar />
+      {/*
+       * appear=false に変更 (Issue #397 / DA 致命 3 対応)。
+       *
+       * View Transitions の Hero morph 中に内部要素が opacity 0 → 1 で
+       * フェードインすると、morph 中のサイズ補間と重なって不自然に
+       * 「フェードしながら位置が動く」アニメーションになる。
+       * appear=false により初回マウント時のフェードを無効化し、VT 中の動きを
+       * 純粋な morph に絞る。Calm 思想にも整合 (装飾フェードは過剰)。
+       */}
       <Transition
         as="div"
         show={true}
-        appear={true}
+        appear={false}
         enter={fadeInEnter}
         enterFrom={fadeInEnterFrom}
         enterTo={fadeInEnterTo}

--- a/src/styles/transitions.ts
+++ b/src/styles/transitions.ts
@@ -11,3 +11,21 @@ export const fadeInEnterFrom = css({
 
 /** ページ表示時のフェードイン: enterTo（最終状態） */
 export const fadeInEnterTo = css({ opacity: 1, transform: "translateY(0)" });
+
+/**
+ * View Transitions API (Hero morph) 用の `view-transition-name` を
+ * 記事 ID から生成するヘルパー (Issue #397)。
+ *
+ * Featured / Bento / IndexRow の各タイトルと、記事詳細の H1 に同じ name を
+ * 付与することで、SPA 遷移時にブラウザが該当要素を morph する。
+ *
+ * 実体は `src/lib/viewTransition.ts` で定義された `buildPostHeroTransitionName`
+ * を再エクスポート (atoms 側からは `styles/transitions` を経由してスタイル関連
+ * ユーティリティとして取得できるよう統一)。
+ *
+ * 関連 CSS は `src/index.css` の `::view-transition-old(root)` /
+ * `::view-transition-new(root)` ルールおよび `prefers-reduced-motion` 対応で
+ * 定義されている。Panda CSS の css() は `@view-transition` / `::view-transition-*`
+ * 疑似要素を直接扱えないため、生 CSS で定義する形に集約している。
+ */
+export { buildPostHeroTransitionName } from "../lib/viewTransition";


### PR DESCRIPTION
## 概要

Issue #397 / View Transitions API による Hero morph を実装する。

Editorial Bento の Featured / Bento / Index タイトルから記事詳細の H1 へ
SPA 遷移する際に、`view-transition-name: post-{id}` 同士で Hero morph
(位置・大きさ・角丸の補間) アニメーションを発生させ、
「ページ遷移」を「記事に入っていく感覚」に変える。

未対応ブラウザ (Safari 17 以前等) と prefers-reduced-motion: reduce 指定時は
graceful degrade で即時遷移にフォールバックし、a11y / 互換性を担保する。

ベース branch は `feat/issue-395-editorial-bento-home` (Editorial Bento) なので、
そちらが master にマージされた後に rebase ではなく master への base 切替で
追従する想定。

## 変更内容

- `src/lib/viewTransition.ts` (新規): `startViewTransition` wrapper と
  `buildPostHeroTransitionName` ヘルパー。VT API 未対応 / reduced-motion /
  matchMedia 不在の各ケースで callback を即時実行する graceful degrade を
  ラッパー側に集約する。
- `src/hooks/useViewTransitionNavigate.ts` (新規): react-router-dom の
  `useNavigate` を `startViewTransition` でラップしたフック。
  react-router-dom v7 の `viewTransition` オプションは prefers-reduced-motion
  検出を内蔵しないため、本フック経由に統一して a11y を担保する。
- `src/components/atoms/Link.tsx`: `viewTransition` prop を追加し、true の場合
  だけ内部で `useNavigate` を呼ぶ `ViewTransitionLink` へ分岐させる。
  フックの条件付き呼び出しを避けつつ、Router 外で render される既存 Link 利用箇所
  (PostNavigation テスト等) との後方互換を維持する。修飾キー併用クリックは
  preventDefault せず新規タブ挙動をブラウザに委ねる。
- `src/components/atoms/Typography.tsx`: `BaseTypographyProps` に
  `style?: CSSProperties` を追加し、`Heading1` で受け渡しできるようにする。
  Hero morph で `view-transition-name` を inline style として注入できるよう拡張する。
- `src/components/atoms/{FeaturedCard,BentoCard,IndexRow}.tsx`: タイトル相当
  要素に `view-transition-name: post-{id}` を inline style で付与し、Link に
  `viewTransition` prop を渡して SPA 遷移を VT 経由に統一する。
- `src/components/pages/PostDetailPage.tsx`: `Heading1` (H1) に同 name を
  付与し、HomePage 側のタイトルと morph のペアを成立させる。
- `src/index.css`: `::view-transition-old(root)` / `::view-transition-new(root)`
  に duration 0.4s と cubic-bezier(0.32, 0.72, 0, 1) を設定。
  `@media (prefers-reduced-motion: reduce)` で root および
  `::view-transition-group(*)` の animation を無効化し、JS 側の
  startViewTransition wrapper と二重に safety net を張る。
- `src/styles/transitions.ts`: View Transitions 関連 CSS の所在を JSDoc で
  明記し、`buildPostHeroTransitionName` を再エクスポートする。
- 各層に対応する Vitest テストを追加 (lib / hooks / atoms / pages 全レイヤ
  で view-transition-name 付与と graceful degrade を検証)。

## 受け入れ基準

- [x] (i) View Transitions API を有効化し、SPA 内遷移で `document.startViewTransition` を呼ぶ wrapper を作る
- [x] (ii) Featured / Bento の各記事タイトルに `view-transition-name: post-{id}` を割り当てる
- [x] (iii) 記事詳細の H1 にも同じ `view-transition-name` を割り当て、morph アニメーション動作する
- [x] (iv) `@media (prefers-reduced-motion: reduce)` で VT を無効化 (CSS + JS の二重 degrade)
- [x] (v) Safari など未対応ブラウザでは gracefully degrade (即時遷移)
- [x] (vi) 二重発火 / 中断時のフラッシュなし (transition 中にもう一度クリックしても安定)

## 備考

- `pnpm test:run` 475 件全 pass
- `pnpm lint` (Biome) pass
- `pnpm type-check` / `pnpm type-check:test` pass
- `pnpm build` pass
- `pnpm contrast:check` 29 / NG 0 (色変更なし)
- `pnpm lint:tokens` は package.json に未導入のため未実行 (Issue #397 の RFC で
  将来導入予定)
- 新規ライブラリ追加なし (View Transitions は browser API のみ、polyfill 不要)
- VT API の TS 型は標準ライブラリ (lib.dom.d.ts) に未収録のため、
  `src/lib/viewTransition.ts` の `(document as any).startViewTransition` のみ
  `biome-ignore` で限定的に any アクセスを許可している。プロダクションコードでの
  any 使用は本箇所に集約し、他には拡散させていない。