### PR TITLE
chore: a11y allow-list から color-contrast を削除 (Closes #455)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -90,7 +90,7 @@ jobs:
                 3,
               );
               await core.summary.addRaw(
-                `total=${data.total} / new=${data.newCount} / known allow-listed ids: ${data.knownIds.join(", ")}\n`,
+                `total=${data.total}\n`,
                 true,
               );
               const rows = [
@@ -99,7 +99,6 @@ jobs:
                   { data: "impact", header: true },
                   { data: "tags", header: true },
                   { data: "nodes", header: true },
-                  { data: "known?", header: true },
                   { data: "help", header: true },
                 ],
                 ...data.violations.map((v) => [
@@ -107,7 +106,6 @@ jobs:
                   v.impact ?? "",
                   (v.tags ?? []).join(","),
                   String(v.nodeCount),
-                  v.isKnown ? "yes" : "**NEW**",
                   `[doc](${v.helpUrl})`,
                 ]),
               ];

--- a/e2e/a11y/violations.spec.ts
+++ b/e2e/a11y/violations.spec.ts
@@ -15,10 +15,11 @@ import { expect, test } from "@playwright/test";
  * - `/about` は本サイトに存在しないため、最新の 2 記事を代表ページとして採用する。
  *
  * 既知違反 (allowList):
- *   現行 gruvbox テーマには WCAG 2.1 AA を満たさないコントラストペアが残存しており、
- *   Editorial Citrus への OKLCH トークン移行 (Issue #0a / #4a) で解消予定。
- *   それまでの間は known violations として `KNOWN_VIOLATION_IDS` で除外し、
- *   新規違反の混入のみを CI ゲートで防ぐ。
+ *   現状 allow-list は空。Editorial Citrus OKLCH トークン移行 (Issue #0a / #4a / Phase2 リニューアル)
+ *   完了に伴い、過去に登録していた `aria-progressbar-name` (Issue #446 / PR #451) と
+ *   `color-contrast` (Issue #455) は本質解消済みのため削除した。
+ *   将来、新たな代表ページ追加 (例: code block 含む記事) などで仕様上不可避な違反が出た場合のみ、
+ *   理由を明記して再登録すること。
  */
 const TARGETS = [
   { name: "home", path: "/" },
@@ -27,14 +28,6 @@ const TARGETS = [
 ];
 
 const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
-
-/**
- * 既知違反 ID 一覧
- *
- * - color-contrast: gruvbox の #83a598 / #7c6f64 系が AA (4.5:1) を満たさない
- *   → Editorial Citrus OKLCH トークン導入 (Issue #0a / G2) で解消
- */
-const KNOWN_VIOLATION_IDS = new Set<string>(["color-contrast"]);
 
 for (const target of TARGETS) {
   test(`${target.name} (${target.path}) に WCAG 2.1 AA 違反がない`, async ({
@@ -45,14 +38,10 @@ for (const target of TARGETS) {
 
     const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
 
-    const newViolations = results.violations.filter(
-      (v) => !KNOWN_VIOLATION_IDS.has(v.id),
-    );
-
     if (results.violations.length > 0) {
-      // 既知 / 新規を含む全違反を CI ログに出力 (GitHub Actions Summary でも参照可能)
+      // 違反を CI ログに出力 (GitHub Actions Summary でも参照可能)
       console.log(
-        `\n[axe violations: ${target.name}] total=${results.violations.length} new=${newViolations.length}\n` +
+        `\n[axe violations: ${target.name}] total=${results.violations.length}\n` +
           JSON.stringify(results.violations, null, 2),
       );
 
@@ -69,8 +58,6 @@ for (const target of TARGETS) {
           {
             target,
             total: results.violations.length,
-            newCount: newViolations.length,
-            knownIds: Array.from(KNOWN_VIOLATION_IDS),
             violations: results.violations.map((v) => ({
               id: v.id,
               impact: v.impact,
@@ -78,7 +65,6 @@ for (const target of TARGETS) {
               helpUrl: v.helpUrl,
               tags: v.tags,
               nodeCount: v.nodes.length,
-              isKnown: KNOWN_VIOLATION_IDS.has(v.id),
             })),
           },
           null,
@@ -87,7 +73,7 @@ for (const target of TARGETS) {
       );
     }
 
-    // 既知違反は allowList で除外、新規違反のみ 0 を要求する。
-    expect.soft(newViolations).toEqual([]);
+    // allow-list は空のため、新規 / 既知を問わず全違反 0 を要求する。
+    expect.soft(results.violations).toEqual([]);
   });
 }


### PR DESCRIPTION
## 概要

`e2e/a11y/violations.spec.ts` の `KNOWN_VIOLATION_IDS` から `color-contrast` を削除し、a11y ハードゲート G1 を本質解消側に倒す。Editorial Citrus OKLCH トークン移行 (Issue #0a / #4a / Phase2 リニューアル) が完了しており、代表 3 ページ × 3 viewport = 9/9 で実測 0 違反であることを確認済み。

Issue #446 (PR #451) で `aria-progressbar-name` allow-list を削除した対応と同質の作業。

Closes #455

## 変更内容

- `e2e/a11y/violations.spec.ts`
  - `KNOWN_VIOLATION_IDS` を削除 (`color-contrast` 唯一のエントリを除去すると空集合になるため、定数自体を削除)
  - 連動して `newViolations` フィルタロジック、および JSON 出力の `knownIds` / `newCount` / `isKnown` フィールドも削除しコードを簡略化
  - 最終アサーションを `expect.soft(results.violations).toEqual([])` に変更し、新規 / 既知の区別なく全違反 0 を直接要求する形に
  - JSDoc を更新し「現状 allow-list は空」「`aria-progressbar-name` (Issue #446 / PR #451) と `color-contrast` (Issue #455) は OKLCH 移行完了で本質解消済み」「将来仕様上不可避な違反が出た場合のみ理由を明記して再登録する」方針を明示

## 備考

- 検証結果
  - `pnpm test:a11y`: 9/9 pass (3 viewports × 3 pages)
  - `pnpm test:run`: 609/609 pass
  - `pnpm lint`: pass
  - `pnpm build`: pass
- code block を含む post (例: Gruvbox hex リテラル) は現行の対象 3 ページに存在しないため本 PR の検証スコープ外。今後 code block を含む記事を代表ページに追加する際は、`color-contrast` の再評価が必要になる可能性がある (Gruvbox hex リテラルは temporary 温存方針のため、必要が生じた時点で別 Issue で扱う)。
- フィルタ構造を維持する案も検討したが、現時点で allow-list 候補が無く、将来再登録時はコメント込みで定数を再導入すれば足りる (Git 履歴で復元可能) ため簡略化を選択。