### PR TITLE
fix: PostDetailPage / ArticleSkeleton の divider を borderTop + border.subtle に変更 (Closes #458)

### DIFF
--- a/src/components/common/ArticleSkeleton.tsx
+++ b/src/components/common/ArticleSkeleton.tsx
@@ -40,11 +40,15 @@ const headerStyles = css({
   },
 });
 
-// 親 articleStyles の bg.surface 上に置く 1px divider のため、同色だと消失する。
-// bg.elevated (より明るい色) でハイライト風の区切り線にする (R-2b 修正)。
+// Issue #458: 旧実装は bg.elevated を background に流用していたが、light テーマ
+// では bg.surface (cream-100) と bg.elevated (cream-50) の差が 1.06:1 と薄く
+// 視覚的にほぼ消失していた。border.subtle (border 専用色) で borderTop を引く
+// ことで、bg.surface 上に 3.29:1 (light) / 3.76:1 (dark) のコントラストを確保し
+// WCAG 1.4.11 (3:1) を満たす static divider にする。
+// 関連: articleStyles の border / navStyles の borderBottom と同一 token。
 const dividerStyles = css({
-  height: "1px",
-  background: "bg.elevated",
+  borderTop: "1px solid",
+  borderColor: "border.subtle",
 });
 
 const contentStyles = css({

--- a/src/components/common/ArticleSkeleton.tsx
+++ b/src/components/common/ArticleSkeleton.tsx
@@ -43,7 +43,7 @@ const headerStyles = css({
 // Issue #458: 旧実装は bg.elevated を background に流用していたが、light テーマ
 // では bg.surface (cream-100) と bg.elevated (cream-50) の差が 1.06:1 と薄く
 // 視覚的にほぼ消失していた。border.subtle (border 専用色) で borderTop を引く
-// ことで、bg.surface 上に 3.29:1 (light) / 3.76:1 (dark) のコントラストを確保し
+// ことで、bg.surface 上に 3.29:1 (light) / 3.29:1 (dark) のコントラストを確保し
 // WCAG 1.4.11 (3:1) を満たす static divider にする。
 // 関連: articleStyles の border / navStyles の borderBottom と同一 token。
 const dividerStyles = css({

--- a/src/components/common/__tests__/ArticleSkeleton.test.tsx
+++ b/src/components/common/__tests__/ArticleSkeleton.test.tsx
@@ -63,4 +63,23 @@ describe("ArticleSkeleton", () => {
     expect(nav).toBeInTheDocument();
     expect(nav?.className).toMatch(/bd-c_border\.subtle/);
   });
+
+  // Issue #458: header と本文の間の 1px divider は、旧実装で bg.elevated を
+  // background に流用しており light テーマでは bg.surface との差が 1.06:1 と薄く
+  // 視覚消失していた。borderTop + border.subtle に変更したことを保証する Tripwire。
+  it("header と本文の間の divider が borderTop + border.subtle を参照している", () => {
+    const { container } = render(<ArticleSkeleton />);
+
+    const article = container.querySelector("article");
+    expect(article).toBeInTheDocument();
+    // article の直下、header の次の sibling が divider。
+    const header = article?.querySelector("header");
+    const divider = header?.nextElementSibling as HTMLElement | null;
+    expect(divider).not.toBeNull();
+    // Panda は `borderTop: "1px solid"` を `bd-t_1px_solid` に変換する。
+    expect(divider?.className).toMatch(/bd-t_1px_solid/);
+    expect(divider?.className).toMatch(/bd-c_border\.subtle/);
+    // 旧実装の background: bg.elevated が残っていないことを確認する。
+    expect(divider?.className).not.toMatch(/bg_bg\.elevated/);
+  });
 });

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -141,7 +141,7 @@ export const PostDetailPage = ({
              * light テーマでは bg.surface (cream-100) と bg.elevated (cream-50)
              * の差が 1.06:1 と薄く、視覚的にほぼ消失していた。
              * border.subtle (border 専用色) で borderTop を引くことで、
-             * bg.surface 上に 3.29:1 (light) / 3.76:1 (dark) のコントラストを
+             * bg.surface 上に 3.29:1 (light) / 3.29:1 (dark) のコントラストを
              * 確保し WCAG 1.4.11 (3:1) を満たす static divider にする。
              * 関連: article 全体の border / nav の borderBottom と同一 token。
              */}

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -137,15 +137,18 @@ export const PostDetailPage = ({
 
             {/* Divider
              *
-             * article 内 (bg.surface = light: cream-100) に置く 1px divider のため、
-             * bg.elevated (light: cream-50 / dark: sumi-600) との 1.06:1 (light) /
-             * 明確 (dark) のコントラストで区切りを表現する。light テーマでは
-             * 1.06:1 と薄いが、本文と header を視覚的に分離する補助線として機能。
+             * Issue #458: 旧実装は bg.elevated を background に流用していたが、
+             * light テーマでは bg.surface (cream-100) と bg.elevated (cream-50)
+             * の差が 1.06:1 と薄く、視覚的にほぼ消失していた。
+             * border.subtle (border 専用色) で borderTop を引くことで、
+             * bg.surface 上に 3.29:1 (light) / 3.76:1 (dark) のコントラストを
+             * 確保し WCAG 1.4.11 (3:1) を満たす static divider にする。
+             * 関連: article 全体の border / nav の borderBottom と同一 token。
              */}
             <div
               className={css({
-                height: "1px",
-                background: "bg.elevated",
+                borderTop: "1px solid",
+                borderColor: "border.subtle",
               })}
             />
 

--- a/src/components/pages/__tests__/PostDetailPage.test.tsx
+++ b/src/components/pages/__tests__/PostDetailPage.test.tsx
@@ -244,6 +244,27 @@ describe("PostDetailPage", () => {
       expect(nav).toBeInTheDocument();
       expect(nav?.className).toMatch(/bd-c_border\.subtle/);
     });
+
+    // Issue #458: header と本文の間の 1px divider は、旧実装で bg.elevated を
+    // background に流用しており light テーマでは bg.surface との差が 1.06:1 と
+    // 薄く視覚消失していた。borderTop + border.subtle に変更したことを保証する。
+    it("header と本文の間の divider が borderTop + border.subtle を参照している", () => {
+      const { container } = render(
+        <MemoryRouter>
+          <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+        </MemoryRouter>,
+      );
+
+      const article = container.querySelector("article");
+      const header = article?.querySelector("header");
+      const divider = header?.nextElementSibling as HTMLElement | null;
+      expect(divider).not.toBeNull();
+      // Panda は `borderTop: "1px solid"` を `bd-t_1px_solid` に変換する。
+      expect(divider?.className).toMatch(/bd-t_1px_solid/);
+      expect(divider?.className).toMatch(/bd-c_border\.subtle/);
+      // 旧実装の background: bg.elevated が残っていないことを確認する。
+      expect(divider?.className).not.toMatch(/bg_bg\.elevated/);
+    });
   });
 
   // ==========================================================================


### PR DESCRIPTION
## 概要

Issue #458 で報告された、PostDetailPage / ArticleSkeleton の header と本文の間の 1px divider が light テーマで視覚消失している問題を修正する。

旧実装は `background: bg.elevated` (cream-50) を使った帯で divider を描いていたが、親 `bg.surface` (cream-100) との差が 1.06:1 と薄く WCAG 1.4.11 (Non-text Contrast, 3:1) を満たせていなかった。border 専用 token (`border.subtle`) で `borderTop` を引く方式 (DA レビュー採用: 案 B) に切り替え、`bg.surface` 上で 3.29:1 (light) / 3.29:1 (dark) のコントラストを確保する。

Closes #458

## 変更内容

- `src/components/pages/PostDetailPage.tsx`: header と TOC の間の 1px divider を `background: bg.elevated` から `borderTop: 1px solid / borderColor: border.subtle` に変更。height は不要のため削除。コメントを Issue #458 の経緯と 3.29:1 の根拠で更新。
- `src/components/common/ArticleSkeleton.tsx`: 同一 divider の `dividerStyles` を同様に変更。`skeletonBase` (L63-67) は skeleton pulse 用で目的が異なるため触らない。コメントを更新。
- `src/components/pages/__tests__/PostDetailPage.test.tsx`: divider の Panda 生成クラス (`bd-t_1px_solid` / `bd-c_border.subtle`) を assert する Tripwire を追加し、`bg_bg.elevated` への回帰を CI で検出できるようにする。
- `src/components/common/__tests__/ArticleSkeleton.test.tsx`: 同様の Tripwire を Skeleton 側にも追加し、実体との挙動乖離を防ぐ。

## 備考

- DA レビュー結果に基づき、hover 反転を伴う #421 / #445 と異なる static divider 方針 (案 B) を採用した。ファイル衝突なし。
- `bg.elevated` を流用していた `skeletonBase` (skeleton pulse 用) は意図的に残している。
- 既存 unit テスト 609 件と新規 Tripwire 2 件、合計 611 件すべて pass。`pnpm lint` / `pnpm build` / `pnpm contrast:check` (border.subtle × bg.surface light 3.29:1 / dark 3.29:1 を含む 47 ペア NG: 0) すべて pass。
- VR baseline (#410 責務) は触っていない。