### PR TITLE
chore: 死コード getAllPosts 関数を削除 (Closes #470)

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -179,63 +179,6 @@ export const getAllPostSummaries = async (): Promise<PostSummary[]> => {
   }
 };
 
-/**
- * 全投稿を取得（後方互換性のため維持、詳細ページで使用）
- */
-export const getAllPosts = async (): Promise<Post[]> => {
-  try {
-    // 開発環境ではAPIを使用、本番環境では静的ファイルを使用
-    if (import.meta.env.DEV) {
-      // まずメタデータを取得
-      const summaries = await getAllPostSummaries();
-
-      // 各投稿の本文を取得
-      const posts = await Promise.all(
-        summaries.map(async (summary) => {
-          const fileResponse = await fetch(`/api/posts/${summary.id}`);
-
-          if (!fileResponse.ok) {
-            return null;
-          }
-
-          const content = await fileResponse.text();
-          return parseMarkdown(content, summary.id);
-        }),
-      );
-
-      return posts
-        .filter((post): post is Post => post !== null)
-        .sort((a, b) => b.id.localeCompare(a.id));
-    } else {
-      // 本番環境では動的インポートを使用して静的ファイルを読み込み
-      const posts: Post[] = [];
-
-      // 既知のMarkdownファイルを動的にインポート
-      try {
-        const modules = import.meta.glob("/datasources/*.md", {
-          query: "?raw",
-          import: "default",
-        });
-
-        for (const filePath in modules) {
-          const content = (await modules[filePath]()) as string;
-          const timestamp = filePath.split("/").pop()?.replace(".md", "") || "";
-          if (timestamp) {
-            posts.push(parseMarkdown(content, timestamp));
-          }
-        }
-      } catch (error) {
-        console.error("Error loading static posts:", error);
-      }
-
-      return posts.sort((a, b) => b.id.localeCompare(a.id));
-    }
-  } catch (error) {
-    console.error("Error loading posts:", error);
-    return [];
-  }
-};
-
 export const getPost = async (timestamp: string): Promise<Post | null> => {
   try {
     // 開発環境ではAPIを使用、本番環境では静的ファイルを使用


### PR DESCRIPTION
## 概要

`src/lib/markdown.ts` で定義されている `getAllPosts` 関数は、`src/` 全体で参照ゼロの完全な死コードであるため削除します。

Closes #470

## 変更内容

- `src/lib/markdown.ts`: `getAllPosts` 関数とその JSDoc コメント (L182-237) を削除
  - 関数本体・関連コメントを全削除 (57 行削除)
  - `Post` 型 export (L107) は `PostDetailPage.tsx` 等が引き続き import するため**残置**
  - 他の関数 (`parseMarkdown`, `getPost`, `getAllPostSummaries` 等) には手を入れない

## 備考

- 削除前に `rg getAllPosts src/` を実行し、宣言箇所以外に参照がないことを確認済み
- テストでも `getAllPosts` の参照ゼロ (テスト変更不要)
- 検証結果:
  - `pnpm test:run`: 640/640 pass
  - `pnpm lint`: pass
  - `pnpm build`: pass
- Issue #471 (tocItems 関数ローカル化) は本 PR のスコープ外。別 PR で順次対応する。