### PR TITLE
fix: usePost / usePosts に cancellation flag を追加 (Closes #466)

### DIFF
--- a/src/hooks/__tests__/usePost.test.ts
+++ b/src/hooks/__tests__/usePost.test.ts
@@ -140,4 +140,47 @@ describe("usePost", () => {
 
     expect(mockGetPost).toHaveBeenCalledWith("20240102120000");
   });
+
+  it("timestamp切替時に古いリクエストの結果は新しいstateに反映されない", async () => {
+    // 2つ目のモック記事
+    const secondPost = {
+      ...mockPost,
+      id: "20240102120000",
+      title: "2つ目の記事",
+    };
+
+    // 1回目のリクエストは手動でresolveできる遅延Promise
+    let resolveFirst: ((value: typeof mockPost) => void) | undefined;
+    const firstPromise = new Promise<typeof mockPost>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    // 2回目のリクエストは即座にresolve
+    mockGetPost
+      .mockImplementationOnce(() => firstPromise)
+      .mockResolvedValueOnce(secondPost);
+
+    const { result, rerender } = renderHook(
+      ({ timestamp }: { timestamp: string }) => usePost(timestamp),
+      { initialProps: { timestamp: "20240101100000" } },
+    );
+
+    // timestampを切り替えると2回目のリクエストが発火する
+    rerender({ timestamp: "20240102120000" });
+
+    // 2回目のリクエストが完了するまで待つ
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.post).toEqual(secondPost);
+
+    // 後から1回目のリクエストをresolveしても、新しいstateを上書きしない
+    await act(async () => {
+      resolveFirst?.(mockPost);
+      await firstPromise;
+    });
+
+    expect(result.current.post).toEqual(secondPost);
+  });
 });

--- a/src/hooks/__tests__/usePosts.test.ts
+++ b/src/hooks/__tests__/usePosts.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as markdownModule from "../../lib/markdown";
 import { usePosts } from "../usePosts";
