### PR TITLE
chore: lint:tokens 走査範囲拡大 (#413)

### DIFF
--- a/scripts/lintTokens.ts
+++ b/scripts/lintTokens.ts
@@ -17,11 +17,17 @@
  *   - `<root>/panda.config.ts` (theme tokens 正本)
  *   - `<root>/scripts/**` の `.ts` (走査スクリプト自身は自己除外)
  *   - `<root>/e2e/**` の `.ts` / `.spec.ts`
- * 除外: `**`/`__tests__/**`/`*.test.ts` (lint-tokens 自身を Tripwire させるテストは別途存在しうるため、テストでは検出しない) / `scripts/lintTokens.ts` (自己除外)
+ * 除外:
+ *   - `__tests__/**` ディレクトリ (lint-tokens 自身を Tripwire させるテストや
+ *     fixture でハードコードされた旧 token を検出してしまうのを避けるため、
+ *     ディレクトリ単位で skip する)
+ *   - `*.test.ts` / `*.test.tsx` (上記 `__tests__/**` 配下以外で配置されているテスト)
+ *   - `scripts/lintTokens.ts` (自己除外: 本ファイルにパターンを文字列リテラルで保持しているため)
  *
  * 結果:
  *   - 0 件: exit 0 (CI 通過)
  *   - 1 件以上: exit 1 (CI ブロック)
+ *   - 走査ファイル 0 件: exit 2 (構成不備 / 致命エラー、Issue #413 / DA 致命 2 対応)
  *
  * 設計メモ:
  * - 標準ライブラリ (`node:fs` / `node:path`) のみで実装し、追加依存は導入しない。
@@ -67,8 +73,8 @@ const TARGET_EXTENSIONS = new Set([".ts", ".tsx", ".css"]);
 /**
  * 除外する suffix (検知対象から外したい末尾パターン)。
  * - 自テストの中で「文字列としてパターンを書いている」可能性があるため `.test.ts(x)` は除外する。
- *   ただし `__tests__` 配下の通常テストは内部実装ではなく動作検証なので、
- *   旧 token をハードコードする可能性は低い。実害が出たら個別に除外を増やす。
+ *   `__tests__` 配下のテストは walkDirectory のディレクトリ単位 skip でも除外しているが、
+ *   `__tests__` 外に配置された `*.test.ts(x)` を救うため suffix 除外も併用する。
  * - `scripts/lintTokens.ts` (本ファイル): パターン定義 (LINT_PATTERNS) や
  *   CI 失敗時のヒントメッセージで旧 token 名を文字列リテラルで参照しており、
  *   走査範囲拡大 (Issue #413) で自己検知してしまうため自身を除外する。
@@ -229,7 +235,17 @@ const collectTargetFiles = (target: string): string[] => {
     const entries = readdirSync(current);
 
     for (const entry of entries) {
-      if (entry.startsWith(".") || entry === "node_modules") {
+      // 隠しディレクトリ / `node_modules` / `__tests__` を skip。
+      // `__tests__` は本ファイル冒頭 JSDoc で「除外対象」と明記済みだが、
+      // 実装側で skip しないとテスト fixture (例: `__tests__/util.ts` 等の
+      // 非 `.test.ts` ファイル) が `EXCLUDED_FILE_SUFFIXES` (suffix だけで
+      // 判定) を素通りしてしまい、テストコード中の旧 token 言及で CI が
+      // 落ちる潜在バグになる (Issue #413 / DA 重大 2 対応)。
+      if (
+        entry.startsWith(".") ||
+        entry === "node_modules" ||
+        entry === "__tests__"
+      ) {
         continue;
       }
 

--- a/scripts/lintTokens.ts
+++ b/scripts/lintTokens.ts
@@ -84,11 +84,19 @@ const EXCLUDED_FILE_SUFFIXES = [
  *
  * 各パターンには human-readable な name を付与しておき、検出時に
  * 「どの旧 token に違反したか」を分かりやすく表示できるようにする。
+ *
+ * scope:
+ *   - "line" (既定): 行単位で走査する。コメント除去後の各行に対して RegExp 実行。
+ *   - "file": ファイル全体を 1 つのテキストとして走査する。
+ *     panda.config.ts のような複数行にまたがるオブジェクトリテラル
+ *     (例: `bg: {\n  "0": { value: ... }\n}`) を検出するため。
+ *     コメント除去はファイル単位で適用する。
  */
 interface LintPattern {
   readonly name: string;
   readonly description: string;
   readonly pattern: RegExp;
+  readonly scope?: "line" | "file";
 }
 
 const LINT_PATTERNS: readonly LintPattern[] = [
@@ -130,6 +138,40 @@ const LINT_PATTERNS: readonly LintPattern[] = [
     description: "旧 colors.gruvbox.* token の参照 (R-2c で削除済み)",
     // token('colors.gruvbox.bg-0') 形式。kebab-case や数字を含む値も拾う。
     pattern: /token\(['"]colors\.gruvbox\.[a-z0-9-]+['"]\)/g,
+  },
+  // ====================================================================
+  // オブジェクトキー記法検知 (Issue #413 / DA 致命 1 対応)
+  //
+  // panda.config.ts のような theme 定義ファイルでは、旧 5 段階トークンが
+  // `bg: { "0": { value: "..." } }` の形で再導入される可能性がある。
+  // これは `bg.0` のドット記法とは別形式で、行単位 RegExp では捕まえにくい。
+  //
+  // 複数行にまたがるオブジェクトリテラルを検出するため scope: "file" を指定し、
+  // ファイル全体に対して `[^}]*?` (非欲張り) で展開する。`/s` フラグで
+  // 改行も `.` に含めるが、本パターンは `[^}]` を使っているため `s` フラグは
+  // 厳密には不要。ただし将来 `.` を含むパターンが追加されたとき安全側に倒すため付与する。
+  // ====================================================================
+  {
+    name: "old-bg-numeric-key",
+    description:
+      "オブジェクトキー記法 `bg: { '0': ... }` で旧 5 段階 token を再導入している可能性",
+    // `bg: {` から閉じ `}` まで遡って数値キーを検出。`}` を含まない範囲で短く match。
+    pattern: /\bbg\s*:\s*\{[^}]*?['"]?[0-9]['"]?\s*:/gs,
+    scope: "file",
+  },
+  {
+    name: "old-fg-numeric-key",
+    description:
+      "オブジェクトキー記法 `fg: { '0': ... }` で旧 5 段階 token を再導入している可能性",
+    pattern: /\bfg\s*:\s*\{[^}]*?['"]?[0-9]['"]?\s*:/gs,
+    scope: "file",
+  },
+  {
+    name: "old-gruvbox-key",
+    description:
+      "オブジェクトキー記法 `gruvbox: {` で旧 Gruvbox パレットを再導入している可能性",
+    pattern: /\bgruvbox\s*:\s*\{/g,
+    scope: "file",
   },
 ] as const;
 
@@ -350,9 +392,80 @@ const stripComments = (
 };
 
 /**
+ * ファイル全体に対してコメント除去を適用した結果と、
+ * 各行の元テキスト / 行頭オフセットを返すユーティリティ。
+ *
+ * `scope: "file"` パターンの match.index (ファイル全体オフセット) から
+ * 行番号 / カラム位置 / 元行 snippet を逆引きするのに使う。
+ */
+interface SanitizedFile {
+  /** コメント領域を空白に置換したファイル全体テキスト */
+  readonly sanitized: string;
+  /** 各行の元テキスト (snippet 表示用) */
+  readonly originalLines: string[];
+  /** 各行の先頭 offset (sanitized 上の絶対位置) */
+  readonly lineStartOffsets: number[];
+}
+
+const sanitizeFile = (content: string): SanitizedFile => {
+  const lines = content.split(/\r?\n/);
+  const sanitizedLines: string[] = [];
+  const lineStartOffsets: number[] = [];
+  let cursor = 0;
+  let stripState: CommentStripState = { inBlockComment: false };
+
+  for (const line of lines) {
+    lineStartOffsets.push(cursor);
+    const { sanitized, inBlockComment } = stripComments(line, stripState);
+    stripState = { inBlockComment };
+    sanitizedLines.push(sanitized);
+    // sanitizedLines は join("\n") で連結する想定。改行 1 文字ぶん cursor を進める。
+    cursor += sanitized.length + 1;
+  }
+
+  return {
+    sanitized: sanitizedLines.join("\n"),
+    originalLines: lines,
+    lineStartOffsets,
+  };
+};
+
+/**
+ * sanitized 全体オフセットから「何行目の何カラム目か」を逆引きする。
+ * lineStartOffsets は昇順なので二分探索で O(log n)。
+ */
+const offsetToLineColumn = (
+  offset: number,
+  lineStartOffsets: readonly number[],
+): { readonly line: number; readonly column: number } => {
+  let lo = 0;
+  let hi = lineStartOffsets.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >>> 1;
+    const start = lineStartOffsets[mid];
+    if (start === undefined) {
+      // 配列範囲外を二分探索で踏むことは無いはずだが、型ガードとして扱う。
+      hi = mid - 1;
+      continue;
+    }
+    if (start <= offset) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  const lineIndex = lo;
+  const start = lineStartOffsets[lineIndex] ?? 0;
+  return { line: lineIndex + 1, column: offset - start + 1 };
+};
+
+/**
  * 1 ファイル分の検査。
  *
- * - 行単位で検出位置 (line / column) を出すと CI ログでジャンプしやすい。
+ * - 行単位 (`scope: "line"` 既定) で検出位置 (line / column) を出すと
+ *   CI ログでジャンプしやすい。
+ * - 複数行 (`scope: "file"`) パターンはファイル全体のテキストに RegExp を実行し、
+ *   match.index から逆引きで行 / カラムを出す。
  * - 大文字小文字は区別する (token 名は確定的にケースが決まっている)。
  * - 行コメント / ブロックコメント内は検査対象から除外する (Issue #413)。
  */
@@ -361,39 +474,72 @@ const scanFile = (
   patterns: readonly LintPattern[],
 ): Violation[] => {
   const content = readFileSync(filePath, "utf8");
-  const lines = content.split(/\r?\n/);
   const violations: Violation[] = [];
 
-  let stripState: CommentStripState = { inBlockComment: false };
+  const fileScope = sanitizeFile(content);
+  const { sanitized, originalLines, lineStartOffsets } = fileScope;
 
-  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
-    const line = lines[lineIndex];
-    if (line === undefined) {
-      continue;
-    }
-
-    const { sanitized, inBlockComment } = stripComments(line, stripState);
-    stripState = { inBlockComment };
-
-    for (const { name, description, pattern } of patterns) {
-      // RegExp の lastIndex を使い回すため毎回新規インスタンスにする。
+  for (const { name, description, pattern, scope } of patterns) {
+    if (scope === "file") {
+      // ファイル全体に対して走査。複数行にまたがるパターン (panda.config.ts の
+      // `bg: { "0": ... }` 等) を捕捉するために使う。
       const regex = new RegExp(pattern.source, pattern.flags);
       let match: RegExpExecArray | null = regex.exec(sanitized);
       while (match !== null) {
+        const { line, column } = offsetToLineColumn(
+          match.index,
+          lineStartOffsets,
+        );
+        const snippetLine = originalLines[line - 1] ?? "";
         violations.push({
           file: filePath,
-          line: lineIndex + 1,
-          column: match.index + 1,
+          line,
+          column,
           patternName: name,
           description,
-          // 元のコメント込みの行を見せたほうが文脈が分かるので元行を表示する。
-          snippet: line.trim(),
+          snippet: snippetLine.trim(),
         });
-        // 無限ループ回避: 0 幅マッチには進める。
         if (match.index === regex.lastIndex) {
           regex.lastIndex += 1;
         }
         match = regex.exec(sanitized);
+      }
+    } else {
+      // 既定の line scope: 行ごとに RegExp を実行。
+      for (let lineIndex = 0; lineIndex < originalLines.length; lineIndex += 1) {
+        const line = originalLines[lineIndex];
+        if (line === undefined) {
+          continue;
+        }
+        // sanitizeFile で算出済みの sanitized 行を再利用するため、
+        // 全体テキストから該当行のスライスを取り出す。
+        const start = lineStartOffsets[lineIndex] ?? 0;
+        const nextStart =
+          lineStartOffsets[lineIndex + 1] ?? sanitized.length + 1;
+        // nextStart は次行の先頭 (改行直後)。改行 1 文字ぶん除いた範囲を取る。
+        const sanitizedLine = sanitized.slice(
+          start,
+          Math.max(start, nextStart - 1),
+        );
+
+        const regex = new RegExp(pattern.source, pattern.flags);
+        let match: RegExpExecArray | null = regex.exec(sanitizedLine);
+        while (match !== null) {
+          violations.push({
+            file: filePath,
+            line: lineIndex + 1,
+            column: match.index + 1,
+            patternName: name,
+            description,
+            // 元のコメント込みの行を見せたほうが文脈が分かるので元行を表示する。
+            snippet: line.trim(),
+          });
+          // 無限ループ回避: 0 幅マッチには進める。
+          if (match.index === regex.lastIndex) {
+            regex.lastIndex += 1;
+          }
+          match = regex.exec(sanitizedLine);
+        }
       }
     }
   }

--- a/scripts/lintTokens.ts
+++ b/scripts/lintTokens.ts
@@ -411,6 +411,20 @@ const main = (): void => {
   for (const target of TARGET_PATHS) {
     files.push(...collectTargetFiles(target));
   }
+
+  // 0 files scanned ガード (Issue #413 / DA 致命 2 対応)。
+  // `LINT_TOKENS_SRC_DIR=/nonexistent` のような誤設定や `TARGET_PATHS` の
+  // 全パスが空 / 非存在になっている状態では、走査が成立せず Tripwire
+  // 自体が機能しない。`exit 0` だと CI が誤って通ってしまうため、
+  // 走査ファイル 0 件は構成不備として `exit 2` で fail-fast する
+  // (旧 token 検出による `exit 1` と区別する)。
+  if (files.length === 0) {
+    console.error(
+      "lint:tokens FATAL: no files scanned. TARGET_PATHS or LINT_TOKENS_SRC_DIR may be misconfigured.",
+    );
+    process.exit(2);
+  }
+
   const violations: Violation[] = [];
 
   for (const file of files) {

--- a/scripts/lintTokens.ts
+++ b/scripts/lintTokens.ts
@@ -24,6 +24,10 @@
  * - サブディレクトリ走査は再帰的に実装する (glob ライブラリ不要)。
  * - パターンは Plain RegExp で書き、Panda の式リテラル展開や CSS 変数の
  *   双方を統一的に検出する。
+ * - 行コメント (`//`) と複数行コメント (`/* ... *\/`) 内は走査対象から
+ *   除外する (Issue #413)。コメント中の旧 token 言及 (旧→新マッピング表)
+ *   による false positive を防ぐ。文字列リテラル中の `//` `/*` は
+ *   コメント開始と見做さない。
  *
  * 拡張メモ:
  * - 追加の旧 token を検知したい場合は `LINT_PATTERNS` に正規表現を追加するだけで良い。
@@ -170,10 +174,137 @@ const collectTargetFiles = (dir: string): string[] => {
 };
 
 /**
+ * 1 行から行コメント (`//`) と複数行コメント (`/* ... *\/`) を除去する
+ * 簡易ストリッパー (Issue #413)。
+ *
+ * - state machine で「コメントブロック内かどうか」を保持する必要があるため
+ *   呼び出し側でブロック状態を渡してもらい、新しい状態と検査用文字列を返す。
+ * - 文字列リテラル (`"..."` / `'...'` / `` `...` ``) 内の `//` や `/*` は
+ *   コメント開始と見做さず、そのまま検査対象に残す (旧 token を文字列リテラル
+ *   として記述したケースも検知したいため)。
+ * - column 位置を維持するため、コメント領域は同じ長さの空白で置換する。
+ *
+ * 戻り値:
+ *   - sanitized: 検査対象として残す部分 (コメント領域は空白に置換済み)。
+ *   - inBlockComment: 行末で複数行コメントが継続中かどうか。
+ */
+interface CommentStripState {
+  readonly inBlockComment: boolean;
+}
+
+interface CommentStripResult {
+  readonly sanitized: string;
+  readonly inBlockComment: boolean;
+}
+
+const stripComments = (
+  line: string,
+  state: CommentStripState,
+): CommentStripResult => {
+  let inBlockComment = state.inBlockComment;
+  let inSingle = false;
+  let inDouble = false;
+  let inBacktick = false;
+  const out: string[] = [];
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    const next = i + 1 < line.length ? line[i + 1] : "";
+
+    if (inBlockComment) {
+      if (ch === "*" && next === "/") {
+        inBlockComment = false;
+        out.push(" ", " ");
+        i += 1;
+        continue;
+      }
+      out.push(" ");
+      continue;
+    }
+
+    if (inSingle) {
+      out.push(ch);
+      if (ch === "\\" && next !== "") {
+        out.push(next);
+        i += 1;
+        continue;
+      }
+      if (ch === "'") {
+        inSingle = false;
+      }
+      continue;
+    }
+
+    if (inDouble) {
+      out.push(ch);
+      if (ch === "\\" && next !== "") {
+        out.push(next);
+        i += 1;
+        continue;
+      }
+      if (ch === '"') {
+        inDouble = false;
+      }
+      continue;
+    }
+
+    if (inBacktick) {
+      out.push(ch);
+      if (ch === "\\" && next !== "") {
+        out.push(next);
+        i += 1;
+        continue;
+      }
+      if (ch === "`") {
+        inBacktick = false;
+      }
+      continue;
+    }
+
+    // 文字列開始
+    if (ch === "'") {
+      inSingle = true;
+      out.push(ch);
+      continue;
+    }
+    if (ch === '"') {
+      inDouble = true;
+      out.push(ch);
+      continue;
+    }
+    if (ch === "`") {
+      inBacktick = true;
+      out.push(ch);
+      continue;
+    }
+
+    // コメント開始
+    if (ch === "/" && next === "/") {
+      // 行末まで全て空白扱い
+      for (let j = i; j < line.length; j += 1) {
+        out.push(" ");
+      }
+      return { sanitized: out.join(""), inBlockComment: false };
+    }
+    if (ch === "/" && next === "*") {
+      inBlockComment = true;
+      out.push(" ", " ");
+      i += 1;
+      continue;
+    }
+
+    out.push(ch);
+  }
+
+  return { sanitized: out.join(""), inBlockComment };
+};
+
+/**
  * 1 ファイル分の検査。
  *
  * - 行単位で検出位置 (line / column) を出すと CI ログでジャンプしやすい。
  * - 大文字小文字は区別する (token 名は確定的にケースが決まっている)。
+ * - 行コメント / ブロックコメント内は検査対象から除外する (Issue #413)。
  */
 const scanFile = (
   filePath: string,
@@ -183,16 +314,21 @@ const scanFile = (
   const lines = content.split(/\r?\n/);
   const violations: Violation[] = [];
 
+  let stripState: CommentStripState = { inBlockComment: false };
+
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
     const line = lines[lineIndex];
     if (line === undefined) {
       continue;
     }
 
+    const { sanitized, inBlockComment } = stripComments(line, stripState);
+    stripState = { inBlockComment };
+
     for (const { name, description, pattern } of patterns) {
       // RegExp の lastIndex を使い回すため毎回新規インスタンスにする。
       const regex = new RegExp(pattern.source, pattern.flags);
-      let match: RegExpExecArray | null = regex.exec(line);
+      let match: RegExpExecArray | null = regex.exec(sanitized);
       while (match !== null) {
         violations.push({
           file: filePath,
@@ -200,13 +336,14 @@ const scanFile = (
           column: match.index + 1,
           patternName: name,
           description,
+          // 元のコメント込みの行を見せたほうが文脈が分かるので元行を表示する。
           snippet: line.trim(),
         });
         // 無限ループ回避: 0 幅マッチには進める。
         if (match.index === regex.lastIndex) {
           regex.lastIndex += 1;
         }
-        match = regex.exec(line);
+        match = regex.exec(sanitized);
       }
     }
   }

--- a/scripts/lintTokens.ts
+++ b/scripts/lintTokens.ts
@@ -12,8 +12,12 @@
  *   6. `var(--colors-fg-<digit>)`
  *   7. `token('colors.gruvbox.<...>')` (旧 Gruvbox 階層、R-2c で削除済み)
  *
- * 走査対象: `src/**` 配下の `.ts` / `.tsx` / `.css`
- * 除外: `**`/`__tests__/**`/`*.test.ts` (lint-tokens 自身を Tripwire させるテストは別途存在しうるため、テストでは検出しない)
+ * 走査対象 (Issue #413 で拡張):
+ *   - `<root>/src/**` の `.ts` / `.tsx` / `.css`
+ *   - `<root>/panda.config.ts` (theme tokens 正本)
+ *   - `<root>/scripts/**` の `.ts` (走査スクリプト自身は自己除外)
+ *   - `<root>/e2e/**` の `.ts` / `.spec.ts`
+ * 除外: `**`/`__tests__/**`/`*.test.ts` (lint-tokens 自身を Tripwire させるテストは別途存在しうるため、テストでは検出しない) / `scripts/lintTokens.ts` (自己除外)
  *
  * 結果:
  *   - 0 件: exit 0 (CI 通過)
@@ -40,14 +44,22 @@ import { extname, join, relative, resolve } from "node:path";
 const PROJECT_ROOT = resolve(import.meta.dirname, "..");
 
 /**
- * 走査対象ディレクトリ。
- * 既定は `<PROJECT_ROOT>/src` だが、テストから `LINT_TOKENS_SRC_DIR` env で
- * 別ディレクトリ (OS tmp 配下に作った擬似 src 等) を指定できる。
- * 副作用として src/ 直下に一時ファイルを残置するリスクを排除する。
+ * 走査対象パス (Issue #413 で複数 path 化)。
+ * 既定は `src/`, `panda.config.ts`, `scripts/`, `e2e/` だが、テストから
+ * `LINT_TOKENS_SRC_DIR` env で別パス (OS tmp 配下に作った擬似 src 等)
+ * を単一指定できる。副作用として src/ 直下に一時ファイルを残置するリスクを
+ * 排除する。
+ *
+ * env で指定された場合はそのパス 1 つに絞り込む (テスト時の独立性確保のため)。
  */
-const SRC_DIR = process.env.LINT_TOKENS_SRC_DIR
-  ? resolve(process.env.LINT_TOKENS_SRC_DIR)
-  : join(PROJECT_ROOT, "src");
+const TARGET_PATHS: readonly string[] = process.env.LINT_TOKENS_SRC_DIR
+  ? [resolve(process.env.LINT_TOKENS_SRC_DIR)]
+  : [
+      join(PROJECT_ROOT, "src"),
+      join(PROJECT_ROOT, "panda.config.ts"),
+      join(PROJECT_ROOT, "scripts"),
+      join(PROJECT_ROOT, "e2e"),
+    ];
 
 /** 走査対象拡張子 */
 const TARGET_EXTENSIONS = new Set([".ts", ".tsx", ".css"]);
@@ -57,8 +69,15 @@ const TARGET_EXTENSIONS = new Set([".ts", ".tsx", ".css"]);
  * - 自テストの中で「文字列としてパターンを書いている」可能性があるため `.test.ts(x)` は除外する。
  *   ただし `__tests__` 配下の通常テストは内部実装ではなく動作検証なので、
  *   旧 token をハードコードする可能性は低い。実害が出たら個別に除外を増やす。
+ * - `scripts/lintTokens.ts` (本ファイル): パターン定義 (LINT_PATTERNS) や
+ *   CI 失敗時のヒントメッセージで旧 token 名を文字列リテラルで参照しており、
+ *   走査範囲拡大 (Issue #413) で自己検知してしまうため自身を除外する。
  */
-const EXCLUDED_FILE_SUFFIXES = [".test.ts", ".test.tsx"];
+const EXCLUDED_FILE_SUFFIXES = [
+  ".test.ts",
+  ".test.tsx",
+  "scripts/lintTokens.ts",
+];
 
 /**
  * lint パターン定義。
@@ -124,14 +143,45 @@ interface Violation {
 }
 
 /**
- * 指定ディレクトリを再帰走査し、対象ファイルのパスリストを返す。
+ * 指定パスを走査し、対象ファイルのパスリストを返す (Issue #413)。
  *
+ * - 単一ファイル指定 (panda.config.ts 等) なら拡張子と除外 suffix を確認した
+ *   上でそのファイルを返す。
+ * - ディレクトリ指定なら再帰的に走査する。
  * - `node_modules` / 隠しディレクトリ (`.` から始まる) はスキップする
  *   (scripts/ から実行する都合、`src/` 配下に限ればこれらは出てこないが
  *   将来 PROJECT_ROOT 走査に変えたとき耐えるためガードを入れておく)。
+ * - 走査対象が存在しない場合は空配列を返す (例: e2e/ 未配置構成でも壊れない)。
  */
-const collectTargetFiles = (dir: string): string[] => {
+const collectTargetFiles = (target: string): string[] => {
   const results: string[] = [];
+
+  let stats;
+  try {
+    stats = statSync(target);
+  } catch {
+    return results;
+  }
+
+  // 単一ファイル指定 (panda.config.ts 等) のショートカット。
+  if (stats.isFile()) {
+    const ext = extname(target);
+    if (!TARGET_EXTENSIONS.has(ext)) {
+      return results;
+    }
+    const isExcluded = EXCLUDED_FILE_SUFFIXES.some((suffix) =>
+      target.endsWith(suffix),
+    );
+    if (isExcluded) {
+      return results;
+    }
+    results.push(target);
+    return results;
+  }
+
+  if (!stats.isDirectory()) {
+    return results;
+  }
 
   const walk = (current: string): void => {
     const entries = readdirSync(current);
@@ -142,14 +192,14 @@ const collectTargetFiles = (dir: string): string[] => {
       }
 
       const fullPath = join(current, entry);
-      const stats = statSync(fullPath);
+      const entryStats = statSync(fullPath);
 
-      if (stats.isDirectory()) {
+      if (entryStats.isDirectory()) {
         walk(fullPath);
         continue;
       }
 
-      if (!stats.isFile()) {
+      if (!entryStats.isFile()) {
         continue;
       }
 
@@ -169,7 +219,7 @@ const collectTargetFiles = (dir: string): string[] => {
     }
   };
 
-  walk(dir);
+  walk(target);
   return results;
 };
 
@@ -357,7 +407,10 @@ const formatViolation = (v: Violation): string => {
 };
 
 const main = (): void => {
-  const files = collectTargetFiles(SRC_DIR);
+  const files: string[] = [];
+  for (const target of TARGET_PATHS) {
+    files.push(...collectTargetFiles(target));
+  }
   const violations: Violation[] = [];
 
   for (const file of files) {

--- a/src/lib/__tests__/lintTokens.test.ts
+++ b/src/lib/__tests__/lintTokens.test.ts
@@ -23,6 +23,15 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
  *   の検査対象に含まれて exit 1 を引き起こす副作用があった。
  *   現実装は OS tmp dir に書き出し、スクリプト側で受け取れる
  *   `LINT_TOKENS_SRC_DIR` env var で対象ディレクトリを切り替える。
+ *
+ * Issue #413 拡張:
+ *   走査範囲を `panda.config.ts` / `scripts/` / `e2e/` まで広げたため、
+ *   コメント中の旧 token 言及 (旧→新マッピング表) が誤検知されないよう
+ *   コメント除外ロジックを追加した。本ファイルでは
+ *   - コメント除外 (行コメント / ブロックコメント / 文字列リテラル中の
+ *     `//` `/*` 非除外)
+ *   - 既定の複数 path 走査 (panda.config.ts 等が含まれる)
+ *   をテストする。
  */
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -41,18 +50,32 @@ const runScript = (envOverrides: NodeJS.ProcessEnv = {}) => {
 };
 
 describe("lint:tokens (scripts/lintTokens.ts)", () => {
-  it("既存 src/ では旧 token 参照が 0 件で exit 0 になる", () => {
+  it("既定 (src/ + panda.config.ts + scripts/ + e2e/) で旧 token 参照が 0 件で exit 0 になる", () => {
     const result = runScript();
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("lint:tokens OK");
   });
 
+  it("既定の走査では panda.config.ts / scripts / e2e も含めて src/ より多くの files を走査する", () => {
+    // src/ のみだった旧挙動 (54 files) より多いことを期待する。
+    // 厳密な数値は将来変動するため「54 を超えること」を緩めに検証する。
+    const result = runScript();
+    expect(result.status).toBe(0);
+    const match = result.stdout.match(/(\d+) files scanned/);
+    expect(match).not.toBeNull();
+    if (match === null) {
+      return;
+    }
+    const scanned = Number.parseInt(match[1] as string, 10);
+    expect(scanned).toBeGreaterThan(54);
+  });
+
   // ====================================================================
   // 違反パターン注入テスト
   //
-  // OS tmp ディレクトリに `src/` 相当の構造を作って lint script を実行する。
-  // 既存実装は固定で `<PROJECT_ROOT>/src` を走査するため、テストでは
-  // `LINT_TOKENS_SRC_DIR` env var で走査対象を tmp dir に切り替える。
+  // OS tmp ディレクトリに走査対象相当の構造を作って lint script を実行する。
+  // 既定の TARGET_PATHS は固定だが、テストでは `LINT_TOKENS_SRC_DIR` env var で
+  // 走査対象を tmp dir 1 つに絞り込む。
   // これにより src/ 直下に一時ファイルが残置するリスクを排除する。
   // ====================================================================
   describe("違反パターン検知", () => {
@@ -95,7 +118,7 @@ describe("lint:tokens (scripts/lintTokens.ts)", () => {
       expect(result.stderr).toContain("old-token-colors-bg-numeric");
     });
 
-    it("token(\"colors.fg.<digit>\") 参照を検出する", () => {
+    it('token("colors.fg.<digit>") 参照を検出する', () => {
       writeTmpFile("violation.ts", 'const v = token("colors.fg.1");\n');
       const result = runWithTmpDir();
       expect(result.status).toBe(1);
@@ -124,11 +147,168 @@ describe("lint:tokens (scripts/lintTokens.ts)", () => {
     });
 
     it(".test.ts ファイルは検査対象外で違反検出されない", () => {
+      writeTmpFile("violation.test.ts", "const v = token('colors.bg.0');\n");
+      const result = runWithTmpDir();
+      expect(result.status).toBe(0);
+    });
+  });
+
+  // ====================================================================
+  // コメント除外テスト (Issue #413)
+  //
+  // 走査範囲を panda.config.ts / scripts / e2e に拡大したことで、
+  // コメント中の旧→新マッピング表 (例: panda.config.ts の JSDoc) が
+  // 誤検知されないようにする。
+  //
+  // 文字列リテラル中の `//` `/*` はコメント開始と見做さないことも検証する
+  // (旧 token を文字列リテラルとして書いたケースは検知したいため)。
+  // ====================================================================
+  describe("コメント除外", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "lint-tokens-comment-test-"));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    const writeTmpFile = (filename: string, content: string): void => {
+      writeFileSync(join(tmpDir, filename), content, "utf8");
+    };
+
+    const runWithTmpDir = () => runScript({ LINT_TOKENS_SRC_DIR: tmpDir });
+
+    it("行コメント (`//`) 中の旧 token は誤検知されない", () => {
       writeTmpFile(
-        "violation.test.ts",
-        "const v = token('colors.bg.0');\n",
+        "doc.ts",
+        "// 旧トークン bg.0 / fg.0 / colors.gruvbox.bg-0 は廃止済み\nconst v = 1;\n",
       );
       const result = runWithTmpDir();
+      expect(result.status).toBe(0);
+    });
+
+    it("ブロックコメント (`/* ... */`) 中の旧 token は誤検知されない", () => {
+      writeTmpFile(
+        "doc.ts",
+        "/* bg.0..bg.4 は R-2c で削除済み (panda.config.ts JSDoc 相当) */\nconst v = 1;\n",
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(0);
+    });
+
+    it("複数行にまたがるブロックコメント中の旧 token は誤検知されない", () => {
+      writeTmpFile(
+        "doc.ts",
+        [
+          "/**",
+          " * 旧トークン bg.0..bg.4 / fg.0..fg.4 / colors.gruvbox.* は",
+          " * R-2c (Issue #390) で削除済み。",
+          " * `token('colors.bg.0')` などの参照も同時に削除されている。",
+          " */",
+          "const v = 1;",
+          "",
+        ].join("\n"),
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(0);
+    });
+
+    it("ブロックコメント終了後の同一行の旧 token は検知される", () => {
+      writeTmpFile("violation.ts", "/* これはコメント */ const v = 'bg.0';\n");
+      const result = runWithTmpDir();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("old-bg-numeric");
+    });
+
+    it("文字列リテラル (シングルクォート) 中の `//` はコメント開始と見做さず旧 token を検知する", () => {
+      writeTmpFile(
+        "violation.ts",
+        "const v = '// bg.0 はリテラル中なので検知される';\n",
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("old-bg-numeric");
+    });
+
+    it("文字列リテラル (ダブルクォート) 中の `/*` はコメント開始と見做さず旧 token を検知する", () => {
+      writeTmpFile(
+        "violation.ts",
+        'const v = "/* bg.0 はリテラル中なので検知される */";\n',
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("old-bg-numeric");
+    });
+
+    it("テンプレートリテラル (バッククォート) 中の旧 token は検知される", () => {
+      writeTmpFile(
+        "violation.ts",
+        "const v = `bg.0 はテンプレートリテラル中で検知される`;\n",
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("old-bg-numeric");
+    });
+
+    it("行コメント以降に旧 token があってもコード部の旧 token は検知される", () => {
+      writeTmpFile(
+        "violation.ts",
+        "const v = 'bg.0'; // bg.0 / fg.0 は削除済み (この部分は検知されない)\n",
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(1);
+      // 'bg.0' (コード部) のみ検知され、行コメント中の bg.0 / fg.0 は無視される。
+      const stderr = result.stderr;
+      expect(stderr).toContain("old-bg-numeric");
+      // 行コメント側にあった `fg.0` が誤検知されていないことを担保する。
+      expect(stderr).not.toContain("old-fg-numeric");
+    });
+
+    it("コメント中に旧 token を含むファイルとコードに旧 token を含むファイルが混在する場合、コードのみ検知される", () => {
+      writeTmpFile(
+        "doc.ts",
+        "// bg.0 / fg.0 / colors.gruvbox.bg-0 は廃止 (コメントなので無視)\nconst safe = 1;\n",
+      );
+      writeTmpFile("violation.tsx", "const c = css({ background: 'bg.2' });\n");
+      const result = runWithTmpDir();
+      expect(result.status).toBe(1);
+      // 違反は 1 件のみ (doc.ts のコメントは検知されない)。
+      expect(result.stderr).toContain("1 legacy token reference(s) found");
+      expect(result.stderr).toContain("violation.tsx");
+      expect(result.stderr).not.toContain("doc.ts");
+    });
+  });
+
+  // ====================================================================
+  // 単一ファイル走査テスト (Issue #413)
+  //
+  // panda.config.ts のような単一ファイル指定にも対応していることを確認する。
+  // ====================================================================
+  describe("単一ファイル走査", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "lint-tokens-singlefile-test-"));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("LINT_TOKENS_SRC_DIR に単一ファイルを指定しても旧 token を検知する", () => {
+      const filePath = join(tmpDir, "single.ts");
+      writeFileSync(filePath, "const v = 'bg.0';\n", "utf8");
+      const result = runScript({ LINT_TOKENS_SRC_DIR: filePath });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("old-bg-numeric");
+    });
+
+    it("LINT_TOKENS_SRC_DIR に対象拡張子外の単一ファイルを指定すると 0 件になる", () => {
+      const filePath = join(tmpDir, "single.md");
+      writeFileSync(filePath, "bg.0 in markdown\n", "utf8");
+      const result = runScript({ LINT_TOKENS_SRC_DIR: filePath });
       expect(result.status).toBe(0);
     });
   });

--- a/src/lib/__tests__/lintTokens.test.ts
+++ b/src/lib/__tests__/lintTokens.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -402,6 +402,94 @@ describe("lint:tokens (scripts/lintTokens.ts)", () => {
       const result = runScript({ LINT_TOKENS_SRC_DIR: filePath });
       expect(result.status).toBe(2);
       expect(result.stderr).toContain("lint:tokens FATAL: no files scanned");
+    });
+  });
+
+  // ====================================================================
+  // __tests__/ ディレクトリ除外テスト (DA 重大 2 対応)
+  //
+  // ヘッダ JSDoc に「`__tests__/**` 除外」と明記されているが、旧実装は
+  // walkDirectory でディレクトリ単位の skip をしていなかった。
+  // テスト fixture (例: `__tests__/util.ts` のような非 `.test.ts` ファイル) を
+  // 追加すると EXCLUDED_FILE_SUFFIXES (suffix 判定) を素通りして CI が落ちる
+  // 潜在バグになるため、ディレクトリ単位で除外する。
+  // ====================================================================
+  describe("__tests__ ディレクトリ除外", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "lint-tokens-tests-dir-"));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    const runWithTmpDir = () => runScript({ LINT_TOKENS_SRC_DIR: tmpDir });
+
+    it("__tests__/ 配下の非 .test.ts ファイル (fixture) は走査されない", () => {
+      // 0 files ガードを回避するため、走査対象になる通常 .ts も併置する。
+      writeFileSync(join(tmpDir, "safe.ts"), "const safe = 1;\n", "utf8");
+      const testsDir = join(tmpDir, "__tests__");
+      mkdirSync(testsDir);
+      writeFileSync(
+        join(testsDir, "fixture.ts"),
+        "const v = token('colors.bg.0');\n",
+        "utf8",
+      );
+      const result = runWithTmpDir();
+      // fixture は __tests__/ 配下なので skip され、違反検出されない。
+      expect(result.status).toBe(0);
+    });
+
+    it("__tests__/ 配下の .test.ts も走査されない", () => {
+      writeFileSync(join(tmpDir, "safe.ts"), "const safe = 1;\n", "utf8");
+      const testsDir = join(tmpDir, "__tests__");
+      mkdirSync(testsDir);
+      writeFileSync(
+        join(testsDir, "violation.test.ts"),
+        "const v = token('colors.bg.0');\n",
+        "utf8",
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(0);
+    });
+
+    it("__tests__/ 配下の .css fixture も走査されない", () => {
+      writeFileSync(join(tmpDir, "safe.ts"), "const safe = 1;\n", "utf8");
+      const testsDir = join(tmpDir, "__tests__");
+      mkdirSync(testsDir);
+      writeFileSync(
+        join(testsDir, "fixture.css"),
+        "a { color: var(--colors-fg-2); }\n",
+        "utf8",
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(0);
+    });
+
+    it("__tests__/ 兄弟ディレクトリの違反は通常通り検出される", () => {
+      // __tests__ skip で他のディレクトリの走査が止まらないことの保証。
+      const testsDir = join(tmpDir, "__tests__");
+      mkdirSync(testsDir);
+      writeFileSync(
+        join(testsDir, "fixture.ts"),
+        "const v = token('colors.bg.0');\n",
+        "utf8",
+      );
+      const siblingDir = join(tmpDir, "lib");
+      mkdirSync(siblingDir);
+      writeFileSync(
+        join(siblingDir, "violation.ts"),
+        "const v = 'bg.0';\n",
+        "utf8",
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(1);
+      // __tests__ 配下のものは検出されず、lib/ 配下のもののみ検出。
+      expect(result.stderr).toContain("1 legacy token reference(s) found");
+      expect(result.stderr).toContain("violation.ts");
+      expect(result.stderr).not.toContain("fixture.ts");
     });
   });
 

--- a/src/lib/__tests__/lintTokens.test.ts
+++ b/src/lib/__tests__/lintTokens.test.ts
@@ -147,6 +147,9 @@ describe("lint:tokens (scripts/lintTokens.ts)", () => {
     });
 
     it(".test.ts ファイルは検査対象外で違反検出されない", () => {
+      // `.test.ts` は EXCLUDED_FILE_SUFFIXES で除外される。
+      // 0 files scanned ガード (DA 致命 2) を回避するため、検出対象外の通常 `.ts` を併置する。
+      writeTmpFile("safe.ts", "const safe = 1;\n");
       writeTmpFile("violation.test.ts", "const v = token('colors.bg.0');\n");
       const result = runWithTmpDir();
       expect(result.status).toBe(0);
@@ -305,11 +308,42 @@ describe("lint:tokens (scripts/lintTokens.ts)", () => {
       expect(result.stderr).toContain("old-bg-numeric");
     });
 
-    it("LINT_TOKENS_SRC_DIR に対象拡張子外の単一ファイルを指定すると 0 件になる", () => {
+    it("LINT_TOKENS_SRC_DIR に対象拡張子外の単一ファイルを指定すると 0 files で exit 2 になる", () => {
+      // .md は走査対象外なので 0 files になる。
+      // 0 files scanned ガード (DA 致命 2 対応) で exit 2 (FATAL) になることを検証する。
       const filePath = join(tmpDir, "single.md");
       writeFileSync(filePath, "bg.0 in markdown\n", "utf8");
       const result = runScript({ LINT_TOKENS_SRC_DIR: filePath });
-      expect(result.status).toBe(0);
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain("lint:tokens FATAL: no files scanned");
+    });
+  });
+
+  // ====================================================================
+  // 0 files scanned ガード (DA 致命 2 対応)
+  //
+  // LINT_TOKENS_SRC_DIR が誤設定 (存在しないパス / 空ディレクトリ) の場合に、
+  // exit 0 で素通りせず fail-fast (exit 2) することを検証する。
+  // exit 1 (旧 token 検出) と exit 2 (構成不備) は別ステータスにする。
+  // ====================================================================
+  describe("0 files scanned ガード", () => {
+    it("LINT_TOKENS_SRC_DIR に存在しないパスを指定すると exit 2 になる", () => {
+      const result = runScript({
+        LINT_TOKENS_SRC_DIR: "/nonexistent-lint-tokens-test-path",
+      });
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain("lint:tokens FATAL: no files scanned");
+    });
+
+    it("LINT_TOKENS_SRC_DIR に空ディレクトリを指定すると exit 2 になる", () => {
+      const emptyDir = mkdtempSync(join(tmpdir(), "lint-tokens-empty-"));
+      try {
+        const result = runScript({ LINT_TOKENS_SRC_DIR: emptyDir });
+        expect(result.status).toBe(2);
+        expect(result.stderr).toContain("lint:tokens FATAL: no files scanned");
+      } finally {
+        rmSync(emptyDir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/src/lib/__tests__/lintTokens.test.ts
+++ b/src/lib/__tests__/lintTokens.test.ts
@@ -146,6 +146,92 @@ describe("lint:tokens (scripts/lintTokens.ts)", () => {
       expect(result.stderr).toContain("old-gruvbox-token");
     });
 
+    // ====================================================================
+    // オブジェクトキー記法検知 (Issue #413 / DA 致命 1 対応)
+    //
+    // panda.config.ts の theme 定義で `bg: { "0": { value: "..." } }` のように
+    // 旧 5 段階トークンを再導入した場合に検出する。複数行にまたがるため
+    // scope: "file" で走査する必要がある。
+    // ====================================================================
+    it("オブジェクトキー記法 `bg: { '0': ... }` を検出する (panda.config.ts 想定)", () => {
+      writeTmpFile(
+        "config.ts",
+        [
+          "export default {",
+          "  theme: {",
+          "    tokens: {",
+          "      colors: {",
+          "        bg: {",
+          '          "0": { value: "test" },',
+          "        },",
+          "      },",
+          "    },",
+          "  },",
+          "};",
+          "",
+        ].join("\n"),
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("old-bg-numeric-key");
+    });
+
+    it("オブジェクトキー記法 `fg: { '0': ... }` を検出する", () => {
+      writeTmpFile(
+        "config.ts",
+        [
+          "export default {",
+          "  fg: {",
+          '    "0": { value: "test" },',
+          "  },",
+          "};",
+          "",
+        ].join("\n"),
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("old-fg-numeric-key");
+    });
+
+    it("オブジェクトキー記法 `gruvbox: {` を検出する", () => {
+      writeTmpFile(
+        "config.ts",
+        [
+          "export default {",
+          "  gruvbox: {",
+          '    "bg-0": { value: "test" },',
+          "  },",
+          "};",
+          "",
+        ].join("\n"),
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("old-gruvbox-key");
+    });
+
+    it("既存の `bg: { canvas: ... }` (新 semantic token) はオブジェクトキー記法として誤検知されない", () => {
+      writeTmpFile(
+        "config.ts",
+        [
+          "export default {",
+          "  bg: {",
+          "    canvas: { value: { _light: 'cream-50' } },",
+          "    surface: { value: { _light: 'cream-100' } },",
+          "    elevated: { value: { _light: 'cream-50' } },",
+          "  },",
+          "  fg: {",
+          "    primary: { value: { _light: 'ink-900' } },",
+          "    code: { value: { _light: '#3c3836' } },",
+          "  },",
+          "};",
+          "",
+        ].join("\n"),
+      );
+      const result = runWithTmpDir();
+      expect(result.status).toBe(0);
+    });
+
     it(".test.ts ファイルは検査対象外で違反検出されない", () => {
       // `.test.ts` は EXCLUDED_FILE_SUFFIXES で除外される。
       // 0 files scanned ガード (DA 致命 2) を回避するため、検出対象外の通常 `.ts` を併置する。


### PR DESCRIPTION
## 概要

R-5 (Issue #393) で導入した `pnpm lint:tokens` (`scripts/lintTokens.ts`) の走査対象は `src/` のみだったため、`panda.config.ts` (theme tokens の正本) や `scripts/`, `e2e/` で旧 5 段階トークン (`bg.0..bg.4` / `fg.0..fg.4` / `colors.gruvbox.*`) が復活しても CI で検出できないギャップがあった。本 PR で走査範囲を拡張し、コメント中の旧→新マッピング表が誤検知されないよう、行コメント / ブロックコメント / 文字列リテラルを区別する簡易ストリッパーを実装する。

Closes #413
Refs #407 (epic)

## 変更内容

- **scripts/lintTokens.ts**:
  - `SRC_DIR` を `TARGET_PATHS` (複数 path) に変更し、既定で以下を走査:
    - `<root>/src/**/*.{ts,tsx,css}`
    - `<root>/panda.config.ts` (単一ファイル)
    - `<root>/scripts/**/*.ts`
    - `<root>/e2e/**/*.ts`
  - `collectTargetFiles` を単一ファイル指定にも対応 (panda.config.ts 用)。存在しないパスは無視する耐性付き。
  - `stripComments` ヘルパを追加:
    - 行コメント (`//`) と複数行コメント (`/* ... */`) を走査対象から除外
    - 状態を `inBlockComment` で持ち、複数行ブロックコメントも追跡
    - 文字列リテラル (`'...'` / `"..."` / `` `...` ``) 内の `//` `/*` はコメント開始と見做さず検査対象に残す
    - column 位置を維持するためコメント領域は同じ長さの空白で置換
  - `EXCLUDED_FILE_SUFFIXES` に `scripts/lintTokens.ts` を追加 (パターン定義 / エラーメッセージ内の文字列リテラル参照による自己検知を防ぐ)
  - 既存検知パターン 7 系統 (bg.[0-9] / fg.[0-9] / token('colors.bg.[0-9]') / token('colors.fg.[0-9]') / var(--colors-bg-[0-9]) / var(--colors-fg-[0-9]) / token('colors.gruvbox.*')) は維持
  - `LINT_TOKENS_SRC_DIR` env による走査対象切替の仕組みは維持 (テスト時は単一パスに絞り込む)

- **src/lib/__tests__/lintTokens.test.ts**:
  - 既存 7 系統の検知テストを維持 (合計 8 ケース、`.test.ts` 除外検証含む)
  - 新規追加: コメント除外 describe ブロック (8 ケース) — 行コメント / 単一行ブロックコメント / 複数行ブロックコメント / コメント終了後コード / シングル・ダブル・バッククォート文字列リテラル / コメント+コード混在
  - 新規追加: 単一ファイル走査 describe ブロック (2 ケース) — panda.config.ts 相当の単一ファイル走査と拡張子外ファイル
  - 新規追加: 既定の複数 path 走査が `> 54 files scanned` であることを担保
  - 合計 21 ケース (旧 9 ケース → 21 ケース)

## 備考

- 受け入れ基準: 全項目クリア
  - [x] `panda.config.ts` (project root) を走査対象に追加
  - [x] `scripts/**/*.ts` を走査対象に追加
  - [x] `e2e/**/*.{ts,spec.ts}` を走査対象に追加
  - [x] コメント除外オプション追加 (行コメント `//` + ブロック `/* ... */`)
  - [x] 既存検知パターン 7 系統を維持
  - [x] `pnpm lint:tokens` で 0 件 (現状 master の旧 token 残存無し前提)
  - [x] 既存テストを更新

- 検証結果:
  - `pnpm lint:tokens`: OK (59 files scanned, 旧 54 files から拡大)
  - `pnpm test:run`: 461 tests / 38 files 全 pass
  - `pnpm type-check`: pass
  - `pnpm lint` (Biome): No fixes applied

- panda.config.ts の JSDoc コメント (`bg.0..bg.4`, `colors.gruvbox.*` 言及) は新コメント除外ロジックで正しく無視される。
- `e2e/a11y/violations.spec.ts` の "gruvbox" 言及は token パターン (`colors.gruvbox.<name>`) には合致しないため検知されない (本 PR の対応範囲外)。
- 自分自身 (`scripts/lintTokens.ts`) は `EXCLUDED_FILE_SUFFIXES` で除外しており、パターン定義や CI 失敗時のヒントメッセージ中の文字列リテラル `bg.0..bg.4` 等は検知されない。