### PR TITLE
chore: .claude/worktrees/ を git の管理対象外にする

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+worktrees/


### PR DESCRIPTION
## 概要

sub-agent の worktree 用一時ディレクトリ `.claude/worktrees/` を git の管理対象外にする。多数の `agent-*` / 名前付き worktree が常時 untracked として表示される状態を解消する。

`.claude/` 配下には `settings.json` / `hooks/` / `skills/` などトラッキング対象のファイルが存在するため、ルートの `.gitignore` ではなく `.claude/.gitignore` を新設しスコープを worktree のみに限定。

## 変更内容

- `.claude/.gitignore` (新規): `worktrees/` を ignore 対象に追加

## 備考

- `git check-ignore` で `.claude/worktrees/agent-*` が無視対象になることを確認済み
- `.claude/settings.json` などトラッキング済みファイルへの影響なし