### PR TITLE
chore: VR テスト基盤 Phase 1 (Home + PostDetail × desktop × light、Refs #410)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -52,7 +52,9 @@ jobs:
         continue-on-error: true
 
       - name: Run Playwright tests
-        run: pnpm exec playwright test
+        # Visual Regression (`visual-desktop` project) は別 workflow (vr.yml) で実行する。
+        # 既存 playwright.yml は smoke + a11y のみ実行するため project を明示する。
+        run: pnpm exec playwright test --project=mobile --project=tablet --project=desktop
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/vr.yml
+++ b/.github/workflows/vr.yml
@@ -1,0 +1,97 @@
+name: vr
+
+on:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      update_snapshots:
+        description: "Update VR baseline snapshots (true で --update-snapshots を付与)"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+jobs:
+  visual:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.4
+        with:
+          version: latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Panda CSS
+        # a11y.yml と同様、`pnpm prepare` (codegen) だけでは styles.css が
+        # 生成されないため `pnpm exec panda` で styles.css も生成する。
+        run: |
+          pnpm prepare
+          pnpm exec panda
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: |
+          version=$(pnpm list @playwright/test --depth=0 --json | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const j=JSON.parse(d);console.log(j[0].devDependencies['@playwright/test'].version)})")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install chromium
+
+      - name: Install Playwright OS dependencies
+        run: pnpm exec playwright install-deps chromium
+        timeout-minutes: 5
+        continue-on-error: true
+
+      - name: Run Playwright VR tests (compare)
+        if: github.event_name == 'pull_request'
+        run: pnpm exec playwright test --project=visual-desktop
+
+      - name: Run Playwright VR tests (update snapshots)
+        if: github.event_name == 'workflow_dispatch' && inputs.update_snapshots == 'true'
+        run: pnpm exec playwright test --project=visual-desktop --update-snapshots
+
+      - name: Run Playwright VR tests (compare on dispatch)
+        if: github.event_name == 'workflow_dispatch' && inputs.update_snapshots != 'true'
+        run: pnpm exec playwright test --project=visual-desktop
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-vr
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload VR snapshots (workflow_dispatch のみ)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: vr-snapshots
+          # Playwright は spec ファイルと同階層に `<spec>-snapshots/` を生成する。
+          # 例: `e2e/visual/main-pages.spec.ts-snapshots/home-visual-desktop-linux.png`
+          path: e2e/visual/**/*-snapshots/**
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/vr.yml
+++ b/.github/workflows/vr.yml
@@ -8,11 +8,15 @@ on:
       update_snapshots:
         description: "Update VR baseline snapshots (true で --update-snapshots を付与)"
         required: false
-        default: "true"
+        default: "false"
         type: choice
         options:
           - "true"
           - "false"
+
+concurrency:
+  group: vr-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   visual:
@@ -66,16 +70,12 @@ jobs:
         continue-on-error: true
 
       - name: Run Playwright VR tests (compare)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.update_snapshots != 'true')
         run: pnpm exec playwright test --project=visual-desktop
 
       - name: Run Playwright VR tests (update snapshots)
         if: github.event_name == 'workflow_dispatch' && inputs.update_snapshots == 'true'
         run: pnpm exec playwright test --project=visual-desktop --update-snapshots
-
-      - name: Run Playwright VR tests (compare on dispatch)
-        if: github.event_name == 'workflow_dispatch' && inputs.update_snapshots != 'true'
-        run: pnpm exec playwright test --project=visual-desktop
 
       - name: Upload Playwright report
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ styled-system-studio
 playwright-report
 test-results
 /playwright/.cache
+
+## Visual Regression (Issue #410)
+# macOS 上で生成された snapshot は CI Linux と必発で差分が出るためコミット禁止。
+# baseline は CI (vr.yml の workflow_dispatch) で生成し、artifact 経由で取得する。
+e2e/visual/**/*-darwin.png

