### PR TITLE
fix: useReadingProgress に scrollY 下限クランプを追加 (Closes #454)

### DIFF
--- a/src/components/common/__tests__/ReadingProgressBar.test.tsx
+++ b/src/components/common/__tests__/ReadingProgressBar.test.tsx
@@ -67,6 +67,23 @@ describe("ReadingProgressBar", () => {
   });
 
   // ====================================================================
+  // Issue #454: useReadingProgress 側で scrollY を下限クランプするため、
+  // ReadingProgressBar には 0..100 の値のみが渡る前提。
+  // Safari overscroll で scrollY が負値になった場合でも、useReadingProgress
+  // が 0 を返すため aria-valuetext は "0%" となり、aria-valid-attr-value
+  // (aria-valuemin=0 に対する範囲外) 違反は発生しない。
+  // ====================================================================
+  it("useReadingProgress が 0 を返すと aria-valuetext は '0%' になる", () => {
+    vi.mocked(useReadingProgress).mockReturnValue(0);
+
+    render(<ReadingProgressBar />);
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "0");
+    expect(bar).toHaveAttribute("aria-valuetext", "0%");
+  });
+
+  // ====================================================================
   // Editorial Citrus token Tripwire テスト (R-2b / Issue #389)
   //
   // RFC 02 §"Persimmon の使用範囲" は accent.brand を

--- a/src/hooks/__tests__/useReadingProgress.test.ts
+++ b/src/hooks/__tests__/useReadingProgress.test.ts
@@ -81,4 +81,79 @@ describe("useReadingProgress", () => {
 
     expect(result.current).toBe(100);
   });
