### PR TITLE
chore: 旧 sumi-400 時代のコメント残存表記を sumi-450 値に更新 (Closes #467)

### DIFF
--- a/src/components/common/ArticleSkeleton.tsx
+++ b/src/components/common/ArticleSkeleton.tsx
@@ -19,7 +19,7 @@ const innerStyles = css({
 // に置換 (Issue #409)。R-2b では bg.elevated 反転で凌いでいたが、light テーマでは
 // 外側 bg.canvas (cream-50) と同色になり 1.0:1 で再消失する設計上の限界があった。
 // border.subtle は border 専用色で、WCAG 1.4.11 の 3:1 を bg.canvas / bg.surface
-// 上で満たす (light: 3.29-3.49:1 / dark: 3.76-7.05:1)。
+// 上で満たす (light: 3.29-3.49:1 / dark: 3.29-6.18:1)。
 const articleStyles = css({
   background: "bg.surface",
   borderRadius: "lg",

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -267,7 +267,7 @@ export const PostDetailPage = ({
 
                 // 区切り線 (GFM <hr>): prose と同じ幅で中央寄せ。
                 // Issue #409 で border 専用 token (border.subtle) に置換。
-                // bg.surface 上に置かれるため 3.29:1 (light) / 3.76:1 (dark) で 1.4.11 PASS。
+                // bg.surface 上に置かれるため 3.29:1 (light) / 3.29:1 (dark) で 1.4.11 PASS。
                 "& hr": {
                   maxWidth: "prose",
                   marginRight: "auto",


### PR DESCRIPTION
## 概要

Issue #423 で `border.subtle` の dark テーマを `sumi-400` から `sumi-450` に変更した後も、コード内コメントに旧 `sumi-400` 時代のコントラスト値表記が残存していました。実測値と整合するよう、`PostDetailPage.tsx` と `ArticleSkeleton.tsx` のコメントを `sumi-450` 実測値に更新します。

Closes #467

## 変更内容

- `src/components/pages/PostDetailPage.tsx` L270: `<hr>` の border.subtle dark 値コメントを `3.76:1` → `3.29:1` に更新 (`docs/contrast-matrix.csv` L88 の sumi-700 × sumi-450 実測値と一致)
- `src/components/common/ArticleSkeleton.tsx` L22: `articleStyles` の range コメントを `dark: 3.76-7.05:1` → `dark: 3.29-6.18:1` に更新 (range の両端とも sumi-400 由来だったため、bg.canvas 上 6.18:1 / bg.surface 上 3.29:1 で更新)

## 備考

### 検証結果

- `pnpm test:run`: pass (43 files / 609 tests)
- `pnpm lint`: pass
- `pnpm build`: pass
- `pnpm contrast:check`: pass (47 / NG: 0)

### 意図的に温存した箇所

以下の箇所は Issue #423 の経緯 (旧 sumi-400 → 新 sumi-450 への変更理由) を説明する文脈で、旧値の言及が必要なため**意図的に温存**しました:

- `src/lib/colorTokens.ts:286` — `Issue #423 で sumi-400 から変更` 注釈
- `src/lib/colorTokens.ts:291-294` — Issue #423 の意図説明 (旧 sumi-400 が 7.05:1 で本文と同等の主張強度だった経緯)
- `src/lib/colorTokens.ts:374-376` — `dark を sumi-400 (L=0.700, 7.05:1) → sumi-450 (L=0.665, 6.18:1) に変更` の経緯ブロック
- `src/lib/__tests__/colorTokens.test.ts:344` — Issue #423 経緯の単体テスト

### 別 Issue 化推奨

- `src/lib/colorTokens.ts:111` の primitive 説明コメント内 `bg.canvas (sumi-950) 上 7.05:1 / bg.surface (sumi-700) 上 3.76:1` という記述は、現状 sumi-400 primitive 自体の説明であり、本 Issue #467 の範囲 (border.subtle の dark 値表記整理) から外れます。別 Issue で対応することを推奨します。