--- a/e2e/visual/main-pages.spec.ts
+++ b/e2e/visual/main-pages.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Visual Regression (VR) Phase 1
+ *
+ * Issue #410: Phase 2 リニューアル後の VR テスト基盤 (新規構築) の Phase 1 スコープ。
+ *
+ * 対象:
+ * - Home (`/`) と PostDetail (`/posts/20260307120000`) の 2 ページ
+ * - viewport: desktop 1280x720
+ * - theme: light のみ
+ * - 合計 2 PNG
+ *
+ * 注意:
+ * - macOS でローカル生成した PNG は CI Linux と必発差分のためコミット禁止
+ *   (`.gitignore` で `e2e/visual/**\/*-darwin.png` を除外)
+ * - baseline 生成は CI (`workflow_dispatch` で `--update-snapshots` 実行) で行う
+ *
+ * 安定化のための前処理:
+ * - `localStorage.clear()`: `useTheme.ts` は localStorage 値を最優先するため
+ *   テーマを `emulateMedia` で固定するには事前クリアが必須
+ * - `emulateMedia({ colorScheme: "light", reducedMotion: "reduce" })`:
+ *   light テーマ固定 + View Transitions 抑制 (`index.css` に対応 CSS あり)
+ * - `document.fonts.ready` await: WebFont 読込完了を待ち、フォント差し替えで
+ *   発生する text glyph 差分を最小化
+ * - `networkidle` 後にさらに font ready を待つことで描画完了を担保
+ *
+ * Phase 2 / Phase 3 は別 PR で対応:
+ * - Phase 2: dark テーマ追加 (合計 4 PNG)
+ * - Phase 3: mobile viewport 追加 (合計 8 PNG)
+ */
+
+type VisualTarget = {
+  readonly name: string;
+  readonly path: string;
+};
+
+const TARGETS: readonly VisualTarget[] = [
+  { name: "home", path: "/" },
+  { name: "post-detail", path: "/posts/20260307120000" },
+];
+
+test.describe("visual: main pages (desktop x light)", () => {
+  test.beforeEach(async ({ page }) => {
+    // useTheme が localStorage を最優先するため、emulateMedia を効かせる
+    // 前提として goto より前にクリアしておく。
+    // ただし localStorage アクセスにはオリジン上のページが必要なため、
+    // about:blank では失敗する。代替として goto 直後に再度クリアし、
+    // theme = system 状態に戻す。
+    await page.emulateMedia({
+      colorScheme: "light",
+      reducedMotion: "reduce",
+    });
+  });
+
+  for (const target of TARGETS) {
+    test(`${target.name} の light テーマ snapshot を取得できる`, async ({
+      page,
+    }) => {
+      // 最初に対象ページを開いてから localStorage をクリアする。
+      // (Playwright の page は新規 BrowserContext 起動直後で空のはずだが、
+      //  reuseExistingServer 等の影響を防ぐため明示的にクリア)
+      await page.goto(target.path);
+      await page.evaluate(() => {
+        try {
+          localStorage.clear();
+        } catch {
+          /* localStorage 不可環境は無視 */
+        }
+      });
+
+      // localStorage クリア後にテーマを system 追従に戻すため再 reload する。
+      // emulateMedia の colorScheme: "light" が有効になるはず。
+      await page.reload();
+      await page.waitForLoadState("networkidle");
+      await page.evaluate(() => document.fonts.ready);
+
+      await expect(page).toHaveScreenshot(`${target.name}.png`, {
+        fullPage: true,
+        maxDiffPixelRatio: 0.01,
+        animations: "disabled",
+      });
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:run": "vitest run",
     "test:ui": "vitest --ui",
     "test:a11y": "playwright test e2e/a11y",
+    "test:visual": "playwright test --project=visual-desktop",
     "e2e": "playwright test",
     "fmt": "biome check --write --unsafe ./src",
     "lint": "biome lint  ./src",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,8 +4,15 @@ import { defineConfig, devices } from "@playwright/test";
  * Playwright 設定
  *
  * - 3 viewport (mobile 390 / tablet 768 / desktop 1280) で smoke を実行
+ * - VR (Visual Regression) は専用 project `visual-desktop` で実行 (Issue #410)
  * - dev server (vite) を webServer で自動起動
  * - CI ではリトライを有効化、ローカルでは無効
+ *
+ * project 構成:
+ * - smoke/a11y は `mobile` / `tablet` / `desktop` で実行する。これらの project は
+ *   `testIgnore` で `visual/**` を除外して VR テストを走らせない。
+ * - VR は `visual-desktop` project (`testMatch: visual/**`) で実行する。
+ *   smoke/a11y テストは含めない。
  */
 export default defineConfig({
   testDir: "./e2e",
@@ -22,6 +29,7 @@ export default defineConfig({
   projects: [
     {
       name: "mobile",
+      testIgnore: /visual\/.*/,
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: 390, height: 844 },
@@ -29,6 +37,7 @@ export default defineConfig({
     },
     {
       name: "tablet",
+      testIgnore: /visual\/.*/,
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: 768, height: 1024 },
@@ -36,9 +45,22 @@ export default defineConfig({
     },
     {
       name: "desktop",
+      testIgnore: /visual\/.*/,
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: 1280, height: 800 },
+      },
+    },
+    {
+      // Visual Regression 専用 project (Issue #410 Phase 1)
+      // desktop 1280x720 / light テーマで Home + PostDetail を snapshot 比較する。
+      // smoke / a11y テストはここでは走らせない (`testMatch` で visual/** に限定)。
+      name: "visual-desktop",
+      testMatch: /visual\/.*\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 720 },
+        colorScheme: "light",
       },
     },
   ],


### PR DESCRIPTION
## 概要

Issue #410 の **Phase 1 (最小構築)** を実装。Phase 2 リニューアル後の Visual Regression テスト基盤を新規構築する。

DA 検証で `e2e/visual/` ディレクトリ自体が未整備、かつ当初想定していた PostList/Tags/NotFound の 3 ルートが `src/main.tsx` に存在しないと判明した経緯から、対象を **Home (`/`) + PostDetail (`/posts/20260307120000`) の 2 ページ** に限定し、段階的に拡張する方針を取る。

### Phase 構成 (本 PR は Phase 1 のみ)

| Phase | スコープ | snapshot 数 | 担当 PR |
|---|---|---|---|
| **Phase 1 (本 PR)** | Home + PostDetail × **desktop × light** | **2 PNG** | ← この PR |
| Phase 2 | + dark テーマ | 4 PNG | 別 PR |
| Phase 3 | + mobile viewport | 8 PNG (最終) | 別 PR |

Refs #410

## 変更内容

- `e2e/visual/main-pages.spec.ts`: VR spec 新規追加 (Home + PostDetail × desktop × light)
  - `useTheme.ts` が localStorage 優先のため goto 直後に `localStorage.clear()` 実行
  - `emulateMedia({ colorScheme: "light", reducedMotion: "reduce" })` でテーマと View Transitions を固定
  - `networkidle` 後に `document.fonts.ready` await して WebFont 描画完了を保証
  - `toHaveScreenshot` `maxDiffPixelRatio: 0.01` で anti-aliasing 微差を吸収
- `playwright.config.ts`: VR 専用 project `visual-desktop` (viewport 1280x720 / colorScheme: light / `testMatch: visual/**`) を追加。既存 smoke/a11y 用 project (mobile/tablet/desktop) に `testIgnore: /visual\/.*/` を付与
- `.github/workflows/vr.yml`: VR 専用 workflow 新規追加 (a11y.yml と同パターンで分離)
  - `pull_request`: 比較のみ
  - `workflow_dispatch`: `update_snapshots` input で `--update-snapshots` を切替、`actions/upload-artifact@v7` で `e2e/visual/**/*-snapshots/**` を 14 日間保存
- `.github/workflows/playwright.yml`: 既存 smoke + a11y workflow の対象を `--project=mobile --project=tablet --project=desktop` に明示限定 (visual-desktop が誤起動して baseline 不在 fail するのを防ぐ)
- `package.json`: `test:visual` script (`playwright test --project=visual-desktop`) を追加
- `.gitignore`: `e2e/visual/**/*-darwin.png` を除外 (macOS 生成 PNG の誤コミット防止)

## 検証結果

- `pnpm test:run`: pass (640/640)
- `pnpm lint`: pass
- `pnpm build`: pass (type-check / panda / tsc / vite build 全 OK)
- YAML 構文: OK (vr.yml / playwright.yml 共に `yaml` で parse 成功)
- `playwright test --list`: project 分離が機能することを確認
  - mobile/tablet/desktop: smoke + a11y のみ (合計 12 tests、visual を含まない)
  - visual-desktop: VR のみ (2 tests)

## baseline 生成手順 (マージ前に user 実施)

本 PR には **PNG をコミットしていない**。macOS と CI Linux のフォントレンダリング差で必発の差分が出るため、baseline は CI Linux 上で生成する必要がある。

1. 本 PR を push 後、GitHub Actions の **vr.yml workflow** を `workflow_dispatch` で実行する
   - GitHub Actions UI から `Run workflow` → Branch を `chore/issue-410-vr-baseline-phase1` に指定 → `Update VR baseline snapshots` を `true` に**明示的に変更**して実行 (デフォルトは `false`)
2. 完了したら `vr-snapshots` アーティファクトを手動 download し、ローカルで展開
3. 展開した `e2e/visual/main-pages.spec.ts-snapshots/` を本ブランチにコミット
   - 例: `e2e/visual/main-pages.spec.ts-snapshots/home-visual-desktop-linux.png` 等
4. 同ブランチへ push すると通常の `pull_request` トリガーで比較モードが走り、green になることを確認
5. green 確認後にマージ

## 備考

- 本 PR はテストインフラ追加のみで、production コード (`src/`) は変更していない
- 既存 smoke / a11y workflow との fail isolation を保つため、VR は独立 workflow に分離
- Phase 2 / Phase 3 は本 PR マージ後、別 Issue/PR で対応する
