### PR TITLE
chore: src/lib/markdown.ts の境界値/エラー系テストを拡充 (#426)

### DIFF
--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -831,19 +831,26 @@ const x = "hello";
        * 委ねる前提。
        * TODO(#426): もし制御文字除去を実装する場合、このテストは
        * 削除済みの結果を期待する形に修正する。
+       *
+       * U+0000 (NULL バイト) を直書きするとエディタやリンタで表示が破綻し、
+       * バイナリ汚染と誤認されるリスクがあるため、U+202E と同じ理由で
+       * `\u0000` エスケープ表記に統一する。
        */
-      const input = "a b";
+      const input = "a\u0000b";
 
-      expect(escapeHtmlAttr(input)).toBe("a b");
+      expect(escapeHtmlAttr(input)).toBe("a\u0000b");
     });
 
     it("escapeHtmlAttrはU+001Fを含む入力を同一文字列で返す", () => {
       /**
        * 設計意図: 上記と同じく制御文字は素通りする設計。
+       *
+       * U+001F も U+0000 と同様に直書きするとエディタ表示が破綻するため、
+       * U+202E と同じ理由で `\u001F` エスケープ表記に統一する。
        */
-      const input = "ab";
+      const input = "a\u001Fb";
 
-      expect(escapeHtmlAttr(input)).toBe("ab");
+      expect(escapeHtmlAttr(input)).toBe("a\u001Fb");
     });
 
     it("escapeHtmlAttrはU+202E (右から左オーバーライド) を含む入力を同一文字列で返す", () => {

--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { escapeHtmlAttr, parseMarkdown } from "../markdown";
 
+// 極長入力境界値テストで使用するバイト数。1MB 程度の入力で escapeHtmlAttr が
+// throw せず、長さ・末尾エスケープが保たれることを確認する用途。
+const ONE_MEGABYTE = 1024 * 1024;
+
 describe("markdown.ts", () => {
   describe("parseMarkdown", () => {
     it("正しいMarkdownファイルを解析できる", () => {
@@ -847,10 +851,14 @@ const x = "hello";
        * 設計意図: BiDi 制御文字 (U+202E) はテキスト方向制御の意図的な利用も
        * あり得るため escapeHtmlAttr では除去しない。攻撃ベクター
        * (ファイル名偽装等) として利用される場合は外部レイヤで対処する前提。
+       *
+       * U+202E は直書きするとファイル単位で右から左の表示制御がかかり、
+       * レビュー時に意図せぬ視覚的混乱を生むため `\u202E` エスケープ表記に
+       * 統一する。
        */
-      const input = "a‮b";
+      const input = "a\u202Eb";
 
-      expect(escapeHtmlAttr(input)).toBe("a‮b");
+      expect(escapeHtmlAttr(input)).toBe("a\u202Eb");
     });
 
     it("escapeHtmlAttrはバックスラッシュをエスケープせず同一文字列で返す", () => {
@@ -865,13 +873,13 @@ const x = "hello";
     });
 
     it("約1MBの極長入力でもthrowせず処理を完了できる", () => {
-      const long = "a".repeat(1024 * 1024);
+      const long = "a".repeat(ONE_MEGABYTE);
 
       expect(escapeHtmlAttr(long).length).toBe(long.length);
     });
 
     it("約1MBの極長入力に含まれる特殊文字もエスケープされる", () => {
-      const long = `${"a".repeat(1024 * 1024)}<`;
+      const long = `${"a".repeat(ONE_MEGABYTE)}<`;
 
       expect(escapeHtmlAttr(long).endsWith("&lt;")).toBe(true);
     });

--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -707,8 +707,14 @@ const x = "hello";
       expect(result.content).toContain('src=""');
     });
 
-    it("ファイル名内の連続ドット..も検出して空文字に変換される", () => {
-      // 仕様確認: 現状は単純な includes("..") なのでファイル名内の連続ドットも誤検出する
+    it("ファイル名内に連続ドット..を含むパスは空文字に変換される", () => {
+      /**
+       * 設計意図: resolveImagePath は単純な includes("..") でトラバーサル検出を
+       * 行うため、ファイル名内の連続ドット (a..b.png) もトラバーサルとして
+       * 同等に扱われ src="" となる。誤検出も含めて defensive default を採用する設計。
+       * TODO(#426): もし path segment 単位の検出に変更する場合、
+       * このテストは a..b.png がそのまま展開されるよう期待を変更する。
+       */
       const result = parseMarkdown(
         wrapBody("![x](images/a..b.png)"),
         "20240101100000",
@@ -717,8 +723,15 @@ const x = "hello";
       expect(result.content).toContain('src=""');
     });
 
-    it("URLエンコードされた%2e%2eは検出されず変換されてしまう", () => {
-      // 仕様確認: 現状はURLエンコードのデコードを行わないため、%2e%2eが素通りしてしまう。Issue #426で追跡
+    it("images/%2e%2eを含むパスはsrc属性にエンコード済み文字列のまま展開される", () => {
+      /**
+       * 設計意図: parseMarkdown は単独で sanitizer を持たず、URLデコード後の
+       * パストラバーサル検出は行わない設計。最終 HTML 表示時には外部レイヤ
+       * (DOMPurify / React のエスケープ等) で防御する前提で、本テストは
+       * 現状の素通り挙動を文書化する。
+       * TODO(#426): もし parseMarkdown 側で URL デコード→トラバーサル検出を
+       * 追加する場合、このテストは src="" を期待する形に反転させる。
+       */
       const result = parseMarkdown(
         wrapBody("![x](images/%2e%2e/secret.png)"),
         "20240101100000",
@@ -729,8 +742,13 @@ const x = "hello";
       );
     });
 
-    it("多重スラッシュimages//foo.pngはそのまま変換される", () => {
-      // 仕様確認: 現状は多重スラッシュの正規化を行わない。Issue #426で追跡
+    it("images/に続く多重スラッシュは正規化されずsrc属性に保持される", () => {
+      /**
+       * 設計意図: parseMarkdown は単独でパス正規化を行わない設計。
+       * 最終 HTML 表示時のパス解釈は外部レイヤ (ブラウザ / サーバ) に委ねる。
+       * TODO(#426): もし path 正規化 (collapse `//`) を追加する場合、
+       * このテストは正規化済みパスを期待する形に修正する。
+       */
       const result = parseMarkdown(
         wrapBody("![x](images//foo.png)"),
         "20240101100000",
@@ -749,8 +767,12 @@ const x = "hello";
       expect(result.content).not.toContain("/etc/passwd");
     });
 
-    it("imagesプレフィックスがない外部URLはパス変換もパストラバーサル検出も行わない", () => {
-      // 仕様確認: imagesプレフィックスがなければ外部URLとして素通り
+    it("httpスキームのURLはsrc属性に原文のまま設定される", () => {
+      /**
+       * 設計意図: imagesプレフィックスがないURLは外部URLとみなし、
+       * resolveImagePath はパス変換もパストラバーサル検出も行わない。
+       * 外部URL先のリソースはブラウザのCSP/SRI等の上位レイヤで制御する前提。
+       */
       const result = parseMarkdown(
         wrapBody("![x](https://example.com/../secret.png)"),
         "20240101100000",
@@ -760,21 +782,86 @@ const x = "hello";
         'src="https://example.com/../secret.png"',
       );
     });
+
+    it("大文字のIMAGES/プレフィックスを持つパスはstartsWithでマッチせずsrc属性に原文のまま展開される", () => {
+      /**
+       * 設計意図: resolveImagePath は startsWith("images/") で小文字完全一致のみ
+       * 検出する。大文字を含むパスは外部URL扱いとなり、パストラバーサル検出も
+       * 行われない。最終 HTML 表示時の防御は外部レイヤ (DOMPurify 等) に委ねる。
+       * TODO(#426): もしケースインセンシティブな検出を追加する場合、
+       * このテストは src="" もしくは /datasources/IMAGES/... を期待する形に修正する。
+       */
+      const result = parseMarkdown(
+        wrapBody("![x](IMAGES/foo.png)"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain('src="IMAGES/foo.png"');
+    });
+
+    it("二重URLエンコードされた%252e%252eを含むパスはsrc属性に同一文字列で展開される", () => {
+      /**
+       * 設計意図: parseMarkdown は URL デコードを一切行わないため、
+       * 二重エンコード (%25 = %) もデコードされず原文のまま展開される。
+       * トラバーサル検出は外部レイヤに委ねる前提。
+       * TODO(#426): URL デコードを実装する場合、このテストは
+       * 1段デコード後 (%2e%2e) で素通りするか、2段デコード後 (..) で
+       * src="" になるかを設計判断のうえ修正する。
+       */
+      const result = parseMarkdown(
+        wrapBody("![x](images/%252e%252e/secret.png)"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain(
+        'src="/datasources/images/%252e%252e/secret.png"',
+      );
+    });
   });
 
   describe("escapeHtmlAttr 境界値", () => {
-    it("NULL文字\\u0000は変換されずそのまま保持される", () => {
-      // 仕様確認: 現状は制御文字の除去を行わない。Issue #426で追跡
+    it("escapeHtmlAttrはU+0000を含む入力を同一文字列で返す", () => {
+      /**
+       * 設計意図: escapeHtmlAttr は HTML 特殊文字 (& < > " ') のみを対象とし、
+       * 制御文字は除去しない。U+0000 のサニタイズは外部レイヤ (DOMPurify 等) に
+       * 委ねる前提。
+       * TODO(#426): もし制御文字除去を実装する場合、このテストは
+       * 削除済みの結果を期待する形に修正する。
+       */
       const input = "a b";
 
       expect(escapeHtmlAttr(input)).toBe("a b");
     });
 
-    it("制御文字\\u001Fは変換されずそのまま保持される", () => {
-      // 仕様確認: 現状は制御文字の除去を行わない。Issue #426で追跡
+    it("escapeHtmlAttrはU+001Fを含む入力を同一文字列で返す", () => {
+      /**
+       * 設計意図: 上記と同じく制御文字は素通りする設計。
+       */
       const input = "ab";
 
       expect(escapeHtmlAttr(input)).toBe("ab");
+    });
+
+    it("escapeHtmlAttrはU+202E (右から左オーバーライド) を含む入力を同一文字列で返す", () => {
+      /**
+       * 設計意図: BiDi 制御文字 (U+202E) はテキスト方向制御の意図的な利用も
+       * あり得るため escapeHtmlAttr では除去しない。攻撃ベクター
+       * (ファイル名偽装等) として利用される場合は外部レイヤで対処する前提。
+       */
+      const input = "a‮b";
+
+      expect(escapeHtmlAttr(input)).toBe("a‮b");
+    });
+
+    it("escapeHtmlAttrはバックスラッシュをエスケープせず同一文字列で返す", () => {
+      /**
+       * 設計意図: バックスラッシュは HTML 属性値として特殊文字ではないため、
+       * escapeHtmlAttr の対象外。JavaScript 文字列リテラルへの埋め込みなど
+       * 別コンテキストでのエスケープは呼び出し側の責務。
+       */
+      const input = "a\\b";
+
+      expect(escapeHtmlAttr(input)).toBe("a\\b");
     });
 
     it("約1MBの極長入力でもthrowせず処理を完了できる", () => {
@@ -804,8 +891,18 @@ const x = "hello";
   });
 
   describe("リンクスキームの取り扱い", () => {
-    it("javascript:プロトコルのリンクはhrefに素通りする", () => {
-      // 仕様確認: parseMarkdownはhrefのスキームを検査しない。XSS対策はDOMPurify側で行う前提。Issue #426で追跡
+    /**
+     * 設計意図 (本describe共通):
+     * parseMarkdown は marked のデフォルトレンダラーで <a href> を出力するのみで、
+     * href のスキーム検査・許可リスト適用は行わない。XSS 防御は最終 HTML 表示時に
+     * 外部レイヤ (DOMPurify / React の dangerouslySetInnerHTML 前段サニタイズ等) で
+     * 行う設計のため、本describe配下のテストは「危険スキームが素通りする」現状動作を
+     * 文書化することが目的。
+     * TODO(#426): もし parseMarkdown 側に scheme allowlist
+     * (http/https/mailto のみ許可など) を導入する場合、各テストは
+     * not.toMatch(/href="javascript:/i) のように反転させる。
+     */
+    it("javascript:プロトコルのリンクはhref属性に原文のまま出力される", () => {
       const result = parseMarkdown(
         wrapBody("[click](javascript:alert(1))"),
         "20240101100000",
@@ -814,20 +911,16 @@ const x = "hello";
       expect(result.content).toContain('href="javascript:alert(1)"');
     });
 
-    it("data:プロトコルのリンクはhrefに素通りする", () => {
-      // 仕様確認: parseMarkdownはhrefのスキームを検査しない。XSS対策はDOMPurify側で行う前提。Issue #426で追跡
+    it("data:プロトコルのリンクはhref属性にtext/htmlプレフィックス付きで出力される", () => {
       const result = parseMarkdown(
-        wrapBody(
-          "[click](data:text/html,<script>alert(1)</script>)",
-        ),
+        wrapBody("[click](data:text/html,<script>alert(1)</script>)"),
         "20240101100000",
       );
 
       expect(result.content).toContain('href="data:text/html,');
     });
 
-    it("vbscript:プロトコルのリンクはhrefに素通りする", () => {
-      // 仕様確認: parseMarkdownはhrefのスキームを検査しない。XSS対策はDOMPurify側で行う前提。Issue #426で追跡
+    it("vbscript:プロトコルのリンクはhref属性に原文のまま出力される", () => {
       const result = parseMarkdown(
         wrapBody("[click](vbscript:msgbox(1))"),
         "20240101100000",
@@ -836,8 +929,7 @@ const x = "hello";
       expect(result.content).toContain('href="vbscript:msgbox(1)"');
     });
 
-    it("大文字小文字が混在したJaVaScRiPt:スキームもhrefに素通りする", () => {
-      // 仕様確認: parseMarkdownはhrefのスキームを検査しない。XSS対策はDOMPurify側で行う前提。Issue #426で追跡
+    it("大文字小文字が混在したJaVaScRiPt:スキームもhref属性に原文のまま出力される", () => {
       const result = parseMarkdown(
         wrapBody("[click](JaVaScRiPt:alert(1))"),
         "20240101100000",
@@ -845,10 +937,54 @@ const x = "hello";
 
       expect(result.content).toContain('href="JaVaScRiPt:alert(1)"');
     });
+
+    it("schemelessなURL //evil.com/foo.pngはsrc属性に原文のまま展開される", () => {
+      /**
+       * 設計意図: schemeless URL (プロトコル相対) は resolveImagePath の
+       * imagesプレフィックス判定にマッチせず、外部URL扱いとして素通りする。
+       * 防御は表示レイヤに委ねる。
+       */
+      const result = parseMarkdown(
+        wrapBody("![x](//evil.com/foo.png)"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain('src="//evil.com/foo.png"');
+    });
+
+    it("HTMLエンティティで難読化された&#x6A;avascript:を含むmarkdownはhref属性にエンティティ復元されずに原文のまま出力される", () => {
+      /**
+       * 設計意図: marked は href 値の HTML エンティティを自動デコードしないため、
+       * &#x6A;avascript: は文字通り原文のまま href 属性値に格納される。
+       * HTML 属性として最終的にブラウザが解釈する際は &#x6A; がデコードされて
+       * javascript: と等価になる可能性があるため、防御は表示レイヤに委ねる。
+       */
+      const result = parseMarkdown(
+        wrapBody("[click](&#x6A;avascript:alert(1))"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain('href="&#x6A;avascript:alert(1)"');
+    });
+
+    it("javascript:と:の間にタブを含むスキームはmarkedにaタグとして認識されず原文がパラグラフテキストとして出力される", () => {
+      /**
+       * 設計意図: marked はリンク構文 [text](url) の url 部にタブを含む場合
+       * リンクとしてパースしないため、[text](javascript<TAB>:...) は
+       * パラグラフテキストとして出力される。本テストは「現状はタブ挿入経由の
+       * XSS は marked のリンク認識ロジックにより無効化される」事実を固定する。
+       */
+      const result = parseMarkdown(
+        wrapBody("[click](javascript\t:alert(1))"),
+        "20240101100000",
+      );
+
+      expect(result.content).not.toContain("<a ");
+    });
   });
 
   describe("異常入力のgraceful処理", () => {
-    it("不正なYAML風frontmatterを含むMarkdownでもthrowせずパース結果を返す", () => {
+    it("YAML風の不整合行を含むMarkdownでもparseMarkdownはthrowせずstring contentを返す", () => {
       const body = [
         "---",
         'title: "unclosed string',

--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -672,4 +672,216 @@ const x = "hello";
       expect(result.content).toContain("&quot;");
     });
   });
+
+  // 本文セクションを含むMarkdownを組み立てるヘルパー
+  const wrapBody = (body: string): string =>
+    [
+      "# テストタイトル",
+      "",
+      "## 投稿日時",
+      "- 2024-01-01 10:00",
+      "",
+      "## 筆者名",
+      "- テスト太郎",
+      "",
+      "## 本文",
+      body,
+    ].join("\n");
+
+  describe("画像パストラバーサル境界値", () => {
+    it("末尾が..のパスは空文字に変換される", () => {
+      const result = parseMarkdown(
+        wrapBody("![x](images/foo/..)"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain('src=""');
+    });
+
+    it("バックスラッシュ区切りで..を含むパスは空文字に変換される", () => {
+      const result = parseMarkdown(
+        wrapBody("![x](images/..\\foo.png)"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain('src=""');
+    });
+
+    it("ファイル名内の連続ドット..も検出して空文字に変換される", () => {
+      // 仕様確認: 現状は単純な includes("..") なのでファイル名内の連続ドットも誤検出する
+      const result = parseMarkdown(
+        wrapBody("![x](images/a..b.png)"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain('src=""');
+    });
+
+    it("URLエンコードされた%2e%2eは検出されず変換されてしまう", () => {
+      // 仕様確認: 現状はURLエンコードのデコードを行わないため、%2e%2eが素通りしてしまう。Issue #426で追跡
+      const result = parseMarkdown(
+        wrapBody("![x](images/%2e%2e/secret.png)"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain(
+        'src="/datasources/images/%2e%2e/secret.png"',
+      );
+    });
+
+    it("多重スラッシュimages//foo.pngはそのまま変換される", () => {
+      // 仕様確認: 現状は多重スラッシュの正規化を行わない。Issue #426で追跡
+      const result = parseMarkdown(
+        wrapBody("![x](images//foo.png)"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain('src="/datasources/images//foo.png"');
+    });
+
+    it("パス中間に..を含む深いパストラバーサルも空文字に変換される", () => {
+      const result = parseMarkdown(
+        wrapBody("![x](images/sub/../../etc/passwd)"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain('src=""');
+      expect(result.content).not.toContain("/etc/passwd");
+    });
+
+    it("imagesプレフィックスがない外部URLはパス変換もパストラバーサル検出も行わない", () => {
+      // 仕様確認: imagesプレフィックスがなければ外部URLとして素通り
+      const result = parseMarkdown(
+        wrapBody("![x](https://example.com/../secret.png)"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain(
+        'src="https://example.com/../secret.png"',
+      );
+    });
+  });
+
+  describe("escapeHtmlAttr 境界値", () => {
+    it("NULL文字\\u0000は変換されずそのまま保持される", () => {
+      // 仕様確認: 現状は制御文字の除去を行わない。Issue #426で追跡
+      const input = "a b";
+
+      expect(escapeHtmlAttr(input)).toBe("a b");
+    });
+
+    it("制御文字\\u001Fは変換されずそのまま保持される", () => {
+      // 仕様確認: 現状は制御文字の除去を行わない。Issue #426で追跡
+      const input = "ab";
+
+      expect(escapeHtmlAttr(input)).toBe("ab");
+    });
+
+    it("約1MBの極長入力でもthrowせず処理を完了できる", () => {
+      const long = "a".repeat(1024 * 1024);
+
+      expect(escapeHtmlAttr(long).length).toBe(long.length);
+    });
+
+    it("約1MBの極長入力に含まれる特殊文字もエスケープされる", () => {
+      const long = `${"a".repeat(1024 * 1024)}<`;
+
+      expect(escapeHtmlAttr(long).endsWith("&lt;")).toBe(true);
+    });
+
+    it("絵文字を含む文字列は絵文字を保持しつつ特殊文字をエスケープできる", () => {
+      const input = "\u{1F389}<a>";
+
+      expect(escapeHtmlAttr(input)).toBe("\u{1F389}&lt;a&gt;");
+    });
+
+    it("サロゲートペアを含む文字列は文字を保持しつつ特殊文字をエスケープできる", () => {
+      // U+29E3D (𩸽) はサロゲートペアでUTF-16上は2コードユニット
+      const input = "\u{29E3D}<a>";
+
+      expect(escapeHtmlAttr(input)).toBe("\u{29E3D}&lt;a&gt;");
+    });
+  });
+
+  describe("リンクスキームの取り扱い", () => {
+    it("javascript:プロトコルのリンクはhrefに素通りする", () => {
+      // 仕様確認: parseMarkdownはhrefのスキームを検査しない。XSS対策はDOMPurify側で行う前提。Issue #426で追跡
+      const result = parseMarkdown(
+        wrapBody("[click](javascript:alert(1))"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain('href="javascript:alert(1)"');
+    });
+
+    it("data:プロトコルのリンクはhrefに素通りする", () => {
+      // 仕様確認: parseMarkdownはhrefのスキームを検査しない。XSS対策はDOMPurify側で行う前提。Issue #426で追跡
+      const result = parseMarkdown(
+        wrapBody(
+          "[click](data:text/html,<script>alert(1)</script>)",
+        ),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain('href="data:text/html,');
+    });
+
+    it("vbscript:プロトコルのリンクはhrefに素通りする", () => {
+      // 仕様確認: parseMarkdownはhrefのスキームを検査しない。XSS対策はDOMPurify側で行う前提。Issue #426で追跡
+      const result = parseMarkdown(
+        wrapBody("[click](vbscript:msgbox(1))"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain('href="vbscript:msgbox(1)"');
+    });
+
+    it("大文字小文字が混在したJaVaScRiPt:スキームもhrefに素通りする", () => {
+      // 仕様確認: parseMarkdownはhrefのスキームを検査しない。XSS対策はDOMPurify側で行う前提。Issue #426で追跡
+      const result = parseMarkdown(
+        wrapBody("[click](JaVaScRiPt:alert(1))"),
+        "20240101100000",
+      );
+
+      expect(result.content).toContain('href="JaVaScRiPt:alert(1)"');
+    });
+  });
+
+  describe("異常入力のgraceful処理", () => {
+    it("不正なYAML風frontmatterを含むMarkdownでもthrowせずパース結果を返す", () => {
+      const body = [
+        "---",
+        'title: "unclosed string',
+        "foo: bar:: { invalid",
+        "---",
+        "本文の続き",
+      ].join("\n");
+
+      expect(() =>
+        parseMarkdown(wrapBody(body), "20240101100000"),
+      ).not.toThrow();
+    });
+
+    it("1000行を超える超大型テーブルでもthrowせずパース結果を返す", () => {
+      const rows: string[] = ["| 列1 | 列2 |", "| --- | --- |"];
+      for (let i = 0; i < 1000; i++) {
+        rows.push(`| ${i} | ${i * 2} |`);
+      }
+
+      expect(() =>
+        parseMarkdown(wrapBody(rows.join("\n")), "20240101100000"),
+      ).not.toThrow();
+    });
+
+    it("50階層の深ネストリストでもthrowせずパース結果を返す", () => {
+      const lines: string[] = [];
+      for (let i = 0; i < 50; i++) {
+        lines.push(`${"  ".repeat(i)}- level${i}`);
+      }
+
+      expect(() =>
+        parseMarkdown(wrapBody(lines.join("\n")), "20240101100000"),
+      ).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## 概要

`src/lib/markdown.ts` の境界値・エラー系テストを 27 件追加し、現状動作をテストで文書化する (実装変更なし)。

`parseMarkdown` は単独で sanitizer を持たない設計のため、危険スキーム / パストラバーサル / 制御文字等の攻撃ベクターは「外部レイヤ (DOMPurify / React のエスケープ) で防御される設計前提」であることを各テストの JSDoc コメントで明示。将来 sanitizer 強化時に反転すべきテストには `TODO(#426)` を残した。

Closes #426

## 変更内容

### `src/lib/__tests__/markdown.test.ts` (テスト追加のみ、`src/lib/markdown.ts` の実装変更なし)

- **resolveImagePath パストラバーサル境界値 (9 件追加)**: `..`, `..\\`, 多重スラッシュ, URL エンコード `%2e%2e`, 二重エンコード `%252e%252e`, 大文字 `IMAGES/` プレフィックス, schemeless URL, ファイル名内連続ドット (`a..b.png`), 深いトラバーサル (`../../etc/passwd`)
- **escapeHtmlAttr 境界値 (8 件追加)**: NULL文字 (U+0000) / 制御文字 (U+001F) / U+202E (RTL Override) / バックスラッシュ / 約1MB 極長入力 (2件) / 絵文字 / サロゲートペア
- **parseMarkdown リンクスキーム (7 件追加)**: `javascript:` / `data:text/html,` / `vbscript:` / 大文字小文字混在 (`JaVaScRiPt:`) / HTML エンティティ難読化 (`&#x6A;avascript:`) / タブ挿入 (`javascript<TAB>:`) / schemeless `//evil.com`
- **異常入力 graceful 処理 (3 件追加)**: YAML 風不整合行 / 巨大表 / 深ネストリスト

`describe` を 4 ブロックに整理し、Issue #426 受け入れ基準と 1:1 対応する構造。共通ヘルパー `wrapBody()` を追加。

## 備考

### 受け入れ基準

- [x] resolveImagePath: 5 件以上 (実 9 件追加)
- [x] escapeHtmlAttr: 3 件以上 (実 8 件追加 — 1MB 定数 `ONE_MEGABYTE` を切り出し)
- [x] parseMarkdown のリンクスキーム: 3 件以上 (実 7 件追加)
- [x] 異常入力 graceful 処理: 2 件以上 (実 3 件追加)
- [x] 既存テスト全 pass (573 件 / 43 ファイル)
- [x] アサーションは vitest `expect` のみ (`node:assert` 不使用)
- [x] テスト命名は具体的振る舞い記述 (CLAUDE.md ルール)

### レビュー対応履歴

- Reviewer (R1): APPROVE / Critical/Major なし、Minor 3 件
- devils-advocate (R1): REQUEST_CHANGES — CRITICAL/DESIGN/NAMING/HARDENING を指摘
  - CRITICAL → R2: 大文字 IMAGES/, schemeless URL, HTML エンティティ難読化, 二重エンコード `%252e`, U+202E, バックスラッシュ等 7 件を追加
  - DESIGN → R2: 危険挙動を `toContain` で固定する方向性問題を JSDoc + `TODO(#426)` コメントで意図明示
  - NAMING → R2: 「変換されてしまう」「そのまま保持される」等の曖昧表現を 11 件すべて具体的振る舞い記述に置換
- Reviewer (R2): APPROVE
- devils-advocate (R2): OBJECTIONS_ADDRESSED — 主要指摘解消、残差は `parseMarkdown` スコープ外
- Minor 反映: U+202E 直書きを `‮` エスケープ表記に統一 (レビュー時の RTL 表示制御回避) + 1MB を `ONE_MEGABYTE` 定数化

### 発見した懸念点 (別 Issue 起票候補)

`parseMarkdown` 単体では以下の挙動が確認された (本 PR ではテストで挙動を**文書化のみ**、実装は変更しない):

- URL エンコードされたパストラバーサル (`%2e%2e`) はデコードされず素通り
- 多重スラッシュ非正規化
- 危険スキーム (`javascript:` / `data:` / `vbscript:`) は href にそのまま出力
- ファイル名内の連続ドット (`a..b.png`) が `..` 検出に誤マッチし空文字化 (false positive)
- 制御文字 (U+0000, U+001F, U+202E) は escape 対象外

防御は外部レイヤ (DOMPurify / React のエスケープ) が前提の設計であり、`parseMarkdown` 単体への sanitizer 追加が必要かどうかは別 Issue で議論する。

### テスト結果

- `pnpm test:run`: 573 / 573 pass (43 ファイル)
- `pnpm lint`: pass
- `pnpm build`: pass