### PR TITLE
refactor: Featured メタ行の text-transform: uppercase / letter-spacing を撤廃 (#424)

### DIFF
--- a/src/components/atoms/FeaturedCard.tsx
+++ b/src/components/atoms/FeaturedCard.tsx
@@ -20,7 +20,7 @@ interface FeaturedCardProps {
  * - 上部に accent.featured (persimmon) の細い罫線で「Featured」を視覚的に位置付け
  * - タイトルは clamp(3rem, 5vw, 5rem) で広い視差。1rem = 10px のため 30px-50px
  * - サブヘッド (excerpt) は 1.25rem〜1.5rem、line-height loose
- * - メタ情報は variant="featured" の uppercase オーバーライン
+ * - メタ情報は variant="featured" の小さめ補助行 (case 変形なし / Issue #424)
  * - hover で subtle elevation + accent underline (タイトルに下線)
  *
  * AA 担保 (calculateContrast.ts による実測値):

--- a/src/components/common/MetaInfo.tsx
+++ b/src/components/common/MetaInfo.tsx
@@ -22,7 +22,11 @@ const containerStyles = css({
   },
 });
 
-// featured 用は中央寄せではなく左寄せの行 (タイトルの上に控えめに乗る用途)
+// featured 用は中央寄せではなく左寄せの行 (タイトルの上に控えめに乗る用途)。
+// Issue #424 で `textTransform: uppercase` と `letterSpacing: 0.08em` を撤去。
+// 英字主体の著者名 (例: `amkkr`) がデータ表記のまま意図せず大文字化される
+// 不具合を解消するため、Featured メタ行はコンテンツの原文表記を尊重する。
+// Editorial 雑誌風の装飾は `featuredLabelStyles` (FeaturedCard.tsx) 側に集約する。
 const containerFeaturedStyles = css({
   display: "flex",
   alignItems: "center",
@@ -30,8 +34,6 @@ const containerFeaturedStyles = css({
   flexWrap: "wrap",
   gap: "md",
   fontSize: "xs",
-  textTransform: "uppercase",
-  letterSpacing: "0.08em",
 });
 
 // bento 用は小さめの行間で左寄せ
@@ -62,8 +64,8 @@ const itemCompactStyles = css({
 // Editorial Citrus トークン (R-2b / Issue #389)
 // - card variant: 補助情報のため fg.muted を使用
 // - header variant: 見出し相当のため fg.primary を使用
-// - featured variant: Featured 大見出しの上に置く控えめなオーバーラインのため
-//   fg.secondary を使い、上部に静かに配置する (Issue #395)。
+// - featured variant: Featured 大見出しの上に置く控えめな補助行 (case 変形なし)
+//   のため fg.secondary を使い、上部に静かに配置する (Issue #395 / #424)。
 // - bento variant: Bento カード内の補助情報。fg.secondary で本文寄り扱い。
 const itemCardStyles = css({
   color: "fg.muted",
@@ -136,7 +138,9 @@ const variantStyleSets: Record<Variant, VariantStyleSet> = {
  * `aria-hidden` で SR から隠し、隣接テキストで意味を伝える。
  *
  * Issue #395 (Editorial Bento) で featured / bento variant を追加。
- * - featured: Featured ヒーロー上の控えめなオーバーライン (uppercase + tracking)
+ * Issue #424 で featured variant の uppercase / letter-spacing を撤去し、
+ * 英字著者名のコンテンツデータが原文表記のまま表示されるよう修正。
+ * - featured: Featured ヒーロー上の控えめな補助行 (case 変形なし)
  * - bento: Bento カード内の補助情報行
  */
 export const MetaInfo = memo(

--- a/src/components/common/__tests__/MetaInfo.test.tsx
+++ b/src/components/common/__tests__/MetaInfo.test.tsx
@@ -99,10 +99,19 @@ describe("MetaInfo", () => {
       />,
     );
 
-    // featured バリアントは uppercase + tracking でオーバーラインとして機能
-    // (text-transform: uppercase の class が付与される)
+    // Issue #424: 当初 (Issue #395) は featured バリアントを uppercase + tracking
+    // のオーバーラインとして実装していたが、英字主体の著者名 (例: `amkkr`) が
+    // データ表記のまま意図せず大文字化される不具合が顕在化したため、
+    // `textTransform: uppercase` と `letterSpacing: 0.08em` を撤去した。
+    // ここでは regression 防止として uppercase クラスが付与されないことを検証する。
+    //
+    // 注意: この `not.toMatch` は #422 (Tripwire CSS 変数解決ベース刷新) 完了
+    // までの暫定実装。Panda の className 命名規則 (textTransform_uppercase /
+    // tt_uppercase) が変更されると false positive で誤検知不能になる。
     const metaInfo = container.firstChild as HTMLElement;
-    expect(metaInfo.className).toMatch(/textTransform_uppercase|tt_uppercase/);
+    expect(metaInfo.className).not.toMatch(
+      /textTransform_uppercase|tt_uppercase/,
+    );
     expect(screen.getByText("2024-01-01")).toBeInTheDocument();
     expect(screen.getByText("山田太郎")).toBeInTheDocument();
     expect(screen.getByText("5分で読了")).toBeInTheDocument();


### PR DESCRIPTION
## 概要

Featured エリアの著者名表示が `AMKKR` (大文字) になっている不具合を、`MetaInfo.tsx` の `containerFeaturedStyles` から `textTransform: uppercase` と `letterSpacing: 0.08em` を撤去することで解消する。

Closes #424
Refs #386 (Phase 1 epic) / #407 (Phase 2 epic)

## 変更内容

### MetaInfo.tsx
- `containerFeaturedStyles` から `textTransform: "uppercase"` と `letterSpacing: "0.08em"` を削除
- 関連コメントを内容と整合する形に微修正

### MetaInfo.test.tsx
- `featuredバリアントが適用できる` test の uppercase 検証を `not.toMatch` に転換
- コメントで Issue 番号と仕様遷移の経緯を記録

### FeaturedCard.tsx
- L23 JSDoc の「メタ情報は variant=\"featured\" の uppercase オーバーライン」を「小さめ補助行 (case 変形なし)」相当に修正

## 検討した代替案

- 案 B (letterSpacing 維持): 装飾効果薄で却下
- 案 D (`By` prefix uppercase): Phase 2 送り
- データ正規化案 (`Amkkr` 等): GitHub username の Web 慣行と全件変更コストで却下

## 備考

- `not.toMatch` は #422 (Tripwire CSS 変数解決ベース刷新) 完了までの暫定実装
- VR baseline は本 PR で更新せず、#410 (VR baseline 更新) に統合運用
- 案 D / fontSize 引き上げは Phase 2 (#407) 送り

## テスト結果

- pnpm test:run: pass (542 / 542)
- pnpm lint: pass
- pnpm build: pass
- pnpm contrast:check: pass (47 / 0 NG)
- pnpm lint:tokens: pass (64 files)