### PR TITLE
fix: sanitizePostHtml ラッパー関数で本番設定下の XSS テストを担保 (Closes #448)

### DIFF
--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -1,9 +1,9 @@
-import DOMPurify from "dompurify";
 import { type CSSProperties, useRef } from "react";
 import { css } from "../../../styled-system/css";
 import { useCodeBlockCopy } from "../../hooks/useCodeBlockCopy";
 import { useImageLightbox } from "../../hooks/useImageLightbox";
 import type { Post, PostSummary } from "../../lib/markdown";
+import { sanitizePostHtml } from "../../lib/sanitize";
 import { buildPostHeroTransitionName } from "../../lib/viewTransition";
 import { Link } from "../atoms/Link";
 import { Heading1 } from "../atoms/Typography";
@@ -357,12 +357,9 @@ export const PostDetailPage = ({
               })}
             >
               <div
-                // biome-ignore lint/security/noDangerouslySetInnerHtml: MarkdownをHTMLとして表示するために必要。DOMPurifyでサニタイズ済み
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: MarkdownをHTMLとして表示するために必要。sanitizePostHtml (DOMPurify) でサニタイズ済み
                 dangerouslySetInnerHTML={{
-                  __html: DOMPurify.sanitize(post.content, {
-                    ADD_TAGS: ["button"],
-                    ADD_ATTR: ["data-code"],
-                  }),
+                  __html: sanitizePostHtml(post.content),
                 }}
               />
             </div>

