### PR TITLE
refactor: fg.onBrand semantic token 化 (#408)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Lint design tokens (R-5 / Issue #393)
         run: pnpm lint:tokens
 
+      - name: Verify AAA contrast (Issue #408)
+        run: pnpm contrast:check
+
       - name: Type check
         run: pnpm exec tsc --noEmit

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -302,6 +302,27 @@ export default defineConfig({
             },
           },
           // ----------------------------------------------------------------
+          // CTA (accent.brand 背景) 上の文字色 (Issue #408 で追加)
+          //
+          // Button.tsx (primary variant) / Link.tsx (button variant) /
+          // EmptyState.tsx の CTA Link で使用していた primitive 直書き
+          // ({_light: "cream.50", _dark: "ink.900"}) を semantic token として
+          // 集約する。値の正本は src/lib/colorTokens.ts の semanticColorTokens.fgOnBrand。
+          //
+          // WCAG コントラスト (scripts/calculateContrast.ts cta/* ペアと同期):
+          //   - light (cream-50 × persimmon-600): 5.74:1 PASS (AA)
+          //   - dark  (ink-900   × persimmon-500): 5.42:1 PASS (AA)
+          //
+          // 必ず accent.brand 背景上で使うこと。bg.canvas / surface 上では
+          // light の cream-50 が背景に同化するため使用不可。
+          // ----------------------------------------------------------------
+          onBrand: {
+            value: {
+              _light: "{colors.cream.50}",
+              _dark: "{colors.ink.900}",
+            },
+          },
+          // ----------------------------------------------------------------
           // コードブロック本文の既定文字色 (R-2a / Issue #388 で追加、R-2c で hex 直接化)
           //
           // Shiki/Prism のシンタックスハイライトが適用されない箇所

--- a/scripts/calculateContrast.ts
+++ b/scripts/calculateContrast.ts
@@ -497,6 +497,25 @@ const verifySemanticPairs = (): readonly ContrastResult[] => {
       minRatio: contrastThresholds.largeText,
       category: "ui-large",
     },
+    // Issue #408 (DA 救済 4): fg.onBrand × accent.featured のペア。
+    // 現状 accent.featured は accent.brand と同値だが、Phase 2 で分離した際に
+    // 値が逸脱した瞬間に検出するための Tripwire。同値の間は AA 値も同一になる。
+    //   - light (cream-50 × persimmon-600): 5.74:1 PASS (AA)
+    //   - dark  (ink-900   × persimmon-500): 5.42:1 PASS (AA)
+    {
+      name: "semantic/light: fg.onBrand × accent.featured (Phase 2 分離 Tripwire)",
+      fg: semanticColorTokens.fgOnBrand.light,
+      bg: semanticColorTokens.accentFeatured.light,
+      minRatio: contrastThresholds.largeText,
+      category: "ui-large",
+    },
+    {
+      name: "semantic/dark: fg.onBrand × accent.featured (Phase 2 分離 Tripwire)",
+      fg: semanticColorTokens.fgOnBrand.dark,
+      bg: semanticColorTokens.accentFeatured.dark,
+      minRatio: contrastThresholds.largeText,
+      category: "ui-large",
+    },
   ];
 
   return semanticPairs.map(computeContrast);

--- a/scripts/calculateContrast.ts
+++ b/scripts/calculateContrast.ts
@@ -478,6 +478,25 @@ const verifySemanticPairs = (): readonly ContrastResult[] => {
       minRatio: contrastThresholds.largeText,
       category: "focus",
     },
+    // Issue #408: fg.onBrand × accent.brand のペア (CTA 文字色)。
+    // primitive ペア cta/light cta/dark と同じ結果を semantic 層でも要求し、
+    // 両層の同期が崩れた瞬間に検出する。
+    //   - light (cream-50 × persimmon-600): 5.74:1 PASS (AA)
+    //   - dark  (ink-900   × persimmon-500): 5.42:1 PASS (AA)
+    {
+      name: "semantic/light: fg.onBrand × accent.brand (CTA 文字色)",
+      fg: semanticColorTokens.fgOnBrand.light,
+      bg: semanticColorTokens.accentBrand.light,
+      minRatio: contrastThresholds.largeText,
+      category: "ui-large",
+    },
+    {
+      name: "semantic/dark: fg.onBrand × accent.brand (CTA 文字色)",
+      fg: semanticColorTokens.fgOnBrand.dark,
+      bg: semanticColorTokens.accentBrand.dark,
+      minRatio: contrastThresholds.largeText,
+      category: "ui-large",
+    },
   ];
 
   return semanticPairs.map(computeContrast);