@@ -100,5 +100,43 @@ describe("usePosts", () => {
     );
 
     consoleSpy.mockRestore();
+  });
+
+  it("unmount後に解決したリクエストでReactの警告を発生させない", async () => {
+    // unmount 後の setState で React が出す警告を検知する
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    // 手動で resolve できる遅延 Promise
+    let resolveLoad: ((value: typeof mockPosts) => void) | undefined;
+    const loadPromise = new Promise<typeof mockPosts>((resolve) => {
+      resolveLoad = resolve;
+    });
+    mockGetAllPostSummaries.mockReturnValueOnce(loadPromise);
+
+    const { unmount } = renderHook(() => usePosts());
+
+    // 解決前にアンマウント
+    unmount();
+
+    // アンマウント後に Promise を解決
+    await act(async () => {
+      resolveLoad?.(mockPosts);
+      await loadPromise;
+    });
+
+    // unmount 後の setState に対する React 警告が出ていないこと
+    const reactStateWarnings = consoleErrorSpy.mock.calls.filter((call) => {
+      const message = String(call[0] ?? "");
+      return (
+        message.includes("unmounted") ||
+        message.includes("memory leak") ||
+        message.includes("Can't perform a React state update")
+      );
+    });
+    expect(reactStateWarnings).toHaveLength(0);
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -10,6 +10,11 @@ interface UsePostReturn {
 
 /**
  * 記事詳細を取得するカスタムフック
+ *
+ * useEffect 内で非同期に記事をロードするため、timestamp 切替や unmount 時に
+ * 古いリクエストの解決が新しい state を上書きする race condition、および
+ * unmount 後の setState を防止するための cancellation flag を併用する。
+ *
  * @param timestamp 記事のタイムスタンプID
  * @returns 記事詳細、ローディング状態、エラー状態、記事が見つからない状態
  */
@@ -20,36 +25,52 @@ export const usePost = (timestamp: string | undefined): UsePostReturn => {
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {
-    const loadPost = async () => {
-      if (!timestamp) {
-        setNotFound(true);
-        setLoading(false);
-        return;
-      }
+    let cancelled = false;
 
-      try {
-        setLoading(true);
-        setError(null);
-        setNotFound(false);
+    if (!timestamp) {
+      setPost(null);
+      setError(null);
+      setNotFound(true);
+      setLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
 
-        const postData = await getPost(timestamp);
+    setLoading(true);
+    setError(null);
+    setNotFound(false);
+
+    getPost(timestamp)
+      .then((postData) => {
+        if (cancelled) {
+          return;
+        }
         if (postData) {
           setPost(postData);
         } else {
           setNotFound(true);
         }
-      } catch (err) {
+      })
+      .catch((err) => {
         console.error("Failed to load post:", err);
+        if (cancelled) {
+          return;
+        }
         setError(
           err instanceof Error ? err.message : "記事の読み込みに失敗しました",
         );
         setNotFound(true);
-      } finally {
-        setLoading(false);
-      }
-    };
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
 
-    loadPost();
+    return () => {
+      cancelled = true;
+    };
   }, [timestamp]);
 
   return { post, loading, error, notFound };

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -30,6 +30,11 @@ interface UsePostsReturn {
 /**
  * 記事一覧を取得するカスタムフック（ページング機能付き）
  * 高速化のためメタデータのみを取得（本文は含まない）
+ *
+ * useEffect の deps は空配列のため再 fetch は走らず race condition は発生しないが、
+ * unmount 後に Promise が解決した際の setState を防止するため cancellation flag を
+ * 併用する。
+ *
  * @returns 記事一覧、ローディング状態、エラー状態、ページング情報
  */
 export const usePosts = (): UsePostsReturn => {
@@ -39,23 +44,36 @@ export const usePosts = (): UsePostsReturn => {
   const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
-    const loadPosts = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const posts = await getAllPostSummaries();
+    let cancelled = false;
+
+    setLoading(true);
+    setError(null);
+
+    getAllPostSummaries()
+      .then((posts) => {
+        if (cancelled) {
+          return;
+        }
         setAllPosts(posts);
-      } catch (err) {
+      })
+      .catch((err) => {
         console.error("Failed to load posts:", err);
+        if (cancelled) {
+          return;
+        }
         setError(
           err instanceof Error ? err.message : "記事の読み込みに失敗しました",
         );
-      } finally {
-        setLoading(false);
-      }
-    };
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
 
-    loadPosts();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const totalPosts = allPosts.length;


### PR DESCRIPTION
## 概要

Issue #466 対応。PR #464 (Issue #459: useAdjacentPosts への cancellation flag 追加) と同パターンを `usePost` / `usePosts` にも適用する。

`useEffect` 内で非同期に記事データをロードしている箇所で、Promise が解決する前に依存値が切り替わる (= rerender) もしくはコンポーネントが unmount された場合に、古いリクエストの結果が新しい state を上書きしたり、unmount 後の setState が走るリスクがあった。cancellation flag を導入してこれを防止する。

## 変更内容

- `src/hooks/usePost.ts`: `useEffect` 内に `cancelled` フラグを導入。`.then` / `.catch` / `.finally` で `cancelled` をチェックして古い結果を破棄する。Biome の cognitive complexity 上限 (15) に収めるため try/catch を Promise chain に書き換え。timestamp が undefined の場合の早期 return も cleanup 関数を返すように修正。JSDoc に意図を追記
- `src/hooks/__tests__/usePost.test.ts`: timestamp 切替時に古いリクエストの結果が新しい state を上書きしないことを検証する race condition 防止テストを追加
- `src/hooks/usePosts.ts`: 同じパターンで cancellation flag を導入。**deps が空配列のため再 fetch は走らず race condition は発生しない**が、unmount 後に Promise が解決した場合の setState を防止する目的で flag を併用。JSDoc に「race は起きない、unmount 防御のみが目的」と明記
- `src/hooks/__tests__/usePosts.test.ts`: unmount 後に解決したリクエストが React の setState 警告を発生させないことを検証するテストを追加

## 備考

- `usePosts` は `useEffect` の deps が `[]` のため race 発生は不可。本変更の目的は unmount 後の setState 防止のみであり、その旨を JSDoc に明記してある
- AbortController は使わない方針 (`import.meta.glob` のキャンセル不可、DA 推奨と一致)
- 既存テストは全て pass (611/611)
- `pnpm lint` / `pnpm build` も pass

Closes #466