### PR TITLE
feat: dark border.subtle 値を Calm 思想に整合 (Closes #423)

### DIFF
--- a/docs/contrast-matrix.csv
+++ b/docs/contrast-matrix.csv
@@ -5,6 +5,7 @@ cream-50,ink-900,"oklch(0.985 0.013 85)","oklch(0.150 0.020 85)",18.85,AAA,yes,y
 cream-50,bone-50,"oklch(0.985 0.013 85)","oklch(0.965 0.005 220)",1.06,FAIL,no,no
 cream-50,bone-100,"oklch(0.985 0.013 85)","oklch(0.920 0.005 220)",1.21,FAIL,no,no
 cream-50,sumi-400,"oklch(0.985 0.013 85)","oklch(0.700 0.012 220)",2.55,FAIL,no,no
+cream-50,sumi-450,"oklch(0.985 0.013 85)","oklch(0.665 0.012 220)",2.91,FAIL,no,no
 cream-50,sumi-500,"oklch(0.985 0.013 85)","oklch(0.620 0 0)",3.49,AA-large,no,no
 cream-50,sumi-600,"oklch(0.985 0.013 85)","oklch(0.470 0 0)",6.54,AA,no,yes
 cream-50,sumi-700,"oklch(0.985 0.013 85)","oklch(0.380 0 0)",9.59,AAA,yes,yes
@@ -20,6 +21,7 @@ cream-75,ink-900,"oklch(0.975 0.015 85)","oklch(0.150 0.020 85)",18.31,AAA,yes,y
 cream-75,bone-50,"oklch(0.975 0.015 85)","oklch(0.965 0.005 220)",1.03,FAIL,no,no
 cream-75,bone-100,"oklch(0.975 0.015 85)","oklch(0.920 0.005 220)",1.18,FAIL,no,no
 cream-75,sumi-400,"oklch(0.975 0.015 85)","oklch(0.700 0.012 220)",2.48,FAIL,no,no
+cream-75,sumi-450,"oklch(0.975 0.015 85)","oklch(0.665 0.012 220)",2.83,FAIL,no,no
 cream-75,sumi-500,"oklch(0.975 0.015 85)","oklch(0.620 0 0)",3.39,AA-large,no,no
 cream-75,sumi-600,"oklch(0.975 0.015 85)","oklch(0.470 0 0)",6.35,AA,no,yes
 cream-75,sumi-700,"oklch(0.975 0.015 85)","oklch(0.380 0 0)",9.31,AAA,yes,yes
@@ -35,6 +37,7 @@ cream-100,ink-900,"oklch(0.965 0.018 85)","oklch(0.150 0.020 85)",17.78,AAA,yes,
 cream-100,bone-50,"oklch(0.965 0.018 85)","oklch(0.965 0.005 220)",1.00,FAIL,no,no
 cream-100,bone-100,"oklch(0.965 0.018 85)","oklch(0.920 0.005 220)",1.14,FAIL,no,no
 cream-100,sumi-400,"oklch(0.965 0.018 85)","oklch(0.700 0.012 220)",2.40,FAIL,no,no
+cream-100,sumi-450,"oklch(0.965 0.018 85)","oklch(0.665 0.012 220)",2.75,FAIL,no,no
 cream-100,sumi-500,"oklch(0.965 0.018 85)","oklch(0.620 0 0)",3.29,AA-large,no,no
 cream-100,sumi-600,"oklch(0.965 0.018 85)","oklch(0.470 0 0)",6.17,AA,no,yes
 cream-100,sumi-700,"oklch(0.965 0.018 85)","oklch(0.380 0 0)",9.05,AAA,yes,yes
@@ -50,6 +53,7 @@ sumi-950,ink-900,"oklch(0.180 0.012 220)","oklch(0.150 0.020 85)",1.05,FAIL,no,n
 sumi-950,bone-50,"oklch(0.180 0.012 220)","oklch(0.965 0.005 220)",16.98,AAA,yes,yes
 sumi-950,bone-100,"oklch(0.180 0.012 220)","oklch(0.920 0.005 220)",14.84,AAA,yes,yes
 sumi-950,sumi-400,"oklch(0.180 0.012 220)","oklch(0.700 0.012 220)",7.05,AAA,yes,yes
+sumi-950,sumi-450,"oklch(0.180 0.012 220)","oklch(0.665 0.012 220)",6.18,AA,no,yes
 sumi-950,sumi-500,"oklch(0.180 0.012 220)","oklch(0.620 0 0)",5.15,AA,no,yes
 sumi-950,sumi-600,"oklch(0.180 0.012 220)","oklch(0.470 0 0)",2.75,FAIL,no,no
 sumi-950,sumi-700,"oklch(0.180 0.012 220)","oklch(0.380 0 0)",1.87,FAIL,no,no
@@ -65,6 +69,7 @@ sumi-650,ink-900,"oklch(0.270 0.012 220)","oklch(0.150 0.020 85)",1.31,FAIL,no,n
 sumi-650,bone-50,"oklch(0.270 0.012 220)","oklch(0.965 0.005 220)",13.59,AAA,yes,yes
 sumi-650,bone-100,"oklch(0.270 0.012 220)","oklch(0.920 0.005 220)",11.87,AAA,yes,yes
 sumi-650,sumi-400,"oklch(0.270 0.012 220)","oklch(0.700 0.012 220)",5.64,AA,no,yes
+sumi-650,sumi-450,"oklch(0.270 0.012 220)","oklch(0.665 0.012 220)",4.94,AA,no,yes
 sumi-650,sumi-500,"oklch(0.270 0.012 220)","oklch(0.620 0 0)",4.12,AA-large,no,no
 sumi-650,sumi-600,"oklch(0.270 0.012 220)","oklch(0.470 0 0)",2.20,FAIL,no,no
 sumi-650,sumi-700,"oklch(0.270 0.012 220)","oklch(0.380 0 0)",1.50,FAIL,no,no
@@ -80,6 +85,7 @@ sumi-700,ink-900,"oklch(0.380 0 0)","oklch(0.150 0.020 85)",1.97,FAIL,no,no
 sumi-700,bone-50,"oklch(0.380 0 0)","oklch(0.965 0.005 220)",9.06,AAA,yes,yes
 sumi-700,bone-100,"oklch(0.380 0 0)","oklch(0.920 0.005 220)",7.91,AAA,yes,yes
 sumi-700,sumi-400,"oklch(0.380 0 0)","oklch(0.700 0.012 220)",3.76,AA-large,no,no
+sumi-700,sumi-450,"oklch(0.380 0 0)","oklch(0.665 0.012 220)",3.29,AA-large,no,no
 sumi-700,sumi-500,"oklch(0.380 0 0)","oklch(0.620 0 0)",2.75,FAIL,no,no
 sumi-700,sumi-600,"oklch(0.380 0 0)","oklch(0.470 0 0)",1.47,FAIL,no,no
 sumi-700,sumi-700,"oklch(0.380 0 0)","oklch(0.380 0 0)",1.00,FAIL,no,no
@@ -95,6 +101,7 @@ sumi-600,ink-900,"oklch(0.470 0 0)","oklch(0.150 0.020 85)",2.88,FAIL,no,no
 sumi-600,bone-50,"oklch(0.470 0 0)","oklch(0.965 0.005 220)",6.18,AA,no,yes
 sumi-600,bone-100,"oklch(0.470 0 0)","oklch(0.920 0.005 220)",5.39,AA,no,yes
 sumi-600,sumi-400,"oklch(0.470 0 0)","oklch(0.700 0.012 220)",2.57,FAIL,no,no
+sumi-600,sumi-450,"oklch(0.470 0 0)","oklch(0.665 0.012 220)",2.25,FAIL,no,no
 sumi-600,sumi-500,"oklch(0.470 0 0)","oklch(0.620 0 0)",1.87,FAIL,no,no
 sumi-600,sumi-600,"oklch(0.470 0 0)","oklch(0.470 0 0)",1.00,FAIL,no,no
 sumi-600,sumi-700,"oklch(0.470 0 0)","oklch(0.380 0 0)",1.47,FAIL,no,no
@@ -110,6 +117,7 @@ persimmon-600,ink-900,"oklch(0.520 0.180 38)","oklch(0.150 0.020 85)",3.28,AA-la
 persimmon-600,bone-50,"oklch(0.520 0.180 38)","oklch(0.965 0.005 220)",5.43,AA,no,yes
 persimmon-600,bone-100,"oklch(0.520 0.180 38)","oklch(0.920 0.005 220)",4.74,AA,no,yes
 persimmon-600,sumi-400,"oklch(0.520 0.180 38)","oklch(0.700 0.012 220)",2.25,FAIL,no,no
+persimmon-600,sumi-450,"oklch(0.520 0.180 38)","oklch(0.665 0.012 220)",1.97,FAIL,no,no
 persimmon-600,sumi-500,"oklch(0.520 0.180 38)","oklch(0.620 0 0)",1.65,FAIL,no,no
 persimmon-600,sumi-600,"oklch(0.520 0.180 38)","oklch(0.470 0 0)",1.14,FAIL,no,no
 persimmon-600,sumi-700,"oklch(0.520 0.180 38)","oklch(0.380 0 0)",1.67,FAIL,no,no
@@ -125,6 +133,7 @@ persimmon-500,ink-900,"oklch(0.640 0.180 38)","oklch(0.150 0.020 85)",5.42,AA,no
 persimmon-500,bone-50,"oklch(0.640 0.180 38)","oklch(0.965 0.005 220)",3.29,AA-large,no,no
 persimmon-500,bone-100,"oklch(0.640 0.180 38)","oklch(0.920 0.005 220)",2.87,FAIL,no,no
 persimmon-500,sumi-400,"oklch(0.640 0.180 38)","oklch(0.700 0.012 220)",1.36,FAIL,no,no
+persimmon-500,sumi-450,"oklch(0.640 0.180 38)","oklch(0.665 0.012 220)",1.19,FAIL,no,no
 persimmon-500,sumi-500,"oklch(0.640 0.180 38)","oklch(0.620 0 0)",1.00,FAIL,no,no
 persimmon-500,sumi-600,"oklch(0.640 0.180 38)","oklch(0.470 0 0)",1.88,FAIL,no,no
 persimmon-500,sumi-700,"oklch(0.640 0.180 38)","oklch(0.380 0 0)",2.76,FAIL,no,no
@@ -140,6 +149,7 @@ ink-900,ink-900,"oklch(0.150 0.020 85)","oklch(0.150 0.020 85)",1.00,FAIL,no,no
 ink-900,bone-50,"oklch(0.150 0.020 85)","oklch(0.965 0.005 220)",17.80,AAA,yes,yes
 ink-900,bone-100,"oklch(0.150 0.020 85)","oklch(0.920 0.005 220)",15.55,AAA,yes,yes
 ink-900,sumi-400,"oklch(0.150 0.020 85)","oklch(0.700 0.012 220)",7.39,AAA,yes,yes
+ink-900,sumi-450,"oklch(0.150 0.020 85)","oklch(0.665 0.012 220)",6.47,AA,no,yes
 ink-900,sumi-500,"oklch(0.150 0.020 85)","oklch(0.620 0 0)",5.40,AA,no,yes
 ink-900,sumi-600,"oklch(0.150 0.020 85)","oklch(0.470 0 0)",2.88,FAIL,no,no
 ink-900,sumi-700,"oklch(0.150 0.020 85)","oklch(0.380 0 0)",1.97,FAIL,no,no

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -101,11 +101,20 @@ export default defineConfig({
             "900": { value: "oklch(0.150 0.020 85)" },
           },
           sumi: {
-            // border 専用色 (Issue #409)。L=0.700 で 1.4.11 3:1 を bg.canvas
-            // (sumi-950, 7.05:1) / bg.surface (sumi-700, 3.76:1) 上で満たす。
-            // bg.elevated (sumi-600, 2.57:1) 上では 3:1 未達のため、bg.elevated
-            // 上の border 用途には使用しないこと (border.subtle JSDoc 参照)。
+            // Issue #409 で追加 (旧 border.subtle dark)。L=0.700 で
+            // bg.canvas 上 7.05:1 / bg.surface 上 3.76:1。
+            // Issue #423 で Calm 思想との整合性が指摘され、border.subtle (dark)
+            // は sumi-450 (L=0.665) に置き換えた。primitive 階層では将来の
+            // 比較用に温存する。
             "400": { value: "oklch(0.700 0.012 220)" },
+            // border 専用色 (Issue #423 で sumi-400 から置換)。L=0.665 で
+            // 1.4.11 3:1 を bg.canvas (sumi-950, 6.18:1) / bg.surface
+            // (sumi-700, 3.29:1) / bg.muted (sumi-650, 4.94:1) 上で満たす。
+            // light cream-300 × bg.surface (3.29:1) と完全な視覚対称性。
+            // bg.elevated (sumi-600, 2.25:1) 上では 3:1 未達のため、
+            // bg.elevated 上の border 用途には使用しないこと
+            // (border.subtle JSDoc 参照)。
+            "450": { value: "oklch(0.665 0.012 220)" },
             // L=0.620 (RFC 02 の初期値 0.560 から AAA 実測で調整、sumi-950 上で 5.15:1)
             "500": { value: "oklch(0.620 0 0)" },
             "600": { value: "oklch(0.470 0 0)" },
@@ -408,28 +417,36 @@ export default defineConfig({
           },
         },
         // ----------------------------------------------------------------
-        // border.subtle (Issue #409 で新規追加)
+        // border.subtle (Issue #409 で新規追加、Issue #423 で dark 値を再調整)
         //
         // R-2b/R-2c で旧 5 段階を圧縮した結果、border に bg.elevated を流用すると
         // 外側 bg.canvas と同色になり視覚消失していた (light の article border が
         // 1.0:1 で完全消失する問題)。border.subtle は border 専用色で、WCAG 1.4.11
-        // (Non-text Contrast) の 3:1 を bg.canvas / bg.surface / bg.muted 上で満たす。
+        // (Non-text Contrast) の 3:1 を bg.canvas / bg.surface / bg.muted 上で
+        // 辛うじて満たす視覚的弱 divider。本文や fg として転用厳禁。
         //
         // 値:
         //   light: cream-300 (oklch(0.620 0.020 85))
         //     - bg.canvas (cream-50) 上 3.49:1 PASS (1.4.11)
         //     - bg.surface (cream-100) 上 3.29:1 PASS (1.4.11)
-        //   dark : sumi-400 (oklch(0.700 0.012 220))
-        //     - bg.canvas (sumi-950) 上 7.05:1 PASS (1.4.11)
-        //     - bg.surface (sumi-700) 上 3.76:1 PASS (1.4.11)
+        //   dark : sumi-450 (oklch(0.665 0.012 220)) — Issue #423 で sumi-400 から変更
+        //     - bg.canvas (sumi-950) 上 6.18:1 PASS (1.4.11)
+        //     - bg.surface (sumi-700) 上 3.29:1 PASS (1.4.11、light と完全に対称)
+        //     - bg.muted (sumi-650) 上 4.94:1 PASS (1.4.11)
+        //
+        // Issue #423 の意図:
+        //   旧 sumi-400 (L=0.700) は dark canvas 上 7.05:1 で本文と同等の主張強度。
+        //   Editorial Citrus の Calm 思想 (装飾ノイズの徹底削除) と相反するため、
+        //   sumi-450 (L=0.665) に変更し、light cream-300 と bg.surface 上で同じ
+        //   3.29:1 となるよう調整して light/dark の視覚的対称性を確保した。
         //
         // 適用ガイドライン:
         //   - article カード (bg.surface) 周りや内部 hr / table / divider など
         //     視覚的区切り線を弱く出したい用途で使用。
-        //   - bg.elevated (dark: sumi-600) 上では 2.57:1 で 3:1 未達。bg.elevated
+        //   - bg.elevated (dark: sumi-600) 上では 2.25:1 で 3:1 未達。bg.elevated
         //     表面の border が必要な場合は引き続き bg.elevated を反転利用する
         //     (Button secondary 等。Issue #409 では置換対象外)。
-        //   - text color として転用しないこと (border 専用 token)。
+        //   - text color として転用厳禁 (border 専用 token)。
         //
         // 関連: bg.muted (light: cream-75 / dark: sumi-650) と組合せて、注釈
         // ブロックや弱強調カードの「面 + 区切り」を表現する。
@@ -438,7 +455,7 @@ export default defineConfig({
           subtle: {
             value: {
               _light: "{colors.cream.300}",
-              _dark: "{colors.sumi.400}",
+              _dark: "{colors.sumi.450}",
             },
           },
         },

--- a/scripts/calculateContrast.ts
+++ b/scripts/calculateContrast.ts
@@ -251,23 +251,25 @@ const getContrastPairs = (): readonly ContrastPair[] => {
       minRatio: 3.0,
       category: "decorative",
     },
+    // Issue #423: dark border.subtle を sumi-400 → sumi-450 に変更
+    // (Calm 思想と整合する弱 divider、light cream-300 との視覚対称性)。
     {
-      name: "border.subtle/dark: sumi-400 × sumi-950 (bg.canvas)",
-      fg: oklchPrimitives.sumi["400"],
+      name: "border.subtle/dark: sumi-450 × sumi-950 (bg.canvas)",
+      fg: oklchPrimitives.sumi["450"],
       bg: oklchPrimitives.sumi["950"],
       minRatio: 3.0,
       category: "decorative",
     },
     {
-      name: "border.subtle/dark: sumi-400 × sumi-700 (bg.surface)",
-      fg: oklchPrimitives.sumi["400"],
+      name: "border.subtle/dark: sumi-450 × sumi-700 (bg.surface)",
+      fg: oklchPrimitives.sumi["450"],
       bg: oklchPrimitives.sumi["700"],
       minRatio: 3.0,
       category: "decorative",
     },
     {
-      name: "border.subtle/dark: sumi-400 × sumi-650 (bg.muted)",
-      fg: oklchPrimitives.sumi["400"],
+      name: "border.subtle/dark: sumi-450 × sumi-650 (bg.muted)",
+      fg: oklchPrimitives.sumi["450"],
       bg: oklchPrimitives.sumi["650"],
       minRatio: 3.0,
       category: "decorative",
@@ -434,8 +436,10 @@ const collectMatrixColors = (): {
     { label: "ink-900", value: oklchPrimitives.ink["900"], role: "fg" },
     { label: "bone-50", value: oklchPrimitives.bone["50"], role: "fg" },
     { label: "bone-100", value: oklchPrimitives.bone["100"], role: "fg" },
-    // Issue #409 で追加 (border.subtle dark)
+    // Issue #409 で追加 (旧 border.subtle dark、Issue #423 で sumi-450 に置換)
     { label: "sumi-400", value: oklchPrimitives.sumi["400"], role: "fg" },
+    // Issue #423 で追加 (border.subtle dark の新値、Calm 思想と整合)
+    { label: "sumi-450", value: oklchPrimitives.sumi["450"], role: "fg" },
     { label: "sumi-500", value: oklchPrimitives.sumi["500"], role: "fg" },
     { label: "sumi-600", value: oklchPrimitives.sumi["600"], role: "fg" },
     { label: "sumi-700", value: oklchPrimitives.sumi["700"], role: "fg" },

--- a/src/components/common/CardSkeleton.tsx
+++ b/src/components/common/CardSkeleton.tsx
@@ -36,7 +36,7 @@ const cardStyles = css({
 //   bg.surface (cream-50) との差が 1.06:1 で視覚消失していた。
 // - border.subtle は WCAG 1.4.11 (Non-text Contrast) の 3:1 を満たす:
 //   light: cream-300 × cream-100 (bg.surface) = 3.29:1
-//   dark : sumi-400  × sumi-700  (bg.surface) = 3.76:1
+//   dark : sumi-450  × sumi-700  (bg.surface) = 3.29:1 (Issue #423 で sumi-400 から変更)
 const cardHeaderStyles = css({
   padding: "sm-md",
   paddingBottom: "md",

--- a/src/components/common/PostNavigation.tsx
+++ b/src/components/common/PostNavigation.tsx
@@ -14,7 +14,7 @@ interface PostNavigationProps {
 //   外側 bg.canvas (cream-50) との差が 1.06:1 で視覚消失していた。
 // - border.subtle は WCAG 1.4.11 (Non-text Contrast) の 3:1 を満たす:
 //   light: cream-300 × cream-50 (bg.canvas) = 3.49:1
-//   dark : sumi-400  × sumi-950 (bg.canvas) = 7.05:1
+//   dark : sumi-450  × sumi-950 (bg.canvas) = 6.18:1 (Issue #423 で sumi-400 から変更、Calm 思想と整合)
 const navStyles = css({
   display: "flex",
   justifyContent: "space-between",

--- a/src/components/common/TableOfContents.tsx
+++ b/src/components/common/TableOfContents.tsx
@@ -21,7 +21,7 @@ interface TableOfContentsProps {
 //   外側 bg.canvas (cream-50) との差が 1.06:1 で視覚消失していた。
 // - border.subtle は WCAG 1.4.11 (Non-text Contrast) の 3:1 を満たす:
 //   light: cream-300 × cream-50 (bg.canvas) = 3.49:1
-//   dark : sumi-400  × sumi-950 (bg.canvas) = 7.05:1
+//   dark : sumi-450  × sumi-950 (bg.canvas) = 6.18:1 (Issue #423 で sumi-400 から変更、Calm 思想と整合)
 const containerStyle = css({
   background: "bg.canvas",
   borderRadius: "sm",

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -101,7 +101,7 @@ const bentoGridStyles = css({
 //   は外側 bg.canvas (cream-50) との差が 1.06:1 で視覚消失していた。
 // - border.subtle は WCAG 1.4.11 (Non-text Contrast) の 3:1 を満たす:
 //   light: cream-300 × cream-50 (bg.canvas) = 3.49:1
-//   dark : sumi-400  × sumi-950 (bg.canvas) = 7.05:1
+//   dark : sumi-450  × sumi-950 (bg.canvas) = 6.18:1 (Issue #423 で sumi-400 から変更、Calm 思想と整合)
 const indexListStyles = css({
   listStyle: "none",
   margin: 0,

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -93,8 +93,9 @@ export const PostDetailPage = ({
            *   bg.canvas (cream-50) と bg.elevated (cream-50) が同値で 1.0:1 の
            *   完全消失となっていた。
            * - border.subtle は border 専用色で、light は cream-300、dark は
-           *   sumi-400。1.4.11 (Non-text Contrast) の 3:1 を bg.canvas /
-           *   bg.surface 上で満たす (light: 3.29-3.49:1 / dark: 3.76-7.05:1)。
+           *   sumi-450 (Issue #423 で sumi-400 から変更)。1.4.11 (Non-text
+           *   Contrast) の 3:1 を bg.canvas / bg.surface 上で満たす
+           *   (light: 3.29-3.49:1 / dark: 3.29-6.18:1)。
            */}
           <article
             className={css({

--- a/src/lib/__tests__/colorTokens.test.ts
+++ b/src/lib/__tests__/colorTokens.test.ts
@@ -51,6 +51,7 @@ describe("oklchPrimitives", () => {
       oklchPrimitives.ink.secondaryOnCream,
       oklchPrimitives.ink["900"],
       oklchPrimitives.sumi["400"],
+      oklchPrimitives.sumi["450"],
       oklchPrimitives.sumi["500"],
       oklchPrimitives.sumi["600"],
       oklchPrimitives.sumi["650"],
@@ -339,9 +340,13 @@ describe("Issue #409: bg.muted / border.subtle 階層 token", () => {
     );
   });
 
-  it("borderSubtle は dark で sumi-400 (border 専用色) を指している", () => {
+  it("borderSubtle は dark で sumi-450 (Calm 思想整合の border 専用色) を指している", () => {
+    // Issue #423: 旧 sumi-400 (L=0.700, 7.05:1) は本文と同等の主張強度のため
+    // Calm 思想と相反していた。sumi-450 (L=0.665, 6.18:1) に変更して弱 divider
+    // を実現しつつ、light cream-300 と bg.surface 上で同じ 3.29:1 となるよう
+    // 視覚的対称性を確保した。
     expect(semanticColorTokens.borderSubtle.dark).toBe(
-      oklchPrimitives.sumi["400"],
+      oklchPrimitives.sumi["450"],
     );
   });
 

--- a/src/lib/colorTokens.ts
+++ b/src/lib/colorTokens.ts
@@ -42,10 +42,19 @@ export interface OklchPrimitives {
   };
   readonly sumi: {
     /**
-     * Issue #409 で追加。border.subtle (dark) の値に使用。
-     * WCAG 1.4.11 (Non-text Contrast) を bg.canvas / bg.surface 上で満たす。
+     * Issue #409 で追加 (旧 border.subtle dark 値)。
+     * 現在は使用されていないが、テストペア記述や CSV 比較用に primitive
+     * 階層では温存する。
      */
     readonly "400": string;
+    /**
+     * Issue #423 で追加。border.subtle (dark) の新値。
+     * L=0.665 で WCAG 1.4.11 (Non-text Contrast) 3:1 を bg.canvas /
+     * bg.surface / bg.muted 上で満たしつつ、light の cream-300 と
+     * bg.surface 上のコントラスト比 (3.29:1) が完全一致するため、Calm
+     * 思想 (装飾ノイズ削除) と light/dark の視覚的対称性を両立する。
+     */
+    readonly "450": string;
     readonly "500": string;
     readonly "600": string;
     /** Issue #409 で追加。bg.muted (dark) の値に使用。sumi-950 と sumi-700 の中間。 */
@@ -98,11 +107,20 @@ export const oklchPrimitives: OklchPrimitives = {
     "900": "oklch(0.150 0.020 85)",
   },
   sumi: {
-    // Issue #409 で追加 (border.subtle dark)。L=0.700 で
+    // Issue #409 で追加 (旧 border.subtle dark)。L=0.700 で
     //   bg.canvas (sumi-950) 上 7.05:1 / bg.surface (sumi-700) 上 3.76:1。
-    //   bg.elevated (sumi-600) 上は 2.57:1 で 3:1 未達のため、bg.elevated 上の
-    //   border 用途には使わない方針 (border.subtle JSDoc 参照)。
+    //   Issue #423 で Calm 思想 (装飾ノイズ削除) との整合性が指摘され、
+    //   border.subtle (dark) は sumi-450 (L=0.665) に置き換えた。
+    //   primitive 階層では将来の比較用に温存する (削除しない)。
     "400": "oklch(0.700 0.012 220)",
+    // Issue #423 で追加 (border.subtle dark の新値)。L=0.665 で
+    //   bg.canvas (sumi-950) 上 6.18:1 / bg.surface (sumi-700) 上 3.29:1。
+    //   light の cream-300 × bg.surface (3.29:1) と完全に一致し、light/dark で
+    //   視覚的対称性が取れる値。Editorial Citrus の Calm 思想 (装飾ノイズの
+    //   徹底削除) と整合する弱 divider。
+    //   bg.muted (sumi-650) 上 4.94:1 / bg.elevated (sumi-600) 上 2.25:1。
+    //   bg.elevated 上は 3:1 未達のため border 用途では使わない方針 (Tripwire)。
+    "450": "oklch(0.665 0.012 220)",
     // L=0.620 (RFC 02 の初期値 0.560 から AAA 実測で調整、sumi-950 上で 5.15:1)
     "500": "oklch(0.620 0 0)",
     "600": "oklch(0.470 0 0)",
@@ -253,28 +271,37 @@ export interface SemanticColorTokens {
    */
   readonly focusRing: SemanticColorPair;
   /**
-   * 控えめな border 専用色 (Issue #409 で追加)。
+   * 控えめな border 専用色 (Issue #409 で追加、Issue #423 で dark 値を再調整)。
    *
    * R-2b/R-2c で旧 5 段階を圧縮した結果、border に bg.elevated を流用すると
    * 外側 bg.canvas と同色になり視覚消失していた (light の article border が
    * 1.0:1 で完全消失する問題)。borderSubtle は border 専用色で、WCAG 1.4.11
-   * (Non-text Contrast) の 3:1 を bg.canvas / bg.surface / bg.muted 上で満たす。
+   * (Non-text Contrast) の 3:1 を bg.canvas / bg.surface / bg.muted 上で
+   * **辛うじて満たす視覚的弱 divider**。本文や fg として転用厳禁。
    *
    * **値**:
    * - light: cream-300 (oklch(0.620 0.020 85))
    *   - bg.canvas (cream-50) 上 3.49:1 PASS (1.4.11)
    *   - bg.surface (cream-100) 上 3.29:1 PASS (1.4.11)
-   * - dark : sumi-400 (oklch(0.700 0.012 220))
-   *   - bg.canvas (sumi-950) 上 7.05:1 PASS (1.4.11)
-   *   - bg.surface (sumi-700) 上 3.76:1 PASS (1.4.11)
+   * - dark : sumi-450 (oklch(0.665 0.012 220)) — Issue #423 で sumi-400 から変更
+   *   - bg.canvas (sumi-950) 上 6.18:1 PASS (1.4.11)
+   *   - bg.surface (sumi-700) 上 3.29:1 PASS (1.4.11、light と完全に対称)
+   *   - bg.muted (sumi-650) 上 4.94:1 PASS (1.4.11)
+   *
+   * **Issue #423 の意図**: 旧 sumi-400 (L=0.700) は dark canvas 上 7.05:1 で
+   * 本文と同等の主張強度となり、Editorial Citrus の Calm 思想 (装飾ノイズの
+   * 徹底削除) と相反していた。新値 sumi-450 (L=0.665) は light cream-300 と
+   * bg.surface 上で同じ 3.29:1 となるよう調整し、light/dark の視覚的対称性を
+   * 確保する。
    *
    * **適用ガイドライン**:
    * - article カード (bg.surface) 周りや内部 hr / table / divider など、
    *   視覚的区切り線を弱く出したい用途で使用する。
-   * - bg.elevated (dark: sumi-600) 上では 2.57:1 で 3:1 未達。bg.elevated
+   * - bg.elevated (dark: sumi-600) 上では 2.25:1 で 3:1 未達。bg.elevated
    *   表面の border が必要な場合は引き続き bg.elevated 反転利用 (Button
    *   secondary / BackToTop など、Issue #409 では置換対象外) を継続する。
-   * - text color として転用しないこと (border 専用 token)。
+   * - **text color として転用厳禁** (border 専用 token)。本文として使うと
+   *   AAA 7.20:1 を満たさず、可読性が大幅に低下する。
    */
   readonly borderSubtle: SemanticColorPair;
   /**
@@ -344,7 +371,10 @@ export const semanticColorTokens: SemanticColorTokens = {
   },
   borderSubtle: {
     light: oklchPrimitives.cream["300"],
-    dark: oklchPrimitives.sumi["400"],
+    // Issue #423: dark を sumi-400 (L=0.700, 7.05:1) → sumi-450 (L=0.665,
+    // 6.18:1) に変更。Calm 思想と整合する弱 divider を実現しつつ、
+    // light cream-300 × bg.surface (3.29:1) と完全な視覚的対称性を確保。
+    dark: oklchPrimitives.sumi["450"],
   },
   bgCode: {
     light: codeBlockColors.light.bg0,


### PR DESCRIPTION
## 概要

Issue #423 で指摘された「PR #418 で導入した dark `border.subtle` (sumi-400, L=0.700) が `bg.canvas` 上 7.05:1 となり Editorial Citrus の Calm 思想と相反する」問題を解消する。

**採用方針**: primitive `sumi-450 = oklch(0.665 0.012 220)` を新設し、`border.subtle` の dark 参照を sumi-400 → sumi-450 に切替。light の `cream-300 × bg.surface = 3.29:1` と dark の `sumi-450 × bg.surface = 3.29:1` が**完全一致**するため、light/dark の視覚的対称性を確保しつつ WCAG 1.4.11 (3:1) を堅持する。

> 注: Issue 本文の案 A (sumi-500 単純置換) は `sumi-500 × bg.surface = 2.75:1` で 1.4.11 fail のため不採用。sumi-500 (L=0.620) を起点に bg.surface 上 3:1 を確保できる最小 L 値を二分探索し、light との視覚対称性が完全一致する L=0.665 を採用した。

Closes #423

## 変更内容

- `src/lib/colorTokens.ts`: primitive `sumi-450` を追加。`borderSubtle.dark` を sumi-450 参照に切替。JSDoc に「本文 / fg として転用厳禁」を明文化し、Issue #423 の経緯を追記。sumi-400 は将来比較用に primitive 階層では温存。
- `panda.config.ts`: 上記と同期。`border.subtle.value._dark` を `{colors.sumi.450}` に切替。
- `scripts/calculateContrast.ts`: `border.subtle/dark` の検証ペア (canvas/surface/muted) を sumi-450 ベースに変更。CSV 出力対象 fg にも sumi-450 を追加。
- `src/lib/__tests__/colorTokens.test.ts`: parse 検証配列に sumi-450 を追加。`borderSubtle.dark` の参照値テストを sumi-450 に更新。閾値 3:1 ベースのテスト群は値変更不要。
- `src/components/{common/CardSkeleton,PostNavigation,TableOfContents}.tsx`, `src/components/pages/{HomePage,PostDetailPage}.tsx`: 適用済コンポーネント内のコメント (旧コントラスト値表記) を sumi-450 の実値に更新。コード自体は変更なし。
- `docs/contrast-matrix.csv`: `pnpm contrast:matrix` で再生成。sumi-450 行 10 件 (surfaces 数) を追加。

## 新値の検証結果

WCAG 1.4.11 (3:1) を全て満たし、light との対称性も実現:

| 背景 | light cream-300 | dark sumi-450 (new) | 旧 dark sumi-400 |
|---|---|---|---|
| `bg.canvas` | 3.49:1 | **6.18:1** | 7.05:1 |
| `bg.surface` | 3.29:1 | **3.29:1** (完全一致) | 3.76:1 |
| `bg.muted` | 3.39:1 | **4.94:1** | 5.64:1 |
| `bg.elevated` | (light: 1.0:1 同値) | 2.25:1 (Tripwire 維持) | 2.57:1 |

検証コマンド:

- `pnpm contrast:check`: 全 47 ペア pass / NG 0
- `pnpm test:run`: 全 606 テスト pass
- `pnpm lint`: pass
- `pnpm build`: pass

## 備考

- VR baseline (`e2e/visual/`) の更新は Issue #410 の責務のため、本 PR には含めない。
- bg.elevated 上の `border.subtle` 2.25:1 (3:1 未達) は意図的な Tripwire (colorTokens.test.ts L413-422) で維持。bg.elevated 表面の border が必要な場合は Button secondary / BackToTop 等の bg.elevated 反転利用を引き続き使用する。