### PR TITLE
refactor: useAdjacentPosts のモジュールキャッシュを削除 (Closes #449)

### DIFF
--- a/src/hooks/__tests__/useAdjacentPosts.test.ts
+++ b/src/hooks/__tests__/useAdjacentPosts.test.ts
@@ -126,4 +126,26 @@ describe("useAdjacentPosts", () => {
     expect(result.current.newerPost).toBeNull();
     expect(mockGetAllPostSummaries).not.toHaveBeenCalled();
   });
+
+  it("同じcurrentIdで2回マウントするとgetAllPostSummariesが2回呼ばれる", async () => {
+    mockGetAllPostSummaries.mockResolvedValue(mockSummaries);
+
+    const { result: firstResult } = renderHook(() =>
+      useAdjacentPosts("20240102100000"),
+    );
+
+    await waitFor(() => {
+      expect(firstResult.current.loading).toBe(false);
+    });
+
+    const { result: secondResult } = renderHook(() =>
+      useAdjacentPosts("20240102100000"),
+    );
+
+    await waitFor(() => {
+      expect(secondResult.current.loading).toBe(false);
+    });
+
+    expect(mockGetAllPostSummaries).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/hooks/useAdjacentPosts.ts
+++ b/src/hooks/useAdjacentPosts.ts
@@ -10,8 +10,6 @@ interface UseAdjacentPostsReturn extends AdjacentPosts {
   loading: boolean;
 }
 
-let summariesCache: PostSummary[] | null = null;
-
 /**
  * 記事リストから指定IDの前後の記事を取得する
  * 配列はID降順（新しい順）のため、index+1が古い記事、index-1が新しい記事
@@ -57,10 +55,8 @@ export const useAdjacentPosts = (
 
       try {
         setLoading(true);
-        if (!summariesCache) {
-          summariesCache = await getAllPostSummaries();
-        }
-        setAdjacentPosts(findAdjacentPosts(summariesCache, currentId));
+        const summaries = await getAllPostSummaries();
+        setAdjacentPosts(findAdjacentPosts(summaries, currentId));
       } catch (error) {
         console.error("Failed to load adjacent posts:", error);
         setAdjacentPosts({ olderPost: null, newerPost: null });


### PR DESCRIPTION
## 概要

Closes #449

`src/hooks/useAdjacentPosts.ts` のモジュールスコープ変数 `summariesCache` を削除し、`useAdjacentPosts` 内で都度 `getAllPostSummaries()` を呼ぶ実装に変更する。

モジュールスコープ cache は以下の問題を抱えていた:

1. Vitest テスト間で状態がリークする (モジュール変数のため初期化されない)
2. dev サーバの HMR で stale data が残留 (記事追加・削除後にブラウザリロード必須)
3. 無効化 API が存在しない

記事数 16 件 (`datasources/*.md` 実測) の規模では `getAllPostSummaries()` の fetch コストは無視可能で、既に `usePosts` 側ではキャッシュなしで都度フェッチしている。両者の挙動を揃える方が一貫性が高いと判断。

Issue 受け入れ基準で示された 3 案のうち **案 A (キャッシュ完全削除)** を採用。
- 案 B (Tanstack Query) は外部ライブラリ追加禁止ルールに抵触
- 案 C (export reset 関数) は production 上の stale data 問題が残るため不採用

## 変更内容

- `src/hooks/useAdjacentPosts.ts`: モジュールレベル `summariesCache` を削除し、`useAdjacentPosts` の `useEffect` 内で都度 `getAllPostSummaries()` を await する実装に変更
- `src/hooks/__tests__/useAdjacentPosts.test.ts`: 同じ `currentId` で 2 回マウントしたとき `getAllPostSummaries` が 2 回呼ばれる (=キャッシュされない) ことを検証する回帰防止テストを追加

## 備考

- 既存テスト 9 ケースは無改修で全 pass (`vi.clearAllMocks()` 後の挙動不変)
- 回帰防止テスト 1 件追加で合計 10 ケース
- `pnpm test:run` / `pnpm lint` / `pnpm build` いずれも pass
- Issue 受け入れ基準「キャッシュ無し/あり両方のケース追加」は、案 A 採用によりキャッシュ概念自体が消えるため不要。代わりに「2 回呼ばれる」回帰防止テストで担保する