### PR TITLE
fix: useAdjacentPosts に cancellation flag を追加 (Closes #459)

### DIFF
--- a/src/hooks/__tests__/useAdjacentPosts.test.ts
+++ b/src/hooks/__tests__/useAdjacentPosts.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as markdownModule from "../../lib/markdown";
 import { findAdjacentPosts, useAdjacentPosts } from "../useAdjacentPosts";
@@ -147,5 +147,43 @@ describe("useAdjacentPosts", () => {
     });
 
     expect(mockGetAllPostSummaries).toHaveBeenCalledTimes(2);
+  });
+
+  it("currentId切替時に古いリクエストの結果は新しいstateに反映されない", async () => {
+    // 1回目のリクエストは手動でresolveできる遅延Promise
+    let resolveFirst: ((value: typeof mockSummaries) => void) | undefined;
+    const firstPromise = new Promise<typeof mockSummaries>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    // 2回目のリクエストは即座にresolve
+    mockGetAllPostSummaries
+      .mockImplementationOnce(() => firstPromise)
+      .mockResolvedValueOnce(mockSummaries);
+
+    const { result, rerender } = renderHook(
+      ({ currentId }: { currentId: string }) => useAdjacentPosts(currentId),
+      { initialProps: { currentId: "20240102100000" } },
+    );
+
+    // currentIdを切り替えると2回目のリクエストが発火する
+    rerender({ currentId: "20240101100000" });
+
+    // 2回目のリクエストが完了するまで待つ（末尾の記事のためolderPostはnull、newerPostは2番目）
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.olderPost).toBeNull();
+    expect(result.current.newerPost).toEqual(mockSummaries[1]);
+
+    // 後から1回目のリクエストをresolveしても、新しいstateを上書きしない
+    await act(async () => {
+      resolveFirst?.(mockSummaries);
+      await firstPromise;
+    });
+
+    expect(result.current.olderPost).toBeNull();
+    expect(result.current.newerPost).toEqual(mockSummaries[1]);
   });
 });

--- a/src/hooks/useAdjacentPosts.ts
+++ b/src/hooks/useAdjacentPosts.ts
@@ -35,6 +35,11 @@ export const findAdjacentPosts = (
 
 /**
  * 前後の記事を取得するカスタムフック
+ *
+ * useEffect 内で非同期に記事サマリーをロードするため、currentId 切替や
+ * unmount 時に古いリクエストの解決が新しい state を上書きする race condition、
+ * および unmount 後の setState を防止するための cancellation flag を併用する。
+ *
  * @param currentId 現在表示中の記事ID
  */
 export const useAdjacentPosts = (
@@ -47,25 +52,40 @@ export const useAdjacentPosts = (
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const loadAdjacentPosts = async () => {
-      if (!currentId) {
-        setLoading(false);
-        return;
-      }
+    let cancelled = false;
 
-      try {
-        setLoading(true);
-        const summaries = await getAllPostSummaries();
-        setAdjacentPosts(findAdjacentPosts(summaries, currentId));
-      } catch (error) {
-        console.error("Failed to load adjacent posts:", error);
-        setAdjacentPosts({ olderPost: null, newerPost: null });
-      } finally {
-        setLoading(false);
+    const loadAdjacentPosts = async (): Promise<AdjacentPosts> => {
+      if (!currentId) {
+        return { olderPost: null, newerPost: null };
       }
+      const summaries = await getAllPostSummaries();
+      return findAdjacentPosts(summaries, currentId);
     };
 
-    loadAdjacentPosts();
+    setLoading(true);
+    loadAdjacentPosts()
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+        setAdjacentPosts(result);
+      })
+      .catch((error) => {
+        console.error("Failed to load adjacent posts:", error);
+        if (cancelled) {
+          return;
+        }
+        setAdjacentPosts({ olderPost: null, newerPost: null });
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [currentId]);
 
   return { ...adjacentPosts, loading };


### PR DESCRIPTION
## 概要

`useAdjacentPosts` フックの useEffect 内で非同期に記事サマリーをロードしているが、currentId 切替時や unmount 時に古いリクエストの解決が新しい state を上書きする race condition、および unmount 後の setState が発生し得る。これを防ぐため cancellation flag を導入する。

Closes #459

## 変更内容

- `src/hooks/useAdjacentPosts.ts`: useEffect 内に `let cancelled = false` を追加。cleanup で `cancelled = true` にし、`.then` / `.catch` / `.finally` で `cancelled` をチェックして state 更新をスキップする。JSDoc に race condition / unmount 防御の旨を追記。
- `src/hooks/__tests__/useAdjacentPosts.test.ts`: 遅延 resolve 中に `currentId` を切り替え、古いリクエスト完了時に新しい state を上書きしないことを検証する race 防止テストを 1 件追加。

### 設計判断

- `AbortController` は採用しない。`import.meta.glob` 由来の動的 import は abort 不可なため、シンプルな `let cancelled = false` flag で十分。
- `findAdjacentPosts` (純関数) は触らない。
- Biome の cognitive complexity 制限 (max 15) に収めるため、try/catch ではなく Promise の `then/catch/finally` チェーン形式に整理。

## 備考

- `usePost.ts` / `usePosts.ts` も同様のパターン (useEffect 内で非同期処理 + setState、cancellation flag なし) を持つが、本 PR のスコープ外。一貫性を取るなら別 Issue 化を推奨。
- React 18+ では unmount 後 setState の warning は抑制されているため実害は軽微だが、currentId 連打時の race condition は理論的に発生し得るため防御として有意義。