+
+  // ====================================================================
+  // Issue #454: Safari overscroll で window.scrollY が負値になるケース
+  //
+  // Safari の elastic scroll (overscroll bounce) では window.scrollY が
+  // 一時的に負値になる。下限クランプが無いと aria-valuenow が負値となり、
+  // axe-core の aria-valid-attr-value (aria-valuemin=0) に違反する。
+  // useReadingProgress 側で scrollY を Math.max(0, ...) でクランプし、
+  // progress 値ドメインを 0..100 に正規化する。
+  // ====================================================================
+  describe("scrollY 下限クランプ (Issue #454)", () => {
+    it("scrollY が大きく負値の場合は 0 を返す", () => {
+      const { result } = renderHook(() => useReadingProgress());
+
+      act(() => {
+        Object.defineProperty(window, "scrollY", {
+          value: -50,
+          writable: true,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(result.current).toBe(0);
+    });
+
+    it("scrollY が -1 でも 0 を返す (-0 にならない)", () => {
+      const { result } = renderHook(() => useReadingProgress());
+
+      act(() => {
+        Object.defineProperty(window, "scrollY", {
+          value: -1,
+          writable: true,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      // Object.is で -0 / +0 を区別。+0 (=0) であることを確認。
+      expect(Object.is(result.current, 0)).toBe(true);
+      expect(Object.is(result.current, -0)).toBe(false);
+    });
+
+    it("scrollY が 0 の場合は 0 を返す", () => {
+      const { result } = renderHook(() => useReadingProgress());
+
+      act(() => {
+        Object.defineProperty(window, "scrollY", {
+          value: 0,
+          writable: true,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(result.current).toBe(0);
+    });
+
+    it("scrollY が 5 / docHeight 1000 の場合は四捨五入で 1 を返す", () => {
+      const { result } = renderHook(() => useReadingProgress());
+
+      // scrollHeight=2000, innerHeight=1000 → docHeight=1000
+      act(() => {
+        Object.defineProperty(window, "scrollY", {
+          value: 5,
+          writable: true,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      // 5 / 1000 * 100 = 0.5 → Math.round で 1
+      expect(result.current).toBe(1);
+    });
+  });
 });

--- a/src/hooks/useReadingProgress.ts
+++ b/src/hooks/useReadingProgress.ts
@@ -1,6 +1,21 @@
 import { useEffect, useState } from "react";
 import { useScrollPosition } from "./useScrollPosition";
 
+/**
+ * ページ全体のスクロール進捗率 (0..100) を返すフック。
+ *
+ * Safari の elastic scroll (overscroll bounce) では `window.scrollY` が
+ * 一時的に負値を取りうるため、計算前に `Math.max(0, scrollY)` で下限を
+ * クランプする。これにより:
+ *
+ * - progress の値ドメインが厳密に 0..100 に正規化される
+ * - `Math.round((-1 / docHeight) * 100)` が `-0` を返す問題を回避
+ * - 呼び出し側 (ReadingProgressBar) の `aria-valuenow` /
+ *   `aria-valuetext` が `aria-valuemin=0` を満たし、axe-core の
+ *   `aria-valid-attr-value` 違反を防止できる
+ *
+ * @returns 0..100 の整数値 (Math.round 済み)
+ */
 export const useReadingProgress = () => {
   const scrollY = useScrollPosition();
   const [progress, setProgress] = useState(0);
@@ -9,7 +24,12 @@ export const useReadingProgress = () => {
     const docHeight =
       document.documentElement.scrollHeight - window.innerHeight;
     if (docHeight > 0) {
-      setProgress(Math.min(Math.round((scrollY / docHeight) * 100), 100));
+      // Safari overscroll 対策: scrollY を先に下限クランプして
+      // progress の値ドメインを 0..100 に正規化する。
+      const clampedScrollY = Math.max(0, scrollY);
+      setProgress(
+        Math.min(Math.round((clampedScrollY / docHeight) * 100), 100),
+      );
     }
   }, [scrollY]);
 


### PR DESCRIPTION
## 概要

Issue #454 の対応。Safari の elastic scroll (overscroll bounce) で `window.scrollY` が一時的に負値となり、`useReadingProgress` の戻り値が負値や `-0` になっていた問題を修正する。これに伴い `ReadingProgressBar` の `aria-valuenow` / `aria-valuetext` が `aria-valuemin=0` を下回り、axe-core の `aria-valid-attr-value` 違反が発生していた。

`Closes #454`

## 変更内容

- `src/hooks/useReadingProgress.ts`: `Math.max(0, scrollY)` で scrollY を先に下限クランプし、`progress` の値ドメインを 0..100 に正規化。JSDoc で Safari overscroll 対応と aria-valid-attr-value 違反防止の意図を明記
- `src/hooks/__tests__/useReadingProgress.test.ts`: 境界ケース追加 (`scrollY = -50, -1, 0, 5, 1000`)。`-1` のケースは `Object.is` で `+0` / `-0` を厳密区別し、`Math.round` の `-0` リーク回避を保証
- `src/components/common/__tests__/ReadingProgressBar.test.tsx`: `useReadingProgress` が 0 を返したとき `aria-valuenow="0"` / `aria-valuetext="0%"` となり aria-valid-attr-value 違反が発生しないことを確認するケースを追加

## 備考

### 採用方針: scrollY 先クランプ (DA 推奨)

Issue 提案の `return 値を Math.max(0, Math.min(progress, 100)) でクランプ` ではなく、**scrollY を Math.max(0, ...) で先にクランプ** する方針を採用した。理由:

- **単一箇所で正規化**: scrollY 入力時点で 0 未満を 0 に揃えれば、後段の Math.round / Math.min と React state、`aria-valuenow` / `aria-valuetext` / `width` style がすべて自動的に整合する
- **`-0` 問題の回避**: 戻り値クランプ案では `scrollY = -1, docHeight = 1000` の場合に `Math.round((-1/1000)*100) = -0` となり、`Math.max(0, -0)` は `-0` のままで `aria-valuetext` に `"-0%"` 文字列が混入する余地が残る。scrollY 先クランプではこの経路自体を消せる
- **Issue AC の欠落補完**: Issue の AC には `aria-valuetext` の負値混入が記載されていなかったが、PR #451 で `aria-valuetext` 追加済みのため `progress` の値ドメインを正規化すれば DOM 全体が連動して正しくなる

### 検証境界 (テストで担保)

| scrollY | docHeight | 期待 progress |
|---------|-----------|---------------|
| -50     | 1000      | 0             |
| -1      | 1000      | 0 (`+0`、`-0` ではない) |
| 0       | 1000      | 0             |
| 5       | 1000      | 1 (Math.round) |
| 1000    | 1000      | 100 (既存上限) |
| 1500    | 1000      | 100 (既存上限) |

### 検証コマンド結果

- `pnpm test:run`: 614/614 pass
- `pnpm lint`: clean
- `pnpm build`: success