### PR TITLE
refactor: MetaInfo header variant の rgba を bg.muted に置換 (Closes #447)

### DIFF
--- a/src/components/common/MetaInfo.tsx
+++ b/src/components/common/MetaInfo.tsx
@@ -73,7 +73,7 @@ const itemCardStyles = css({
 
 const itemHeaderStyles = css({
   color: "fg.primary",
-  background: "rgba(251, 241, 199, 0.15)",
+  background: "bg.muted",
   paddingY: "sm",
   paddingX: "md",
   borderRadius: "xl",


### PR DESCRIPTION
## 概要

Issue #447 対応。`MetaInfo` の `header` variant に残っていた `rgba(251, 241, 199, 0.15)` ハードコードを、Issue #409 で実装済みの semantic token `bg.muted` (light: `cream-75` / dark: `sumi-650`) に置換します。R-2c (Issue #390) で見落とされた token 化漏れの修正です。

## 変更内容

- `src/components/common/MetaInfo.tsx`: `itemHeaderStyles.background` を `rgba(251, 241, 199, 0.15)` から `bg.muted` に変更。light/dark 個別の hex を使い分ける必要が解消され、semantic token 経由でテーマ対応が一本化されます。

## 備考

### デザイン変更の方向性

**light テーマで chip の視認性が現状より上がる方向の変化です**。

- 現状 (light): cream-50 (`#fbf1c7`) に対し `rgba(251, 241, 199, 0.15)` (cream-50 を 15% 透過合成) は背景と非常に近く chip が浮き上がりにくい
- 変更後 (light): `cream-75` (R/G/B が `#fbf1c7` と canvas の中間) のため、chip がより明瞭に区別できる
- 変更後 (dark): `sumi-650` (canvas より明るい中間階調) で chip が浮き上がる方向

light/dark で「浮く/沈む」が反転しますが、どちらも視認性は確保されており、Editorial Citrus の semantic 設計 (bg.muted = canvas と surface の中間階調) に整合します。

### コントラスト検証 (`pnpm contrast:check`)

- light: `fg.primary × bg.muted` = **16.67:1 (AAA)**
- dark : `fg.primary × bg.muted` = **13.59:1 (AAA)**
- 1.4.11 (Non-text Contrast 3:1) の chip 輪郭は `border.subtle` で確保 (既存 token 検証済み)

### スコープ外

- `scripts/lintTokens.ts` への rgba / hex 検出パターン追加は本 PR に含めません (Issue 補足のとおり、別 PR / 別 Issue で対応)。

## 検証結果

- [x] `pnpm test:run` 全 pass (43 files / 606 tests)
- [x] `pnpm test:run -- MetaInfo` pass (`[class*="bg_"]` セレクタは bg.muted でも引き続きマッチし、テスト変更不要)
- [x] `pnpm lint` pass
- [x] `pnpm build` pass
- [x] `pnpm contrast:check` pass (47 OK / 0 NG)

Closes #447