--- a/scripts/lintTokens.ts
+++ b/scripts/lintTokens.ts
@@ -53,8 +53,19 @@ const TARGET_EXTENSIONS = new Set([".ts", ".tsx", ".css"]);
  * - 自テストの中で「文字列としてパターンを書いている」可能性があるため `.test.ts(x)` は除外する。
  *   ただし `__tests__` 配下の通常テストは内部実装ではなく動作検証なので、
  *   旧 token をハードコードする可能性は低い。実害が出たら個別に除外を増やす。
+ * - `src/components/common/ThemeToggle.tsx` は thumb 背景上の icon 色という
+ *   別コンテキストで `{_light: "cream.50", _dark: "ink.900"}` の primitive ペアを
+ *   意図的に使用しているため除外する (Issue #408 スコープ外)。
+ * - `src/lib/colorTokens.ts` は semantic token 定義の単一ソースであり、
+ *   JSDoc で「過去の直書きパターン」を文字列として説明する箇所がある。
+ *   実装上は `oklchPrimitives.*` を介して値を組み立てるため除外して問題ない。
  */
-const EXCLUDED_FILE_SUFFIXES = [".test.ts", ".test.tsx"];
+const EXCLUDED_FILE_SUFFIXES = [
+  ".test.ts",
+  ".test.tsx",
+  "src/components/common/ThemeToggle.tsx",
+  "src/lib/colorTokens.ts",
+];
 
 /**
  * lint パターン定義。
@@ -107,6 +118,19 @@ const LINT_PATTERNS: readonly LintPattern[] = [
     description: "旧 colors.gruvbox.* token の参照 (R-2c で削除済み)",
     // token('colors.gruvbox.bg-0') 形式。kebab-case や数字を含む値も拾う。
     pattern: /token\(['"]colors\.gruvbox\.[a-z0-9-]+['"]\)/g,
+  },
+  {
+    name: "primitive-pair-cream-ink-fg-on-brand",
+    description:
+      '`{ _light: "cream.50", _dark: "ink.900" }` の primitive ペアは `color: "fg.onBrand"` semantic token に置換可能。直書きは fg.onBrand への移行漏れの可能性 (Issue #408)',
+    // _light: "cream.50", _dark: "ink.900" の順で並ぶ primitive ペア。
+    pattern: /\{\s*_light:\s*['"]cream\.50['"]\s*,\s*_dark:\s*['"]ink\.900['"]\s*\}/g,
+  },
+  {
+    name: "primitive-pair-cream-ink-fg-on-brand-reversed",
+    description:
+      '同上 (key 順違い): `{ _dark: "ink.900", _light: "cream.50" }` も `color: "fg.onBrand"` に置換可能 (Issue #408)',
+    pattern: /\{\s*_dark:\s*['"]ink\.900['"]\s*,\s*_light:\s*['"]cream\.50['"]\s*\}/g,
   },
 ] as const;
 

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -41,8 +41,9 @@ const baseButtonStyles = css({
 // バリアントスタイル
 // 旧 Gruvbox トークン群を Editorial Citrus セマンティック token に置換 (R-2b)。
 // - primary は CTA 系のため accent.brand (persimmon) を使用。
-//   文字色は light=cream.50, dark=ink.900 (CTA 専用ペア、scripts/calculateContrast.ts で
-//   light 5.74:1 AA / dark は ink-900 × persimmon-500 で AA pass を担保)。
+//   文字色は fg.onBrand (Issue #408 で primitive 直書きから semantic token に集約)。
+//   light: fg.onBrand (cream-50) × accent.brand (persimmon-600) = 5.74:1 AA。
+//   dark : fg.onBrand (ink-900)  × accent.brand (persimmon-500) = 5.42:1 AA。
 // - secondary は表面階層のため bg.elevated / bg.surface で構成し、文字色は fg.primary。
 //   light: bg.elevated (cream-50) × fg.primary (ink-primary) = 17.16:1 AAA。
 //   dark : bg.elevated (sumi-600) × fg.primary (bone-50) = 7.76:1 AAA (実測)。
@@ -52,10 +53,7 @@ const baseButtonStyles = css({
 const variantStyles = {
   primary: css({
     background: "accent.brand",
-    // TODO(R-2c+): fg.onBrand semantic token に置換予定
-    // (CTA 文字色を直書きせず semantic token に集約する。R-2a #388 は merge 準備中
-    //  のため再変更は避け、R-2c または別 hotfix で導入。)
-    color: { _light: "cream.50", _dark: "ink.900" },
+    color: "fg.onBrand",
     "&:hover:not(:disabled)": {
       background: "accent.brand",
       transform: "translateY(-1px)",

--- a/src/components/atoms/Link.tsx
+++ b/src/components/atoms/Link.tsx
@@ -49,7 +49,9 @@ export const Link = ({
   // - default / navigation / card のリンク色は accent.link (indigo) で統一。
   //   light: cream-50 上 7.82:1 AAA / dark: sumi-950 上 8.79:1 AAA。
   // - button variant は CTA 扱いのため accent.brand を使用。
-  //   文字色は light=cream.50, dark=ink.900 (CTA 専用ペア、AA pass を担保)。
+  //   文字色は fg.onBrand (Issue #408 で primitive 直書きから semantic token に集約)。
+  //   light: fg.onBrand (cream-50) × accent.brand (persimmon-600) = 5.74:1 AA。
+  //   dark : fg.onBrand (ink-900)  × accent.brand (persimmon-500) = 5.42:1 AA。
   // - hover で色相を切り替えず、background の変化や filter で表現する
   //   (Editorial Citrus の「accent は単色運用」方針)。
   const variantStyles = {
@@ -76,10 +78,7 @@ export const Link = ({
       justifyContent: "center",
       padding: "sm-md md",
       background: "accent.brand",
-      // TODO(R-2c+): fg.onBrand semantic token に置換予定
-      // (CTA 文字色を直書きせず semantic token に集約する。R-2a #388 は merge 準備中
-      //  のため再変更は避け、R-2c または別 hotfix で導入。)
-      color: { _light: "cream.50", _dark: "ink.900" },
+      color: "fg.onBrand",
       fontWeight: "600",
       borderRadius: "md",
       // R-5 (Issue #393) AC (ii): CTA は背景色で誘導するため下線なし。

--- a/src/components/atoms/__tests__/Button.test.tsx
+++ b/src/components/atoms/__tests__/Button.test.tsx
@@ -186,6 +186,15 @@ describe("Button", () => {
       expect(button.className).toMatch(/bg_accent\.brand/);
     });
 
+    // Issue #408: CTA 文字色は primitive 直書きから fg.onBrand semantic token
+    // に集約済み。Panda 生成 class 名の `c_fg.onBrand` を Tripwire として固定し、
+    // primitive 直書き ({_light: cream.50, _dark: ink.900}) への退行を検出する。
+    it("primary variant は fg.onBrand の color class を持つ", () => {
+      render(<Button variant="primary">Primary</Button>);
+      const button = screen.getByRole("button", { name: "Primary" });
+      expect(button.className).toMatch(/c_fg\.onBrand/);
+    });
+
     it("secondary variant は bg.surface の background class を持つ", () => {
       render(<Button variant="secondary">Secondary</Button>);
       const button = screen.getByRole("button", { name: "Secondary" });

--- a/src/components/atoms/__tests__/Link.test.tsx
+++ b/src/components/atoms/__tests__/Link.test.tsx
@@ -244,6 +244,21 @@ describe("Link", () => {
       expect(link.className).toMatch(/bg_accent\.brand/);
     });
 
+    // Issue #408: CTA 文字色は primitive 直書きから fg.onBrand semantic token
+    // に集約済み。Panda 生成 class 名の `c_fg.onBrand` を Tripwire として固定し、
+    // primitive 直書き ({_light: cream.50, _dark: ink.900}) への退行を検出する。
+    it("button variant は fg.onBrand の color class を持つ", () => {
+      render(
+        <MemoryRouter>
+          <Link to="/cta" variant="button">
+            CTA
+          </Link>
+        </MemoryRouter>,
+      );
+      const link = screen.getByRole("link", { name: "CTA" });
+      expect(link.className).toMatch(/c_fg\.onBrand/);
+    });
+
     it("card variant は hover 時に accent.link の color class が適用される", () => {
       render(
         <MemoryRouter>

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -78,9 +78,9 @@ export const EmptyState = ({
         </p>
         {action && (
           // R-4 (Issue #392) で CTA の文字色を AA pass の組合せに修正。
-          // accent.brand 背景に対し:
-          //   - light (persimmon-600 上): cream.50 で 5.74:1 PASS (AA)
-          //   - dark  (persimmon-500 上): ink.900 で 5.42:1 PASS (AA)
+          // accent.brand 背景に対し fg.onBrand (Issue #408 で semantic token 化):
+          //   - light: fg.onBrand (cream-50) × accent.brand (persimmon-600) = 5.74:1 PASS (AA)
+          //   - dark : fg.onBrand (ink-900)  × accent.brand (persimmon-500) = 5.42:1 PASS (AA)
           // calculateContrast.ts の `cta/light` `cta/dark` ペアと同期させる。
           //
           // R-5 (Issue #393) AC i: accent.brand 背景上の CTA は
@@ -93,12 +93,7 @@ export const EmptyState = ({
               alignItems: "center",
               gap: "2",
               bg: "accent.brand",
-              // CTA 文字色は light=cream.50 / dark=ink.900 (calculateContrast.ts の
-              // cta/light: 5.74:1, cta/dark: 5.42:1 と同期)。
-              // TODO(R-2c+): fg.onBrand semantic token に置換予定
-              // (CTA 文字色を直書きせず semantic token に集約する。Button.tsx /
-              //  Link.tsx と表記を揃えており、将来一括で置換する想定。)
-              color: { _light: "cream.50", _dark: "ink.900" },
+              color: "fg.onBrand",
               px: "6",
               py: "3",
               borderRadius: "full",

--- a/src/components/common/__tests__/EmptyState.test.tsx
+++ b/src/components/common/__tests__/EmptyState.test.tsx
@@ -129,4 +129,23 @@ describe("EmptyState", () => {
       );
     });
   });
+
+  // ====================================================================
+  // Issue #408 fg.onBrand semantic token Tripwire
+  //
+  // CTA 文字色は primitive 直書きから fg.onBrand semantic token に集約済み。
+  // Panda 生成 class 名の `c_fg.onBrand` を Tripwire として固定し、
+  // primitive 直書き ({_light: cream.50, _dark: ink.900}) への退行を検出する。
+  // ====================================================================
+  describe("Issue #408 fg.onBrand 参照 (Tripwire)", () => {
+    it("CTA Link は fg.onBrand の color class を持つ", () => {
+      const action = {
+        label: "記事を作成",
+        href: "/posts/new",
+      };
+      render(<EmptyState {...defaultProps} action={action} />);
+      const actionLink = screen.getByRole("link", { name: "記事を作成" });
+      expect(actionLink.className).toMatch(/c_fg\.onBrand/);
+    });
+  });
 });

--- a/src/lib/__tests__/colorTokens.test.ts
+++ b/src/lib/__tests__/colorTokens.test.ts
@@ -320,6 +320,36 @@ describe("R-2a (Issue #388) で追加した semantic token", () => {
   });
 });
 
+describe("Issue #408 fg.onBrand semantic token", () => {
+  // CTA (accent.brand 背景) 上の文字色を集約する semantic token。
+  // Button.tsx / Link.tsx / EmptyState.tsx の primitive 直書きを置換。
+  it("fgOnBrand は light で cream-50 を指している", () => {
+    expect(semanticColorTokens.fgOnBrand.light).toBe(
+      oklchPrimitives.cream["50"],
+    );
+  });
+
+  it("fgOnBrand は dark で ink-900 を指している", () => {
+    expect(semanticColorTokens.fgOnBrand.dark).toBe(oklchPrimitives.ink["900"]);
+  });
+
+  it("fgOnBrand × accentBrand (light) が AA 4.5:1 以上である (cta/light: 5.74:1)", () => {
+    const r = ratio(
+      semanticColorTokens.fgOnBrand.light,
+      semanticColorTokens.accentBrand.light,
+    );
+    expect(r).toBeGreaterThanOrEqual(contrastThresholds.largeText);
+  });
+
+  it("fgOnBrand × accentBrand (dark) が AA 4.5:1 以上である (cta/dark: 5.42:1)", () => {
+    const r = ratio(
+      semanticColorTokens.fgOnBrand.dark,
+      semanticColorTokens.accentBrand.dark,
+    );
+    expect(r).toBeGreaterThanOrEqual(contrastThresholds.largeText);
+  });
+});
+
 describe("コードブロック token (旧パレット温存の Tripwire)", () => {
   // Editorial Citrus 移行後もコードブロックは従来配色を温存する方針
   // (RFC 02 §既存 Gruvbox の取り扱い)。

--- a/src/lib/__tests__/lintTokens.test.ts
+++ b/src/lib/__tests__/lintTokens.test.ts
@@ -123,6 +123,28 @@ describe("lint:tokens (scripts/lintTokens.ts)", () => {
       expect(result.stderr).toContain("old-gruvbox-token");
     });
 
+    it('{ _light: "cream.50", _dark: "ink.900" } の primitive ペアを検出する (Issue #408)', () => {
+      writeTmpFile(
+        "violation.tsx",
+        'const c = css({ color: { _light: "cream.50", _dark: "ink.900" } });\n',
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("primitive-pair-cream-ink-fg-on-brand");
+    });
+
+    it('{ _dark: "ink.900", _light: "cream.50" } の primitive ペア (key 順違い) を検出する (Issue #408)', () => {
+      writeTmpFile(
+        "violation.tsx",
+        'const c = css({ color: { _dark: "ink.900", _light: "cream.50" } });\n',
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "primitive-pair-cream-ink-fg-on-brand-reversed",
+      );
+    });
+
     it(".test.ts ファイルは検査対象外で違反検出されない", () => {
       writeTmpFile(
         "violation.test.ts",

--- a/src/lib/colorTokens.ts
+++ b/src/lib/colorTokens.ts
@@ -155,6 +155,23 @@ export interface SemanticColorTokens {
   readonly fgSecondary: SemanticColorPair;
   /** 注釈・補助 */
   readonly fgMuted: SemanticColorPair;
+  /**
+   * CTA (accent.brand 背景) 上の文字色 (Issue #408 で追加)
+   *
+   * Button.tsx (primary variant) / Link.tsx (button variant) /
+   * EmptyState.tsx の CTA Link で使用していた primitive 直書き
+   * (`{_light: "cream.50", _dark: "ink.900"}`) を semantic token として集約。
+   *
+   * **使用ルール (重要)**:
+   *   - 必ず accent.brand 背景上で使うこと。bg.canvas / surface 上では
+   *     light の cream-50 が背景に同化するため使用不可。
+   *   - hover/focus でブランド背景を維持する場合に文字色も同期させること。
+   *
+   * **WCAG コントラスト (scripts/calculateContrast.ts cta/* ペアと同期)**:
+   *   - light (cream-50 × persimmon-600): 5.74:1 PASS (AA)
+   *   - dark  (ink-900   × persimmon-500): 5.42:1 PASS (AA)
+   */
+  readonly fgOnBrand: SemanticColorPair;
   /** ブランド色 (CTA) */
   readonly accentBrand: SemanticColorPair;
   /**
@@ -235,6 +252,10 @@ export const semanticColorTokens: SemanticColorTokens = {
   fgMuted: {
     light: oklchPrimitives.sumi["600"],
     dark: oklchPrimitives.bone["100"],
+  },
+  fgOnBrand: {
+    light: oklchPrimitives.cream["50"],
+    dark: oklchPrimitives.ink["900"],
   },
   accentBrand: {
     light: oklchPrimitives.persimmon["600"],

--- a/src/lib/colorTokens.ts
+++ b/src/lib/colorTokens.ts
@@ -149,7 +149,11 @@ export interface SemanticColorTokens {
   readonly bgSurface: SemanticColorPair;
   /** 浮き上がる要素 (モーダル / トースト) */
   readonly bgElevated: SemanticColorPair;
-  /** 本文前景 */
+  /**
+   * 本文前景
+   *
+   * @see fgOnBrand - CTA 文字色 (accent.brand 背景上) は fg.primary ではなく fg.onBrand を使用
+   */
   readonly fgPrimary: SemanticColorPair;
   /** メタ / キャプション */
   readonly fgSecondary: SemanticColorPair;
@@ -166,6 +170,11 @@ export interface SemanticColorTokens {
    *   - 必ず accent.brand 背景上で使うこと。bg.canvas / surface 上では
    *     light の cream-50 が背景に同化するため使用不可。
    *   - hover/focus でブランド背景を維持する場合に文字色も同期させること。
+   *
+   * **誤用パターン**:
+   *   - bg.canvas (light: cream-50) 上で使うと cream-50 × cream-50 = 1.0:1 で完全不可視
+   *   - bg.surface 上では light cream-100 と cream-50 で 1.06:1 で実質不可視
+   *   - accent.featured 上で使う場合は Phase 2 で分離検証してから (現状は accent.brand と同値で OK)
    *
    * **WCAG コントラスト (scripts/calculateContrast.ts cta/* ペアと同期)**:
    *   - light (cream-50 × persimmon-600): 5.74:1 PASS (AA)


### PR DESCRIPTION
## 概要

CTA (`accent.brand` 背景) の文字色 `{_light: "cream.50", _dark: "ink.900"}` が
`Button.tsx (primary variant)` / `Link.tsx (button variant)` /
`EmptyState.tsx (CTA Link)` の **3 箇所で primitive 直書き** されていた。
Issue #408 は、これを `fg.onBrand` semantic token に集約してリファクタする。

将来 CTA 文字色を変える際の修正点を 1 箇所に集約し、primitive 直書きの再導入を
Tripwire テストで検出できる状態にする。

Closes #408
Refs #407 (epic)

### スコープ

本 PR の対象は **`accent.brand` 背景上の CTA 文字色 3 箇所のみ** (`Button.tsx`
primary variant / `Link.tsx` button variant / `EmptyState.tsx` CTA Link)。

`src/components/common/ThemeToggle.tsx` の thumb 背景上 icon 色 (`{_light:
"ink.900", _dark: "cream.50"}` および `{_light: "cream.50", _dark: "ink.900"}`)
は **別コンテキスト (thumb 背景) のため `fg.onBrand` 不適用**、本 PR 対象外。
ThemeToggle は `accent.brand` 背景上ではなく thumb (light: ink.900 / dark:
cream.50) 背景上の icon 色を扱っており、`fg.onBrand` の使用ルール (必ず
accent.brand 背景上で使うこと) に反するため意図的に除外する。

`scripts/lintTokens.ts` の `EXCLUDED_FILE_SUFFIXES` で ThemeToggle.tsx を
許可リストに追加して、Tripwire の検出から除外している。

## 変更内容

- `panda.config.ts`: `theme.extend.semanticTokens.colors.fg` に `onBrand` を追加。
  値は `light: cream.50` / `dark: ink.900`。Panda 制約により値は
  `src/lib/colorTokens.ts` とリテラル一致させる。
- `src/lib/colorTokens.ts`: `SemanticColorTokens` に `fgOnBrand` を追加し、
  使用ガイド (accent.brand 背景前提、bg.canvas/surface 上では使用不可) と
  WCAG コントラスト値 (light 5.74:1 / dark 5.42:1) を JSDoc に明記。
  `誤用パターン` (bg.canvas / bg.surface / accent.featured) の具体例も追加。
  `fgPrimary` の JSDoc に `@see fgOnBrand` の相互参照を追加。
- `src/components/atoms/Button.tsx`: primary variant の `color` を
  `"fg.onBrand"` に置換。`TODO(R-2c+)` コメントを削除し、バリアントヘッダの
  コントラスト記述を `fg.onBrand` 経由に更新。
- `src/components/atoms/Link.tsx`: button variant の `color` を
  `"fg.onBrand"` に置換。`TODO(R-2c+)` コメントを削除。
- `src/components/common/EmptyState.tsx`: CTA Link の `color` を
  `"fg.onBrand"` に置換。`TODO(R-2c+)` コメントを削除し、Button/Link との
  コメント表記を揃える。
- `scripts/calculateContrast.ts`: semantic 層に
  `fg.onBrand × accent.brand` の light/dark ペアを追加。
  primitive 層 `cta/light` `cta/dark` との同期が崩れた瞬間に検出できる。
  さらに `fg.onBrand × accent.featured` の light/dark ペアも追加し、
  Phase 2 で `accent.featured` を `accent.brand` から分離した瞬間に
  Tripwire が連動する状態にする (現状は同値のため AA 値も同一)。
- `scripts/lintTokens.ts`: primitive 直書きペア
  `{ _light: "cream.50", _dark: "ink.900" }` および
  `{ _dark: "ink.900", _light: "cream.50" }` (key 順違い) を検出する
  パターンを `LINT_PATTERNS` に追加。`fg.onBrand` への移行漏れを CI で検出。
  `EXCLUDED_FILE_SUFFIXES` に `src/components/common/ThemeToggle.tsx` と
  `src/lib/colorTokens.ts` を追加 (前者は別コンテキスト、後者は token 定義の
  単一ソースで JSDoc が文字列パターンを含むため除外)。
- `.github/workflows/ci.yml`: `pnpm contrast:check` step を追加 (lint:tokens
  の直後)。AAA / AA を満たさないペアが入った瞬間に CI で fail する。
- `src/lib/__tests__/colorTokens.test.ts`: `Issue #408` describe を新設し、
  `fgOnBrand` の primitive 値対応 + AA 4.5:1 (light/dark 両方) を Tripwire で固定。
- `src/lib/__tests__/lintTokens.test.ts`: 新規 primitive ペア検出 2 ケース
  (key 順 2 通り) を追加。
- `src/components/atoms/__tests__/Button.test.tsx`: primary variant に
  `c_fg.onBrand` class 名の Tripwire を追加。
- `src/components/atoms/__tests__/Link.test.tsx`: button variant に
  `c_fg.onBrand` class 名の Tripwire を追加。
- `src/components/common/__tests__/EmptyState.test.tsx`: CTA Link に
  `c_fg.onBrand` class 名の Tripwire を別 describe で追加。

## 備考

- `pnpm test:run`: 38 files / 458 tests pass (lintTokens.test.ts 新規 2 ケース込み)。
- `pnpm lint`: 91 files clean。
- `pnpm build`: success。
- `pnpm contrast:check`: 32/32 OK (新規 `fg.onBrand × accent.brand` ペアは
  light 5.74:1 / dark 5.42:1 で Issue 受け入れ基準と一致。
  `fg.onBrand × accent.featured` も同値 5.74:1 / 5.42:1)。
- `pnpm lint:tokens`: 52 files clean、旧 token 参照および primitive 直書き
  ペアの再導入なし。