### PR TITLE
fix: BentoCard / IndexRow の border を border.subtle に置換 (Closes #445)

### DIFF
--- a/src/components/atoms/BentoCard.tsx
+++ b/src/components/atoms/BentoCard.tsx
@@ -25,7 +25,7 @@ interface BentoCardProps {
  * "tall" / "wide" / "default" を切り替える。
  *
  * 設計方針:
- * - bg.surface フラット背景 + hover で bg.elevated + subtle shadow
+ * - bg.surface フラット背景 + hover で subtle elevation (translateY + shadow)
  * - タイトルは fg.primary、メタは variant="bento" で fg.secondary
  * - excerpt は line-clamp 3 行で密度を揃える
  * - hover 時にタイトルが accent.link で下線 (subtle underline)
@@ -37,10 +37,18 @@ interface BentoCardProps {
  * - bg.surface (light cream-100) × fg.primary: 16.19:1 AAA
  * - bg.surface (dark sumi-700)   × fg.primary (bone-50): 7.93:1 AAA
  * - bg.surface × fg.secondary (light/dark): 本文寄りでも AAA pass
+ *
+ * border の WCAG 1.4.11 (Non-text Contrast / Issue #445):
+ * 旧 token (bg.elevated) は light 環境で外側 bg.canvas との差が 1.06:1 と
+ * なり border が視覚消失していた。border 専用 token (border.subtle) に置換
+ * して、bg.canvas / bg.surface 上で 1.4.11 の 3:1 を満たす。
+ *   - light: cream-300 × bg.surface 3.29:1 / × bg.canvas 3.49:1 PASS
+ *   - dark : sumi-450  × bg.surface 3.29:1 / × bg.canvas 6.18:1 PASS
  */
 
 // Bento カード共通スタイル。
-// - bg.surface のフラット背景に薄い枠線 (bg.elevated)
+// - bg.surface のフラット背景に border.subtle 専用 token の薄い枠線
+//   (Issue #445: 旧 bg.elevated は light で 1.06:1 視覚消失していた)。
 // - hover で subtle elevation (translateY + shadow) のみ。Calm 思想 (panda.config.ts
 //   L441-447) に従い、background / border-color の動的変化は撤廃して静謐感を保つ。
 // - 内部タイトル (.bento-title) の text-decoration / color 変化は重要なフィードバック
@@ -56,7 +64,7 @@ const bentoWrapperBaseStyles = css({
   borderRadius: "lg",
   padding: "lg",
   border: "1px solid",
-  borderColor: "bg.elevated",
+  borderColor: "border.subtle",
   transition: "transform 0.2s ease, box-shadow 0.2s ease",
   "&:hover": {
     transform: "translateY(-2px)",

--- a/src/components/atoms/IndexRow.tsx
+++ b/src/components/atoms/IndexRow.tsx
@@ -34,11 +34,21 @@ interface IndexRowProps {
  * - bg.canvas × fg.secondary: 9.59:1 AAA / 14.84:1 AAA
  * - bg.canvas × accent.featured: 5.74:1 AA / 5.17:1 AA
  *
+ * borderBottom の WCAG 1.4.11 (Non-text Contrast / Issue #445):
+ * 旧 token (bg.elevated) は light 環境で外側 bg.canvas との差が 1.06:1 と
+ * なり区切り線が視覚消失していた。border 専用 token (border.subtle) に
+ * 置換して、bg.canvas / bg.surface 上で 1.4.11 の 3:1 を満たす。
+ *   - light: cream-300 × bg.canvas 3.49:1 / × bg.surface 3.29:1 PASS
+ *   - dark : sumi-450  × bg.canvas 6.18:1 / × bg.surface 3.29:1 PASS
+ * 最終行は親 ul 構造上、上下罫線が不要なため `&:last-child` で
+ * borderBottom: none を維持する (削除厳禁)。
+ *
  * UI 用絵文字は使用しない (R-4 / Issue #395 (vi))。区切りは Em ダッシュと
  * dotted border のみで構成する。
  */
 
-// 行ラッパー。border-bottom で行間を視覚的に区切る。
+// 行ラッパー。borderBottom (border.subtle) で行間を視覚的に区切る。
+// (Issue #445: 旧 bg.elevated は light で 1.06:1 視覚消失していたため置換。)
 // hover/focus で背景色を bg.surface に切り替えて行を強調。
 // position: relative で stretched link (::after) のアンカーを兼ねる。
 const indexRowStyles = css({
@@ -49,7 +59,7 @@ const indexRowStyles = css({
   paddingY: "sm-md",
   paddingX: "sm",
   borderBottom: "1px solid",
-  borderColor: "bg.elevated",
+  borderColor: "border.subtle",
   flexWrap: "wrap",
   transition: "background 0.2s ease",
   "&:hover": {

--- a/src/components/atoms/__tests__/BentoCard.test.tsx
+++ b/src/components/atoms/__tests__/BentoCard.test.tsx
@@ -145,4 +145,20 @@ describe("BentoCard", () => {
       expect(heading.style.viewTransitionName).toBe("post-bento-vt");
     });
   });
+
+  // Issue #445: 旧 token (bg.elevated) は light 環境で外側 bg.canvas との
+  // 差が 1.06:1 となり border が視覚消失していた。border 専用 token
+  // (border.subtle) に置換した後、Tripwire テストで CI 検出する。
+  it("article の borderColor が border.subtle 専用 token を参照している", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <BentoCard post={buildPost()} />
+      </MemoryRouter>,
+    );
+
+    const article = container.querySelector("article");
+    expect(article).toBeInTheDocument();
+    // Panda は `borderColor: "border.subtle"` を `bd-c_border.subtle` 等に変換する。
+    expect(article?.className).toMatch(/bd-c_border\.subtle/);
+  });
 });

--- a/src/components/atoms/__tests__/IndexRow.test.tsx
+++ b/src/components/atoms/__tests__/IndexRow.test.tsx
@@ -158,4 +158,42 @@ describe("IndexRow", () => {
       );
     });
   });
+
+  // Issue #445: 旧 token (bg.elevated) は light 環境で外側 bg.canvas との
+  // 差が 1.06:1 となり borderBottom が視覚消失していた。border 専用 token
+  // (border.subtle) に置換した後、Tripwire テストで CI 検出する。
+  it("li の borderColor が border.subtle 専用 token を参照している", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ul>
+          <IndexRow post={buildPost()} index={0} />
+        </ul>
+      </MemoryRouter>,
+    );
+
+    const li = container.querySelector("li");
+    expect(li).toBeInTheDocument();
+    // Panda は `borderColor: "border.subtle"` を `bd-c_border.subtle` 等に変換する。
+    expect(li?.className).toMatch(/bd-c_border\.subtle/);
+  });
+
+  // Issue #445: 最終行は親 ul の構造的位置から上下罫線不要のため、
+  // `&:last-child` の borderBottom: none を維持していることを Panda の
+  // 生成クラス名 ([&:last-child]:bd-b_none 形式) で検証する。border.subtle
+  // 置換後もこの挙動が継続することを保証する Tripwire。
+  it("最終行の borderBottom を none に上書きするクラスを持つ", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ul>
+          <IndexRow post={buildPost()} index={0} />
+        </ul>
+      </MemoryRouter>,
+    );
+
+    const li = container.querySelector("li");
+    expect(li).toBeInTheDocument();
+    // Panda は `&:last-child` の borderBottom: none を
+    // `[&:last-child]:bd-b_none` 形式に変換する。
+    expect(li?.className).toMatch(/\[&:last-child\]:bd-b_none/);
+  });
 });


