### PR TITLE
fix: bg.elevated 反転 border 4 components を border.subtle + hover bg.muted で解消 (Closes #421)

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -443,9 +443,14 @@ export default defineConfig({
         // 適用ガイドライン:
         //   - article カード (bg.surface) 周りや内部 hr / table / divider など
         //     視覚的区切り線を弱く出したい用途で使用。
-        //   - bg.elevated (dark: sumi-600) 上では 2.25:1 で 3:1 未達。bg.elevated
-        //     表面の border が必要な場合は引き続き bg.elevated を反転利用する
-        //     (Button secondary 等。Issue #409 では置換対象外)。
+        //   - Issue #421 で「bg.elevated 反転利用は light で 1.06:1 となり
+        //     視覚消失する」方針が確定したため、Button secondary / BackToTop /
+        //     ImageLightbox / ThemeToggle の border も全て border.subtle に
+        //     置換済み。bg.elevated を border 色として転用することは原則禁止する。
+        //   - bg.elevated (dark: sumi-600) 上では border.subtle × bg.elevated =
+        //     2.25:1 で 3:1 未達。bg.elevated 表面に border が乗る hover 状態
+        //     などは hover 背景を bg.muted (dark: sumi-650) に切替えること
+        //     (border.subtle × bg.muted = light 3.39:1 / dark 4.94:1 で PASS)。
         //   - text color として転用厳禁 (border 専用 token)。
         //
         // 関連: bg.muted (light: cream-75 / dark: sumi-650) と組合せて、注釈

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -62,17 +62,29 @@ const variantStyles = {
       filter: "brightness(0.92)",
     },
   }),
-  // R-2b 修正: border bg.surface × bg bg.elevated は 1.06:1 で枠線が視覚消失していたため、
-  // bg を bg.surface (一段濃い色) / border を bg.elevated (ハイライト色) に反転。
-  // light: bg.surface (cream-100) × fg.primary = 16.19:1 AAA を維持。
-  // dark : bg.surface (sumi-700) × fg.primary (bone-50) = 7.93:1 AAA を維持。
+  // Issue #421 修正: R-2b の bg.elevated 反転 border は light で
+  //   bg.surface (cream-100) × bg.elevated (cream-50) = 1.06:1 となり
+  //   視覚消失していた。border 専用 token (border.subtle) に置換することで、
+  //   1.4.11 (Non-text Contrast) 3:1 を確保する。
+  //   - light: bg.surface (cream-100) × border.subtle (cream-300) = 3.29:1 PASS
+  //   - dark : bg.surface (sumi-700) × border.subtle (sumi-450) = 3.29:1 PASS
+  // また hover 背景は bg.elevated のままだと dark で
+  //   bg.elevated (sumi-600) × border.subtle (sumi-450) = 2.25:1 となり 3:1 未達。
+  // 対応として hover 背景を bg.muted に変更:
+  //   - light: bg.muted (cream-75) × border.subtle (cream-300) = 3.39:1 PASS
+  //   - dark : bg.muted (sumi-650) × border.subtle (sumi-450) = 4.94:1 PASS
+  // 本文コントラスト (AAA 7.20:1) も維持される:
+  //   - light: bg.surface × fg.primary = 16.19:1 / bg.muted × fg.primary = 16.67:1
+  //   - dark : bg.surface × fg.primary = 7.93:1 / bg.muted × fg.primary = 13.59:1
+  // 視覚効果: hover が「明るくフラッシュ」→「わずかに沈み込み」となり、
+  // Editorial Citrus の Calm 思想と整合する。
   secondary: css({
     background: "bg.surface",
     color: "fg.primary",
     border: "1px solid",
-    borderColor: "bg.elevated",
+    borderColor: "border.subtle",
     "&:hover:not(:disabled)": {
-      background: "bg.elevated",
+      background: "bg.muted",
       transform: "translateY(-1px)",
     },
   }),

--- a/src/components/atoms/__tests__/Button.test.tsx
+++ b/src/components/atoms/__tests__/Button.test.tsx
@@ -194,10 +194,24 @@ describe("Button", () => {
       expect(button.className).toMatch(/bg_bg\.surface/);
     });
 
-    it("secondary variant は bg.elevated の border class を持つ", () => {
+    // Issue #421: bg.elevated 反転 border は light で 1.06:1 となり視覚消失
+    // していた。border 専用 token (border.subtle) に置換した後、Tripwire
+    // テストで CI 検出する。
+    it("secondary variant は border.subtle 専用 token の border class を持つ", () => {
       render(<Button variant="secondary">Secondary</Button>);
       const button = screen.getByRole("button", { name: "Secondary" });
-      expect(button.className).toMatch(/bd-c_bg\.elevated|borderColor.*bg\.elevated/);
+      expect(button.className).toMatch(
+        /bd-c_border\.subtle|borderColor.*border\.subtle/,
+      );
+    });
+
+    // Issue #421: hover 背景を bg.elevated から bg.muted に変更。
+    // dark で bg.elevated × border.subtle = 2.25:1 となり 3:1 未達のため、
+    // hover bg を bg.muted (sumi-650) に切り替えて 4.94:1 を確保する。
+    it("secondary variant は hover で bg.muted の background class を持つ", () => {
+      render(<Button variant="secondary">Secondary</Button>);
+      const button = screen.getByRole("button", { name: "Secondary" });
+      expect(button.className).toMatch(/bg_bg\.muted/);
     });
 
     it("ghost variant は accent.link の color class を持つ", () => {

--- a/src/components/common/BackToTop.tsx
+++ b/src/components/common/BackToTop.tsx
@@ -5,11 +5,19 @@ import { focusRingStyles } from "../../styles/focusRing";
 
 const SHOW_THRESHOLD = 300;
 
-// Editorial Citrus トークン (R-2b / Issue #389)
+// Editorial Citrus トークン (R-2b / Issue #389、Issue #421 で border/hover を改訂)
 // - 浮き上がる固定ボタンのため bg.surface を背景に使用 (親 bg.canvas より一段濃く、視認性確保)
-// - border は bg.elevated でハイライト風の枠線にする (bg.surface 同色だと 1.06:1 で消失するため)
-// - hover 時に bg.elevated に反転させて押下感を演出
-// - 文字色は本文色 fg.primary。bg.surface 上で AAA を担保。
+// - border 専用 token (border.subtle) で 1.4.11 (3:1) を確保
+//   旧 bg.elevated 反転は light で bg.surface × bg.elevated = 1.06:1 となり視覚消失していた
+//   - light: bg.surface (cream-100) × border.subtle (cream-300) = 3.29:1 PASS
+//   - dark : bg.surface (sumi-700) × border.subtle (sumi-450) = 3.29:1 PASS
+// - hover 背景は bg.elevated だと dark で bg.elevated × border.subtle = 2.25:1 (3:1 未達)
+//   となるため bg.muted に変更し、light/dark とも 3:1 以上を維持:
+//   - light: bg.muted (cream-75) × border.subtle = 3.39:1 PASS
+//   - dark : bg.muted (sumi-650) × border.subtle = 4.94:1 PASS
+//   視覚効果は「明るくフラッシュ」→「わずかに沈み込み」へ。translateY(-2px) と
+//   boxShadow: card → card-hover は維持し、浮き上がり感は補強する。
+// - 文字色は本文色 fg.primary。bg.surface / bg.muted 上で AAA を担保。
 // R-5 (Issue #393) で transition は prefers-reduced-motion: reduce 時に無効化。
 const buttonStyles = css({
   position: "fixed",
@@ -21,7 +29,7 @@ const buttonStyles = css({
   background: "bg.surface",
   color: "fg.primary",
   border: "1px solid",
-  borderColor: "bg.elevated",
+  borderColor: "border.subtle",
   cursor: "pointer",
   display: "flex",
   alignItems: "center",
@@ -34,7 +42,7 @@ const buttonStyles = css({
     transition: "none",
   },
   "&:hover": {
-    background: "bg.elevated",
+    background: "bg.muted",
     transform: "translateY(-2px)",
     boxShadow: "card-hover",
   },

--- a/src/components/common/ImageLightbox.tsx
+++ b/src/components/common/ImageLightbox.tsx
@@ -41,11 +41,20 @@ const imageStyle = css({
   borderRadius: "md",
 });
 
-// Editorial Citrus トークンに置換 (R-2b / Issue #389、R-2b 修正で border 色を修正)
+// Editorial Citrus トークン (R-2b / Issue #389、Issue #421 で border/hover を改訂)
 // - 暗い backdrop 上の浮き上がる閉じるボタン: bg.surface を背景に
-//   (bg.elevated と bg.surface の同色 border 問題を回避し、視認性も向上)
-// - border は bg.elevated でハイライト風の枠線
-// - hover で bg.elevated に反転
+// - border 専用 token (border.subtle) で 1.4.11 (3:1) を確保
+//   旧 bg.elevated 反転は light で bg.surface × bg.elevated = 1.06:1 となり視覚消失していた
+//   - light: bg.surface (cream-100) × border.subtle (cream-300) = 3.29:1 PASS
+//   - dark : bg.surface (sumi-700) × border.subtle (sumi-450) = 3.29:1 PASS
+// - hover 背景は bg.elevated だと dark で bg.elevated × border.subtle = 2.25:1 (3:1 未達)
+//   となるため bg.muted に変更し、light/dark とも 3:1 以上を維持:
+//   - light: bg.muted (cream-75) × border.subtle = 3.39:1 PASS
+//   - dark : bg.muted (sumi-650) × border.subtle = 4.94:1 PASS
+//   視覚効果は「明るくフラッシュ」→「わずかに沈み込み」へ。
+// 注意: light の backdrop は overlay 暗色のため、light でも事実上暗背景上に
+// 閉じるボタンが浮かぶ。border.subtle (cream-300) が overlay 上で視認可能か
+// は手動確認推奨だが、ボタン本体 bg.surface との 3.29:1 で枠線が縁取れる。
 const closeButtonStyle = css({
   position: "absolute",
   top: "sm",
@@ -53,7 +62,7 @@ const closeButtonStyle = css({
   background: "bg.surface",
   color: "fg.primary",
   border: "1px solid",
-  borderColor: "bg.elevated",
+  borderColor: "border.subtle",
   borderRadius: "full",
   width: "xl",
   height: "xl",
@@ -64,7 +73,7 @@ const closeButtonStyle = css({
   fontSize: "base",
   lineHeight: 1,
   _hover: {
-    background: "bg.elevated",
+    background: "bg.muted",
   },
 });
 

--- a/src/components/common/ThemeToggle.tsx
+++ b/src/components/common/ThemeToggle.tsx
@@ -20,11 +20,14 @@ import { focusRingStyles } from "../../styles/focusRing";
  * - aria-label は現在の状態と次の操作を含めて動的に変更
  * - キーボード操作 (Space) は Headless UI Switch が WAI-ARIA に従い対応
  *
- * Editorial Citrus トークン (R-2b / Issue #389、R-2b 修正で配色を反転):
+ * Editorial Citrus トークン (R-2b / Issue #389、Issue #421 で border を改訂):
  * - Switch (タッチ枠): 透明 (タッチターゲット拡張用、視覚は内部 track で表現)
- * - track 視覚: bg.surface 背景 + bg.elevated ボーダー (1px solid)
- *   light: bg.surface (cream-100) × bg.elevated (cream-50) で 1.06:1。
- *   dark : bg.surface (sumi-700) × bg.elevated (sumi-600) で見切り十分。
+ * - track 視覚: bg.surface 背景 + border.subtle ボーダー (2px solid)
+ *   旧 bg.elevated 反転は light で bg.surface × bg.elevated = 1.06:1 となり視覚消失
+ *   - light: bg.surface (cream-100) × border.subtle (cream-300) = 3.29:1 PASS
+ *   - dark : bg.surface (sumi-700) × border.subtle (sumi-450) = 3.29:1 PASS
+ *   ThemeToggle はクリックで即状態遷移するため hover 状態は存在せず、border の
+ *   単純置換のみ。(他 3 コンポーネントの「hover bg を bg.muted」適用は不要)
  * - thumb (動く丸): light=ink.900 / dark=cream.50 で track と AA 以上のコントラスト確保
  *   light: ink-900 (oklch 0.150) × cream-100 (oklch 0.965) で >= 16:1 (AAA)
  *   dark : cream-50 (oklch 0.985) × sumi-700 (oklch 0.380) で >= 8:1 (AAA)
@@ -50,6 +53,8 @@ const switchOuterStyles = css({
 });
 
 // 視覚 track: 56x32px (R-5 修正で thumb 24x24 + 上下 2px 余白に拡張)。
+// Issue #421: borderColor を bg.elevated → border.subtle に置換。
+// (bg.elevated 反転は light で 1.06:1 で視覚消失していた)
 const trackStyles = css({
   position: "relative",
   display: "inline-flex",
@@ -58,7 +63,7 @@ const trackStyles = css({
   height: "32px",
   borderRadius: "full",
   border: "2px solid",
-  borderColor: "bg.elevated",
+  borderColor: "border.subtle",
   background: "bg.surface",
   transition: "background 0.2s ease",
   _motionReduce: {

--- a/src/components/common/__tests__/BackToTop.test.tsx
+++ b/src/components/common/__tests__/BackToTop.test.tsx
@@ -56,4 +56,33 @@ describe("BackToTop", () => {
       behavior: "smooth",
     });
   });
+
+  // ====================================================================
+  // Editorial Citrus token Tripwire (Issue #421)
+  //
+  // bg.elevated 反転 border は light で 1.06:1 となり視覚消失していた。
+  // border 専用 token (border.subtle) に置換し、hover bg は bg.elevated
+  // (dark で border.subtle と 2.25:1 = 3:1 未達) を避けて bg.muted に変更する。
+  // ====================================================================
+  describe("Editorial Citrus token 参照 (Tripwire)", () => {
+    it("border.subtle 専用 token の border class を持つ", () => {
+      vi.mocked(useScrollPosition).mockReturnValue(500);
+
+      render(<BackToTop />);
+
+      const button = screen.getByRole("button", { name: "ページトップへ戻る" });
+      expect(button.className).toMatch(
+        /bd-c_border\.subtle|borderColor.*border\.subtle/,
+      );
+    });
+
+    it("hover 背景に bg.muted の class を持つ", () => {
+      vi.mocked(useScrollPosition).mockReturnValue(500);
+
+      render(<BackToTop />);
+
+      const button = screen.getByRole("button", { name: "ページトップへ戻る" });
+      expect(button.className).toMatch(/bg_bg\.muted/);
+    });
+  });
 });

--- a/src/components/common/__tests__/ImageLightbox.test.tsx
+++ b/src/components/common/__tests__/ImageLightbox.test.tsx
@@ -110,4 +110,44 @@ describe("ImageLightbox", () => {
       "×",
     );
   });
+
+  // ====================================================================
+  // Editorial Citrus token Tripwire (Issue #421)
+  //
+  // 閉じるボタンの bg.elevated 反転 border は light で 1.06:1 となり視覚消失
+  // していた。border 専用 token (border.subtle) に置換し、hover bg は
+  // bg.elevated (dark で border.subtle と 2.25:1 = 3:1 未達) を避けて
+  // bg.muted に変更する。
+  // ====================================================================
+  describe("Editorial Citrus token 参照 (Tripwire)", () => {
+    it("閉じるボタンが border.subtle 専用 token の border class を持つ", () => {
+      render(
+        <ImageLightbox
+          isOpen={true}
+          imageSrc="https://example.com/photo.jpg"
+          imageAlt=""
+          onClose={vi.fn()}
+        />,
+      );
+
+      const button = screen.getByRole("button", { name: "閉じる" });
+      expect(button.className).toMatch(
+        /bd-c_border\.subtle|borderColor.*border\.subtle/,
+      );
+    });
+
+    it("閉じるボタンが hover 背景に bg.muted の class を持つ", () => {
+      render(
+        <ImageLightbox
+          isOpen={true}
+          imageSrc="https://example.com/photo.jpg"
+          imageAlt=""
+          onClose={vi.fn()}
+        />,
+      );
+
+      const button = screen.getByRole("button", { name: "閉じる" });
+      expect(button.className).toMatch(/bg_bg\.muted/);
+    });
+  });
 });

--- a/src/components/common/__tests__/ThemeToggle.test.tsx
+++ b/src/components/common/__tests__/ThemeToggle.test.tsx
@@ -175,4 +175,25 @@ describe("ThemeToggle", () => {
       expect(toggle.className).toMatch(/h_44px/);
     });
   });
+
+  // ====================================================================
+  // Editorial Citrus token Tripwire (Issue #421)
+  //
+  // track の bg.elevated 反転 border は light で 1.06:1 となり視覚消失して
+  // いた。border 専用 token (border.subtle) に置換する。ThemeToggle は
+  // hover 状態を持たない (クリックで即状態遷移) ため、border 単純置換のみ。
+  // ====================================================================
+  describe("Editorial Citrus token 参照 (Tripwire) - Issue #421", () => {
+    it("track が border.subtle 専用 token の border class を持つ", () => {
+      render(<ThemeToggle />);
+
+      const toggle = screen.getByRole("switch");
+      // track 視覚層は toggle 内部の span。innerHTML を介して class を確認する。
+      const track = toggle.querySelector("span[aria-hidden='true']");
+      expect(track).not.toBeNull();
+      expect(track?.className).toMatch(
+        /bd-c_border\.subtle|borderColor.*border\.subtle/,
+      );
+    });
+  });
 });

--- a/src/lib/colorTokens.ts
+++ b/src/lib/colorTokens.ts
@@ -297,9 +297,14 @@ export interface SemanticColorTokens {
    * **適用ガイドライン**:
    * - article カード (bg.surface) 周りや内部 hr / table / divider など、
    *   視覚的区切り線を弱く出したい用途で使用する。
-   * - bg.elevated (dark: sumi-600) 上では 2.25:1 で 3:1 未達。bg.elevated
-   *   表面の border が必要な場合は引き続き bg.elevated 反転利用 (Button
-   *   secondary / BackToTop など、Issue #409 では置換対象外) を継続する。
+   * - Issue #421 で「bg.elevated 反転利用は light で 1.06:1 となり視覚消失する」
+   *   方針が確定したため、Button secondary / BackToTop / ImageLightbox /
+   *   ThemeToggle の border も全て border.subtle に置換済み。bg.elevated を
+   *   border 色として転用することは原則禁止する。
+   * - bg.elevated (dark: sumi-600) 上では border.subtle × bg.elevated =
+   *   2.25:1 で 3:1 未達。bg.elevated 表面に border が乗る hover 状態などは
+   *   hover 背景を bg.muted (dark: sumi-650) に切替えること
+   *   (border.subtle × bg.muted = light 3.39:1 / dark 4.94:1 で PASS)。
    * - **text color として転用厳禁** (border 専用 token)。本文として使うと
    *   AAA 7.20:1 を満たさず、可読性が大幅に低下する。
    */


### PR DESCRIPTION
## 概要

Issue #421 を解消する。

bg.elevated 反転 border (Button secondary / BackToTop / ImageLightbox / ThemeToggle の 4 components) は light テーマで `bg.surface (cream-100) × bg.elevated (cream-50) = 1.06:1` となり、WCAG 1.4.11 (Non-text Contrast) を大きく下回って視覚消失していた。

border 専用 token `border.subtle` (Issue #409 で追加、#423 で dark 値再調整済み) に置換し、`bg.surface × border.subtle = 3.29:1` (light/dark とも一致) を確保する。

hover 背景は旧 `bg.elevated` のままだと dark で `bg.elevated (sumi-600) × border.subtle (sumi-450) = 2.25:1` となり 3:1 未達。`bg.muted` に切り替えることで、light/dark とも `border.subtle × bg.muted >= 3.39:1` を維持する。

## 変更内容

- `src/components/atoms/Button.tsx` (secondary variant): `borderColor: bg.elevated → border.subtle`、`_hover background: bg.elevated → bg.muted`
- `src/components/common/BackToTop.tsx`: 同上 (`boxShadow: card → card-hover` と `translateY(-2px)` は維持し浮き上がり感を補強)
- `src/components/common/ImageLightbox.tsx`: 閉じるボタン同上
- `src/components/common/ThemeToggle.tsx`: track の `borderColor` のみ置換 (hover 状態が無いため bg.muted 切替は適用箇所なし)
- `src/lib/colorTokens.ts` / `panda.config.ts`: `border.subtle` JSDoc から「bg.elevated 反転継続」記述を削除し、Issue #421 で方針改訂された旨を反映 (bg.elevated を border 色として転用することは原則禁止、hover 背景は bg.muted 切替)
- 各 `__tests__/*.test.tsx`: `border.subtle` / `bg.muted` の Tripwire テストを追加 (PostNavigation.test.tsx L91 のパターンを踏襲)

## 視覚効果

hover の視覚効果が「明るくフラッシュ」(bg.elevated 反転) → 「わずかに沈み込み + 持ち上がり」(bg.muted + translateY) に変化し、Editorial Citrus の Calm 思想と整合する。

## 案 A 適用後のコントラスト実測

| 対象 | light | dark |
| --- | --- | --- |
| 通常 bg.surface × border.subtle | 3.29:1 PASS | 3.29:1 PASS |
| hover bg.muted × border.subtle | 3.39:1 PASS | 4.94:1 PASS |

## 備考

- ImageLightbox の backdrop は overlay 暗色のため light でも事実上暗背景上、border.subtle (cream-300) が overlay 上で視認可能かは手動確認推奨 (DA 指摘)
- FeaturedCard (DA で Issue #421 のスコープ拡張候補と指摘) と BentoCard / IndexRow (Issue #445 別 PR) は本 PR では対応しない
- VR baseline (e2e/visual/) は Issue #410 の責務のため触らない

## 検証結果

- `pnpm test:run`: 615/615 pass
- `pnpm lint`: pass
- `pnpm build`: pass
- `pnpm contrast:check`: 47/47 pass (NG 0)

Closes #421