--- a/src/hooks/useCodeBlockCopy.ts
+++ b/src/hooks/useCodeBlockCopy.ts
@@ -1,7 +1,17 @@
 import { useEffect } from "react";
 
 /**
- * コードブロックのコピーボタンにイベントデリゲーションでクリックリスナーを設定するフック
+ * コードブロックのコピーボタンにイベントデリゲーションでクリックリスナーを設定するフック。
+ *
+ * クリック時、対象 button の `data-code` 属性値を `navigator.clipboard.writeText` に
+ * 渡してクリップボードへコピーする。`writeText` はコード実行 sink ではなく単なる
+ * 文字列書き込みのため、`data-code` 内に `javascript:` URI や `<script>` 文字列が
+ * 含まれていてもコード実行リスクは生じない (XSS 観点では低リスク)。
+ *
+ * 加えて、`src/lib/sanitize.ts` の `sanitizePostHtml` 経由で DOMPurify が
+ * `data-code` 値内の危険なパターンを検知すると属性ごと除去するため、本フックには
+ * 危険な文字列が到達しにくい構造になっている。
+ *
  * @param containerRef コンテンツを包含する要素のref
  */
 export const useCodeBlockCopy = (

--- a/src/lib/__tests__/sanitize.test.ts
+++ b/src/lib/__tests__/sanitize.test.ts
@@ -1,11 +1,11 @@
-import DOMPurify from "dompurify";
 import { describe, expect, it } from "vitest";
+import { sanitizePostHtml } from "../sanitize";
 
-describe("DOMPurify.sanitize", () => {
-  describe("XSSパターンの除去", () => {
+describe("sanitizePostHtml", () => {
+  describe("既定の XSS パターン除去 (DOMPurify 既存防御)", () => {
     it("scriptタグが除去される", () => {
       const dirty = "<script>alert('xss')</script>";
-      const result = DOMPurify.sanitize(dirty);
+      const result = sanitizePostHtml(dirty);
 
       expect(result).not.toContain("<script>");
       expect(result).not.toContain("alert");
@@ -13,7 +13,7 @@ describe("DOMPurify.sanitize", () => {
 
     it("imgタグのonerrorイベントハンドラが除去される", () => {
       const dirty = "<img src=x onerror=alert(1)>";
-      const result = DOMPurify.sanitize(dirty);
+      const result = sanitizePostHtml(dirty);
 
       expect(result).not.toContain("onerror");
       expect(result).not.toContain("alert");
@@ -21,14 +21,14 @@ describe("DOMPurify.sanitize", () => {
 
     it("javascript:URIが除去される", () => {
       const dirty = '<a href="javascript:alert(1)">click</a>';
-      const result = DOMPurify.sanitize(dirty);
+      const result = sanitizePostHtml(dirty);
 
       expect(result).not.toContain("javascript:");
     });
 
     it("SVGタグ内のスクリプトが除去される", () => {
       const dirty = '<svg><script>alert("xss")</script></svg>';
-      const result = DOMPurify.sanitize(dirty);
+      const result = sanitizePostHtml(dirty);
 
       expect(result).not.toContain("<script>");
       expect(result).not.toContain("alert");
@@ -36,14 +36,14 @@ describe("DOMPurify.sanitize", () => {
 
     it("iframeタグが除去される", () => {
       const dirty = '<iframe src="https://evil.com"></iframe>';
-      const result = DOMPurify.sanitize(dirty);
+      const result = sanitizePostHtml(dirty);
 
       expect(result).not.toContain("<iframe");
     });
 
     it("onloadイベントハンドラが除去される", () => {
       const dirty = '<body onload="alert(1)">';
-      const result = DOMPurify.sanitize(dirty);
+      const result = sanitizePostHtml(dirty);
 
       expect(result).not.toContain("onload");
       expect(result).not.toContain("alert");
@@ -53,14 +53,14 @@ describe("DOMPurify.sanitize", () => {
   describe("安全なHTMLの保持", () => {
     it("pタグが保持される", () => {
       const safe = "<p>テキストです。</p>";
-      const result = DOMPurify.sanitize(safe);
+      const result = sanitizePostHtml(safe);
 
       expect(result).toBe(safe);
     });
 
     it("httpsリンクを含むaタグが保持される", () => {
       const safe = '<a href="https://example.com">リンク</a>';
-      const result = DOMPurify.sanitize(safe);
+      const result = sanitizePostHtml(safe);
 
       expect(result).toContain('href="https://example.com"');
       expect(result).toContain("リンク");
@@ -68,14 +68,14 @@ describe("DOMPurify.sanitize", () => {
 
     it("strongタグが保持される", () => {
       const safe = "<strong>太字テキスト</strong>";
-      const result = DOMPurify.sanitize(safe);
+      const result = sanitizePostHtml(safe);
 
       expect(result).toBe(safe);
     });
 
     it("ulとliタグが保持される", () => {
       const safe = "<ul><li>項目1</li><li>項目2</li></ul>";
-      const result = DOMPurify.sanitize(safe);
+      const result = sanitizePostHtml(safe);
 
       expect(result).toContain("<ul>");
       expect(result).toContain("<li>項目1</li>");
@@ -83,10 +83,148 @@ describe("DOMPurify.sanitize", () => {
 
     it("imgタグのsrcとaltが保持される", () => {
       const safe = '<img src="https://example.com/image.png" alt="説明">';
-      const result = DOMPurify.sanitize(safe);
+      const result = sanitizePostHtml(safe);
 
       expect(result).toContain('src="https://example.com/image.png"');
       expect(result).toContain('alt="説明"');
+    });
+  });
+
+  describe("本番設定 (ADD_TAGS: button, ADD_ATTR: data-code) 下の許可挙動", () => {
+    it("buttonタグが保持される", () => {
+      const safe = '<button type="button">クリック</button>';
+      const result = sanitizePostHtml(safe);
+
+      expect(result).toContain("<button");
+      expect(result).toContain("クリック</button>");
+    });
+
+    it("buttonタグのdata-code属性が保持される", () => {
+      const safe =
+        '<button type="button" class="copy-btn" data-code="const x = 1;">コピー</button>';
+      const result = sanitizePostHtml(safe);
+
+      expect(result).toContain("<button");
+      expect(result).toContain('data-code="const x = 1;"');
+      expect(result).toContain("コピー</button>");
+    });
+
+    it("renderer.code が生成するコードブロックラッパー構造が保持される", () => {
+      const safe =
+        '<div class="code-block-wrapper"><button type="button" class="copy-btn" data-code="echo hi">コピー</button><pre><code class="language-bash">echo hi</code></pre></div>';
+      const result = sanitizePostHtml(safe);
+
+      expect(result).toContain('class="code-block-wrapper"');
+      expect(result).toContain('class="copy-btn"');
+      expect(result).toContain('data-code="echo hi"');
+      expect(result).toContain('class="language-bash"');
+    });
+  });
+
+  describe("本番設定下の XSS パターン除去 (button + data-code 許可下のフルパス検証)", () => {
+    it("button タグの onclick 属性が除去される", () => {
+      const dirty = '<button onclick="alert(1)">XSS</button>';
+      const result = sanitizePostHtml(dirty);
+
+      expect(result).toContain("<button");
+      expect(result).not.toContain("onclick");
+      expect(result).not.toContain("alert(1)");
+    });
+
+    it("button タグの onmouseover 等の他イベントハンドラも除去される", () => {
+      const dirty = '<button onmouseover="alert(1)" onfocus="alert(2)">XSS</button>';
+      const result = sanitizePostHtml(dirty);
+
+      expect(result).toContain("<button");
+      expect(result).not.toContain("onmouseover");
+      expect(result).not.toContain("onfocus");
+      expect(result).not.toContain("alert");
+    });
+
+    it("button タグの formaction 属性が除去される", () => {
+      const dirty = '<button formaction="javascript:alert(1)">submit</button>';
+      const result = sanitizePostHtml(dirty);
+
+      expect(result).toContain("<button");
+      expect(result).not.toContain("formaction");
+      expect(result).not.toContain("javascript:");
+    });
+
+    it("data-code 内に javascript: URI を仕込んでも、data-* は実行 sink ではないため許可属性として残るが、HTML 解釈上は無害である", () => {
+      // data-code は単なるカスタムデータ属性のため、属性値内の文字列は実行されない。
+      // useCodeBlockCopy は値を clipboard.writeText に渡すのみで、コード実行 sink ではない。
+      const dirty = '<button data-code="javascript:alert(1)">click</button>';
+      const result = sanitizePostHtml(dirty);
+
+      // data-code は ADD_ATTR で許可されているため保持される
+      expect(result).toContain('data-code="javascript:alert(1)"');
+      // しかし <script> や onclick のような実行コンテキストは生まれない
+      expect(result).not.toContain("<script");
+      expect(result).not.toContain("onclick");
+    });
+
+    it("data-code 値内に script タグの文字列があっても、属性値はパース時にエスケープ済みで実行されない", () => {
+      // marked の renderer.code は escapeHtmlAttr 済みのため、実際の本番経路では
+      // &quot; / &lt; 等にエスケープ済の状態で DOMPurify に渡される。
+      // ここでは「ユーザが直接書いた <button> + 危険な data-code」を再現。
+      const dirty =
+        '<button data-code="&quot;><script>alert(1)</script>">click</button>';
+      const result = sanitizePostHtml(dirty);
+
+      // DOMPurify を通った後、独立した <script> タグは残らない
+      expect(result).not.toContain("<script>");
+      expect(result).not.toContain("alert(1)</script>");
+    });
+
+    it("data-code 値内の生クォートブレイクアウト試行は属性値として正規化され、実行コンテキストを生まない", () => {
+      // 生のHTML文字列で属性値にダブルクォートを含めようとしたケース。
+      // ブラウザのHTMLパーサが属性値の境界を再解釈し、後続は別属性/テキストになる。
+      const dirty =
+        '<button data-code="\\"><script>alert(1)</script>">click</button>';
+      const result = sanitizePostHtml(dirty);
+
+      // <script> はサニタイズ対象なので残らない
+      expect(result).not.toContain("<script>");
+      expect(result).not.toContain("alert(1)");
+    });
+
+    it("button タグ内に script タグを直接埋め込もうとしても script は除去される", () => {
+      const dirty =
+        '<button data-code="x">click<script>alert(1)</script></button>';
+      const result = sanitizePostHtml(dirty);
+
+      expect(result).toContain("<button");
+      expect(result).not.toContain("<script>");
+      expect(result).not.toContain("alert(1)");
+    });
+  });
+
+  describe("renderer.code 経路を経た本番想定 HTML の挙動 (退行検知)", () => {
+    it("escapeHtmlAttr で &quot; に変換された data-code 値は属性値として保持される", () => {
+      // renderer.code が生成する形式: " は &quot; にエスケープ済み
+      const escaped =
+        '<button type="button" class="copy-btn" data-code="alert(&quot;xss&quot;)">コピー</button>';
+      const result = sanitizePostHtml(escaped);
+
+      // エスケープ済みの状態が保持される
+      expect(result).toContain('data-code="alert(&quot;xss&quot;)"');
+      expect(result).not.toContain("<script");
+      expect(result).not.toContain("</button><");
+    });
+
+    it("escapeHtmlAttr で &lt; / &gt; に変換された data-code 値が script 文字列を含む場合、DOMPurify が data-code 属性ごと除去する (退行検知)", () => {
+      // < > も &lt; / &gt; にエスケープ済みの想定。
+      // DOMPurify は属性値内の "script" 等を検知すると、その属性自体を除去する。
+      // これは本プロジェクトの想定 (XSS 防御) 上は望ましい挙動であり、退行検知として固定する。
+      const escaped =
+        '<button type="button" class="copy-btn" data-code="&lt;script&gt;alert(1)&lt;/script&gt;">コピー</button>';
+      const result = sanitizePostHtml(escaped);
+
+      // button タグ自体は許可されるが、data-code 属性は DOMPurify により除去される
+      expect(result).toContain("<button");
+      expect(result).not.toContain("data-code=");
+      // 当然、生の <script> タグも残らない
+      expect(result).not.toContain("<script>alert(1)</script>");
     });
   });
 });

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,36 @@
+import DOMPurify from "dompurify";
+
+/**
+ * 投稿本文 (Markdown を marked で HTML 化したもの) を DOMPurify でサニタイズする
+ * ラッパー関数。
+ *
+ * 本プロジェクトでは、コードブロックに「コピー」ボタン (`<button class="copy-btn"
+ * data-code="...">`) を埋め込むため、DOMPurify の既定許可タグ・属性に加えて
+ * 以下を許可している。
+ *
+ * - `ADD_TAGS: ["button"]` … コピー UI に使用する button タグを保持する
+ * - `ADD_ATTR: ["data-code"]` … コピー対象テキストを格納するカスタム属性を保持する
+ *
+ * これらの追加許可は `PostDetailPage` で必要となる最小限の拡張であり、
+ * `onclick` などのイベントハンドラ属性は DOMPurify が既定で除去するため、
+ * button が許可された状態でも XSS 経路は開かない。
+ *
+ * `data-code` 属性は `useCodeBlockCopy.ts` から `navigator.clipboard.writeText` に
+ * 渡されるが、`writeText` はコード実行 sink ではなく単なる文字列書き込みのため、
+ * 属性値内に `javascript:` URI や `<script>` 文字列が含まれていてもコード実行
+ * リスクは生じない。万一クリップボードに長文や制御文字が含まれてもユーザ操作で
+ * 上書き可能であり、即時の悪用リスクは低い。
+ *
+ * 設定の drift を防ぐため、本番コードでの DOMPurify 呼び出しは必ずこの関数を
+ * 経由すること (インラインで `DOMPurify.sanitize(..., { ADD_TAGS, ADD_ATTR })`
+ * を書かない)。
+ *
+ * @param html サニタイズ対象の HTML 文字列 (通常 marked が生成した文字列)
+ * @returns 安全な HTML 文字列
+ */
+export const sanitizePostHtml = (html: string): string => {
+  return DOMPurify.sanitize(html, {
+    ADD_TAGS: ["button"],
+    ADD_ATTR: ["data-code"],
+  });
+};


### PR DESCRIPTION
## 概要

`src/lib/__tests__/sanitize.test.ts` は DOMPurify を**既定設定**で直接呼んでおり、本番の `ADD_TAGS: ["button"]` / `ADD_ATTR: ["data-code"]` 設定下での XSS 耐性は一切検証されていなかった。また、`PostDetailPage.tsx:361-366` でサニタイズ設定がインラインで書かれており、追加箇所が増えた際に設定 drift を検知できない構造だった。

本 PR は (1) `sanitizePostHtml` ラッパー関数を新設し本番設定を一元化、(2) テストを `sanitizePostHtml` 経由に書き換え、(3) Issue #448 の AC で挙げられた本番設定下の XSS パターンを網羅するテストを追加する。

## 変更内容

- `src/lib/sanitize.ts`: 新設。`sanitizePostHtml(html)` を export し、`ADD_TAGS=["button"]` / `ADD_ATTR=["data-code"]` を内包。設定 drift を防ぐため、本番経路は必ずこの関数を経由する旨を JSDoc に明記
- `src/components/pages/PostDetailPage.tsx`: インラインの `DOMPurify.sanitize(post.content, { ADD_TAGS, ADD_ATTR })` を `sanitizePostHtml(post.content)` に置換、`DOMPurify` の直接 import を削除
- `src/hooks/useCodeBlockCopy.ts`: `data-code` 経由のクリップボード書き込みがコード実行 sink ではなく XSS 観点で低リスクである旨を JSDoc に明記
- `src/lib/__tests__/sanitize.test.ts`: 既定設定下の DOMPurify テストを `sanitizePostHtml` 経由に書き換え、本番設定下の以下のテストを新規追加
  - 既定の XSS 除去 (script / onerror / javascript: URI / iframe / svg内script / onload) を維持
  - 本番設定下の許可挙動 (button タグ・data-code 属性・renderer.code 構造) を positive test として固定
  - 本番設定下の XSS 除去 (button onclick / onmouseover / formaction / data-code 内 script / quote ブレイクアウト)
  - renderer.code 経路を経た escapeHtmlAttr 済 HTML の挙動を退行検知テストとして記録

## 備考

- Issue #448 に紐づく対応 (Closes #448)
- 外部ライブラリ追加なし (DOMPurify は既存依存)
- 検証: `pnpm test:run` 618 件 pass / `pnpm lint` pass / `pnpm build` pass
- DOMPurify は `data-code` 属性値内に `"script"` 等の文字列が含まれていると属性ごと除去する挙動が確認された。これは XSS 防御として望ましく、退行検知テストとして固定している