### PR DESCRIPTION
## 概要

BentoCard / IndexRow の `borderColor: bg.elevated` を `border.subtle` に置換し、WCAG 1.4.11 (Non-text Contrast) 違反を解消する (Issue #445)。

旧 token (bg.elevated) は light 環境で外側 bg.canvas との差が 1.06:1 となり border が視覚消失していた。Issue #423 (PR #450) で sumi-450 が border 専用 token に整備されたため、light/dark 双方で対称的に置換可能になった。

DA レビュー結論 (案 A 単純置換) を採用。FeaturedCard は hover 反転構造を持つためスコープ外として Issue #421 で別途扱う。

## 変更内容

- `src/components/atoms/BentoCard.tsx`: article ラッパーの `borderColor` を `bg.elevated` から `border.subtle` に置換。JSDoc に WCAG 1.4.11 達成値 (light 3.29:1 / dark 3.29:1) と Issue #445 経緯を追記。hover transform/shadow は Calm 思想下の subtle elevation として維持。
- `src/components/atoms/IndexRow.tsx`: li ラッパーの `borderColor` を同様に置換。JSDoc に達成値・経緯・`&:last-child` の borderBottom: none 維持注記を追記。最終行の罫線抑制は親 ul 構造上必須のため削除厳禁。
- `src/components/atoms/__tests__/BentoCard.test.tsx`: PostNavigation テスト L80-93 の Tripwire パターンを踏襲し、article className に `bd-c_border.subtle` が含まれることを検証するテストを追加。`bg.elevated` への退行を CI で検出する。
- `src/components/atoms/__tests__/IndexRow.test.tsx`: 同様の border.subtle Tripwire に加え、Panda が `&:last-child` を `[&:last-child]:bd-b_none` クラスに変換していることを検証する Tripwire も追加 (last-child 罫線抑制の維持確認)。

### コントラスト数値 (`pnpm contrast:check` 実測)

| 環境 | 組合せ | 比 | 1.4.11 |
| --- | --- | --- | --- |
| light | cream-300 × bg.canvas (cream-50) | 3.49:1 | PASS |
| light | cream-300 × bg.surface (cream-100) | 3.29:1 | PASS |
| dark | sumi-450 × bg.canvas (sumi-950) | 6.18:1 | PASS |
| dark | sumi-450 × bg.surface (sumi-700) | 3.29:1 | PASS |

## 備考

- VR snapshot 再生成は Issue #410 の責務のため本 PR では実施しない。
- FeaturedCard は hover 反転を伴う構造で対称性検討が必要なため、Issue #421 で別途検討 (本 PR スコープ外)。
- 検証: `pnpm test:run` 612/612 pass、`pnpm lint` pass、`pnpm build` pass、`pnpm contrast:check` 47/47 OK。

Closes #445