### PR TITLE
fix: ReadingProgressBar に aria-label を付与 (Closes #446)

### DIFF
--- a/e2e/a11y/violations.spec.ts
+++ b/e2e/a11y/violations.spec.ts
@@ -33,13 +33,8 @@ const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
  *
  * - color-contrast: gruvbox の #83a598 / #7c6f64 系が AA (4.5:1) を満たさない
  *   → Editorial Citrus OKLCH トークン導入 (Issue #0a / G2) で解消
- * - aria-progressbar-name: ReadingProgressBar の aria 名称欠落
- *   → Issue #4a で名称付与
  */
-const KNOWN_VIOLATION_IDS = new Set<string>([
-  "color-contrast",
-  "aria-progressbar-name",
-]);
+const KNOWN_VIOLATION_IDS = new Set<string>(["color-contrast"]);
 
 for (const target of TARGETS) {
   test(`${target.name} (${target.path}) に WCAG 2.1 AA 違反がない`, async ({

--- a/src/components/common/ReadingProgressBar.tsx
+++ b/src/components/common/ReadingProgressBar.tsx
@@ -31,9 +31,11 @@ export const ReadingProgressBar = () => {
     <div
       className={barContainerStyles}
       role="progressbar"
+      aria-label="読書進捗"
       aria-valuenow={progress}
       aria-valuemin={0}
       aria-valuemax={100}
+      aria-valuetext={`${progress}%`}
     >
       <div className={barStyles} style={{ width: `${progress}%` }} />
     </div>

--- a/src/components/common/__tests__/ReadingProgressBar.test.tsx
+++ b/src/components/common/__tests__/ReadingProgressBar.test.tsx
@@ -48,6 +48,24 @@ describe("ReadingProgressBar", () => {
     expect(bar).toHaveAttribute("aria-valuemax", "100");
   });
 
+  it("aria-label として「読書進捗」を持つ", () => {
+    vi.mocked(useReadingProgress).mockReturnValue(0);
+
+    render(<ReadingProgressBar />);
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-label", "読書進捗");
+  });
+
+  it("aria-valuetext として進捗をパーセント表記で持つ", () => {
+    vi.mocked(useReadingProgress).mockReturnValue(42);
+
+    render(<ReadingProgressBar />);
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuetext", "42%");
+  });
+
   // ====================================================================
   // Editorial Citrus token Tripwire テスト (R-2b / Issue #389)
   //


### PR DESCRIPTION
## 概要

ReadingProgressBar の `aria-progressbar-name` 違反を根本解消するため、`role="progressbar"` 要素に `aria-label="読書進捗"` と `aria-valuetext` を付与する。あわせて a11y 既知違反 allow-list から `aria-progressbar-name` を削除し、新規違反混入を CI で検出できる状態に戻す。

Closes #446

## 変更内容

- `src/components/common/ReadingProgressBar.tsx`
  - progressbar role に `aria-label="読書進捗"` を追加 (root cause 解消)
  - `aria-valuetext={`${progress}%`}` を追加し、SR で「読書進捗 N パーセント」を明示できるようにする
- `src/components/common/__tests__/ReadingProgressBar.test.tsx`
  - 「aria-label として『読書進捗』を持つ」テストを追加
  - 「aria-valuetext として進捗をパーセント表記で持つ」テストを追加 (TDD: Red → Green)
- `e2e/a11y/violations.spec.ts`
  - `KNOWN_VIOLATION_IDS` から `aria-progressbar-name` を削除
  - 対応するコメントも削除

## 備考

- DA レビュー結果に従い、可視ラベル DOM が無いため `aria-labelledby` ではなく `aria-label` を採用 (文言「読書進捗」、`lang="ja"`)。
- 既存の role / valuenow / valuemin / valuemax / token Tripwire テストには影響なし。
- スコープ外として、以下は本 PR では触らない:
  - `useReadingProgress` の下限クランプ (`Math.max(0, ...)`)
  - `color-contrast` allow-list 残置
- 検証結果:
  - `pnpm test:run`: 608/608 pass
  - `pnpm lint`: pass
  - `pnpm build`: pass
  - `pnpm test:a11y`: 9/9 pass (allow-list 削除後も新規違反 0)