### PR TITLE
feat: 個人史座標エンジン anchors.ts を追加（Closes #488）

### DIFF
--- a/src/lib/__tests__/anchors.test.ts
+++ b/src/lib/__tests__/anchors.test.ts
@@ -1,0 +1,351 @@
+/**
+ * 個人史座標エンジン (anchors.ts) のテスト
+ *
+ * 設計書: epic #487 / Issue #488
+ *
+ * - publishedAt 推定 (ファイル名 → ISO 8601 JST 固定)
+ * - 層1=座標 (computeCoordinates): 登録節目との差分日数
+ * - 層2=経過 (computeElapsed): フォールバックの暦上経過日数
+ *
+ * `meta.ts` には依存しない (death module 扱い、本 Issue の制約)
+ */
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  type Coordinate,
+  computeCoordinates,
+  computeElapsed,
+  type Elapsed,
+  inferPublishedAt,
+  type Milestone,
+} from "../anchors";
+
+describe("inferPublishedAt: ファイル名からの ISO 8601 推定 (JST 固定)", () => {
+  describe("正常系", () => {
+    it("ファイル名 20250101120000.md から 2025-01-01T12:00:00+09:00 を返す", () => {
+      expect(inferPublishedAt("20250101120000.md")).toBe(
+        "2025-01-01T12:00:00+09:00",
+      );
+    });
+
+    it("拡張子 .md なしの 20250101120000 も同じ ISO 8601 を返す", () => {
+      expect(inferPublishedAt("20250101120000")).toBe(
+        "2025-01-01T12:00:00+09:00",
+      );
+    });
+
+    it("ファイル名 20250908234321.md から 2025-09-08T23:43:21+09:00 を返す", () => {
+      expect(inferPublishedAt("20250908234321.md")).toBe(
+        "2025-09-08T23:43:21+09:00",
+      );
+    });
+
+    it("ファイル名 20260307120000.md から 2026-03-07T12:00:00+09:00 を返す", () => {
+      expect(inferPublishedAt("20260307120000.md")).toBe(
+        "2026-03-07T12:00:00+09:00",
+      );
+    });
+
+    it("閏年 2024-02-29 のファイル名 20240229120000.md は実在日付として 2024-02-29T12:00:00+09:00 を返す", () => {
+      expect(inferPublishedAt("20240229120000.md")).toBe(
+        "2024-02-29T12:00:00+09:00",
+      );
+    });
+  });
+
+  describe("異常系・境界値", () => {
+    it("ゼロ埋めの 00000000000000.md は null を返す", () => {
+      expect(inferPublishedAt("00000000000000.md")).toBeNull();
+    });
+
+    it("上限超過の 99999999999999.md は null を返す", () => {
+      expect(inferPublishedAt("99999999999999.md")).toBeNull();
+    });
+
+    it("数字以外を含む abc.md は null を返す", () => {
+      expect(inferPublishedAt("abc.md")).toBeNull();
+    });
+
+    it("13 桁しか無い 2025010112000.md は null を返す", () => {
+      expect(inferPublishedAt("2025010112000.md")).toBeNull();
+    });
+
+    it("15 桁の 202501011200001.md は null を返す", () => {
+      expect(inferPublishedAt("202501011200001.md")).toBeNull();
+    });
+
+    it("空文字列は null を返す", () => {
+      expect(inferPublishedAt("")).toBeNull();
+    });
+
+    it("拡張子のみの .md は null を返す", () => {
+      expect(inferPublishedAt(".md")).toBeNull();
+    });
+
+    /**
+     * 設計上の意図: ファイル名推定は正規表現で年月日時分秒を抽出して
+     * 文字列を組み立てる実装。Date.parse が非閏年の 2/29 をロールオーバー
+     * させても文字列は再構築されないため、推定値はそのまま "2025-02-29T..."
+     * を返す。meta.test.ts の同じ境界値ケースと対称な振る舞いを保つ。
+     *
+     * 将来 isIso8601 側を厳密化する場合は本テストの期待値を null に反転する。
+     */
+    it("非閏年 2/29 ファイル名 20250229120000.md は 2025-02-29T12:00:00+09:00 を返す (実在しない日付だが文字列再構築のため許容)", () => {
+      expect(inferPublishedAt("20250229120000.md")).toBe(
+        "2025-02-29T12:00:00+09:00",
+      );
+    });
+  });
+
+  describe("既存16記事すべての解決", () => {
+    it("datasources/ 配下の全 .md ファイルで publishedAt が解決できる", () => {
+      const datasourcesDir = join(__dirname, "../../../datasources");
+      const files = readdirSync(datasourcesDir).filter((file) =>
+        file.endsWith(".md"),
+      );
+
+      // 前提: 16 記事以上存在する (本 Issue の前提)
+      expect(files.length).toBeGreaterThanOrEqual(16);
+
+      for (const file of files) {
+        const result = inferPublishedAt(file);
+        expect(result, `ファイル ${file} の推定に失敗`).not.toBeNull();
+        expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+09:00$/);
+      }
+    });
+  });
+});
+
+describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () => {
+  describe("基本動作", () => {
+    it("publishedAt より前の節目1つの差分日数を計算する", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-01", label: "社会復帰", tone: "neutral" },
+      ];
+      const result = computeCoordinates(
+        "2025-01-10T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual<Coordinate>({
+        label: "社会復帰",
+        tone: "neutral",
+        daysSince: 9,
+      });
+    });
+
+    it("同日 (節目=publishedAt) の差分日数は 0 になる", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-01", label: "サイト開設", tone: "neutral" },
+      ];
+      const result = computeCoordinates(
+        "2025-01-01T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].daysSince).toBe(0);
+    });
+
+    it("複数の節目すべてについて差分日数を返す", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-01", label: "社会復帰", tone: "neutral" },
+        { date: "2025-01-05", label: "サイト開設", tone: "light" },
+      ];
+      const result = computeCoordinates(
+        "2025-01-10T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result.find((c) => c.label === "社会復帰")?.daysSince).toBe(9);
+      expect(result.find((c) => c.label === "サイト開設")?.daysSince).toBe(5);
+    });
+
+    it("空の節目配列を渡すと空配列を返す", () => {
+      const result = computeCoordinates("2025-01-10T12:00:00+09:00", []);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("publishedAt より後の節目は除外", () => {
+    it("publishedAt より後 (未来) の節目は結果に含まれない", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-01", label: "過去", tone: "neutral" },
+        { date: "2025-12-31", label: "未来", tone: "light" },
+      ];
+      const result = computeCoordinates(
+        "2025-01-10T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].label).toBe("過去");
+    });
+
+    it("全ての節目が publishedAt より後なら空配列を返す", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-12-31", label: "未来", tone: "neutral" },
+      ];
+      const result = computeCoordinates(
+        "2025-01-10T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("tone の保持", () => {
+    it("neutral / light / heavy の tone をそのまま結果に保持する", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-01", label: "中立", tone: "neutral" },
+        { date: "2025-01-02", label: "軽め", tone: "light" },
+        { date: "2025-01-03", label: "重い", tone: "heavy" },
+      ];
+      const result = computeCoordinates(
+        "2025-02-01T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result.find((c) => c.label === "中立")?.tone).toBe("neutral");
+      expect(result.find((c) => c.label === "軽め")?.tone).toBe("light");
+      expect(result.find((c) => c.label === "重い")?.tone).toBe("heavy");
+    });
+  });
+
+  describe("日数計算の精度", () => {
+    it("月をまたぐ場合も暦日数で計算される (2025-01-31 → 2025-02-01 は 1 日)", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-31", label: "境界", tone: "neutral" },
+      ];
+      const result = computeCoordinates(
+        "2025-02-01T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result[0].daysSince).toBe(1);
+    });
+
+    it("年をまたぐ場合も暦日数で計算される (2024-12-31 → 2025-01-01 は 1 日)", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2024-12-31", label: "大晦日", tone: "neutral" },
+      ];
+      const result = computeCoordinates(
+        "2025-01-01T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result[0].daysSince).toBe(1);
+    });
+
+    it("publishedAt 内の時刻に関係なく日付の差で計算される (00:00 と 23:59 で同じ)", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-01", label: "起点", tone: "neutral" },
+      ];
+      const morning = computeCoordinates(
+        "2025-01-10T00:00:00+09:00",
+        milestones,
+      );
+      const night = computeCoordinates("2025-01-10T23:59:59+09:00", milestones);
+
+      expect(morning[0].daysSince).toBe(9);
+      expect(night[0].daysSince).toBe(9);
+    });
+  });
+});
+
+describe("computeElapsed: 層2=経過 (暦上の経過日数)", () => {
+  it("origin から publishedAt までの経過日数を返す", () => {
+    const result = computeElapsed(
+      "2025-01-10T12:00:00+09:00",
+      "2025-01-01",
+      "サイト開設",
+    );
+
+    expect(result).toEqual<Elapsed>({
+      label: "サイト開設",
+      daysSince: 9,
+    });
+  });
+
+  it("origin と publishedAt が同日なら 0 日を返す", () => {
+    const result = computeElapsed(
+      "2025-01-01T15:00:00+09:00",
+      "2025-01-01",
+      "サイト開設",
+    );
+
+    expect(result.daysSince).toBe(0);
+  });
+
+  it("origin が publishedAt より後ろの場合は負の値を返さず 0 を返す", () => {
+    const result = computeElapsed(
+      "2025-01-01T12:00:00+09:00",
+      "2025-01-10",
+      "サイト開設",
+    );
+
+    expect(result.daysSince).toBe(0);
+  });
+
+  it("label がそのまま結果に保持される", () => {
+    const result = computeElapsed(
+      "2025-01-10T12:00:00+09:00",
+      "2025-01-01",
+      "任意のラベル",
+    );
+
+    expect(result.label).toBe("任意のラベル");
+  });
+
+  it("年をまたぐ経過日数も計算できる", () => {
+    const result = computeElapsed(
+      "2026-01-01T12:00:00+09:00",
+      "2025-01-01",
+      "1年経過",
+    );
+
+    expect(result.daysSince).toBe(365);
+  });
+});
+
+describe("型定義: status / tags / updatedAt を露出しない", () => {
+  it("Coordinate 型は label / tone / daysSince のみを公開し、メタ情報を持たない", () => {
+    const coordinate: Coordinate = {
+      label: "ラベル",
+      tone: "neutral",
+      daysSince: 0,
+    };
+
+    // status / tags / updatedAt のキーは存在しない
+    expect(Object.keys(coordinate).sort()).toEqual(
+      ["daysSince", "label", "tone"].sort(),
+    );
+  });
+
+  it("Elapsed 型は label / daysSince のみを公開し、tone も含まない", () => {
+    const elapsed: Elapsed = {
+      label: "ラベル",
+      daysSince: 0,
+    };
+
+    expect(Object.keys(elapsed).sort()).toEqual(["daysSince", "label"].sort());
+  });
+
+  it("Milestone 型は date / label / tone のみを公開する", () => {
+    const milestone: Milestone = {
+      date: "2025-01-01",
+      label: "ラベル",
+      tone: "neutral",
+    };
+
+    expect(Object.keys(milestone).sort()).toEqual(
+      ["date", "label", "tone"].sort(),
+    );
+  });
+});

--- a/src/lib/__tests__/anchors.test.ts
+++ b/src/lib/__tests__/anchors.test.ts
@@ -263,6 +263,153 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       expect(night[0].daysSince).toBe(9);
     });
   });
+
+  describe("入力順の保持", () => {
+    /**
+     * 設計上の意図: computeCoordinates の JSDoc に「milestones の順序を
+     * 保ったまま返す」と明記しているため、テストで仕様固定する。
+     * 表示層 (#491) でソート順を別途指定する/しないの判断はこの不変条件に依存する。
+     */
+    it("milestones の入力順を保持したまま Coordinate 配列を返す", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-05", label: "B", tone: "neutral" },
+        { date: "2025-01-01", label: "A", tone: "neutral" },
+        { date: "2025-01-03", label: "C", tone: "light" },
+      ];
+      const result = computeCoordinates(
+        "2025-02-01T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result.map((c) => c.label)).toEqual(["B", "A", "C"]);
+    });
+
+    it("publishedAt より後ろの節目を除外しても残った要素の相対順は保持される", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-05", label: "B", tone: "neutral" },
+        { date: "2025-12-31", label: "未来", tone: "light" },
+        { date: "2025-01-01", label: "A", tone: "neutral" },
+        { date: "2025-01-03", label: "C", tone: "light" },
+      ];
+      const result = computeCoordinates(
+        "2025-02-01T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result.map((c) => c.label)).toEqual(["B", "A", "C"]);
+    });
+  });
+
+  /**
+   * Milestone.date の値範囲検証は本モジュールでは行わない。
+   * 不正な YYYY-MM-DD は `Date.UTC` のロールオーバーでサイレントに
+   * 別の日付として解釈される (例: "2025-13-32" → 2026-02-01)。
+   *
+   * 将来 milestones.json の値範囲検証関数を #489 で追加するため、
+   * 本モジュールの「ロールオーバー許容」挙動を仕様としてここで固定する。
+   * 将来 #489 で検証関数が導入されたとしても、anchors.ts の純粋関数は
+   * この挙動を保つ前提 (検証は呼び出し側責務)。
+   */
+  describe("Milestone.date 不正値の仕様: Date.UTC ロールオーバーを許容", () => {
+    it('Milestone.date が "2025-13-32" のとき、Date.UTC のロールオーバーで 2026-02-01 として解釈される', () => {
+      // 2025-13-32 → Date.UTC(2025, 12, 32) = 2026-02-01
+      // publishedAt = 2026-02-10 とすると 9 日差になる
+      const milestones: readonly Milestone[] = [
+        { date: "2025-13-32", label: "ロールオーバー", tone: "neutral" },
+      ];
+      const result = computeCoordinates(
+        "2026-02-10T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].daysSince).toBe(9);
+    });
+
+    it('Milestone.date が "2025-00-01" のとき、Date.UTC のロールオーバーで 2024-12-01 として解釈される', () => {
+      // 2025-00-01 → Date.UTC(2025, -1, 1) = 2024-12-01
+      // publishedAt = 2024-12-11 とすると 10 日差になる
+      const milestones: readonly Milestone[] = [
+        { date: "2025-00-01", label: "ロールオーバー", tone: "neutral" },
+      ];
+      const result = computeCoordinates(
+        "2024-12-11T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].daysSince).toBe(10);
+    });
+
+    it('Milestone.date が "2025-99-99" のとき、Date.UTC のロールオーバーで 2033-06-07 として解釈される', () => {
+      // 2025-99-99 → Date.UTC(2025, 98, 99) = 2033-06-07
+      const milestones: readonly Milestone[] = [
+        { date: "2025-99-99", label: "ロールオーバー", tone: "neutral" },
+      ];
+      const result = computeCoordinates(
+        "2033-06-08T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].daysSince).toBe(1);
+    });
+
+    it('Milestone.date が "abc-de-fg" のとき、正規表現で reject されて結果から除外される', () => {
+      const milestones: readonly Milestone[] = [
+        { date: "abc-de-fg", label: "形式不正", tone: "neutral" },
+      ];
+      const result = computeCoordinates(
+        "2025-02-01T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('Milestone.date が "2025-02-29" (非閏年 2/29) のとき、Date.UTC のロールオーバーで 2025-03-01 として解釈される', () => {
+      // 2025-02-29 → Date.UTC(2025, 1, 29) = 2025-03-01
+      const milestones: readonly Milestone[] = [
+        { date: "2025-02-29", label: "非閏年 2/29", tone: "neutral" },
+      ];
+      const result = computeCoordinates(
+        "2025-03-02T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].daysSince).toBe(1);
+    });
+  });
+
+  /**
+   * ラウンドトリップ整合性: inferPublishedAt が非閏年 2/29 を文字列として
+   * 通すため (`"2025-02-29T12:00:00+09:00"`)、それを computeCoordinates に
+   * 渡したときの挙動を仕様として固定する。
+   *
+   * - inferPublishedAt: 文字列再構築のためそのまま返す
+   * - computeCoordinates: JST 暦上では Date.UTC ロールオーバーで 2025-03-01 扱い
+   * - 結果として milestone "2025-03-01" との差分は 0 日になる
+   */
+  describe("inferPublishedAt → computeCoordinates のラウンドトリップ整合性", () => {
+    it("inferPublishedAt が返した非閏年 2/29 の publishedAt は、暦上同一日 (2025-03-01) として扱われる", () => {
+      const publishedAt = inferPublishedAt("20250229120000.md");
+      expect(publishedAt).toBe("2025-02-29T12:00:00+09:00");
+
+      // null チェック: 上の expect で確定済みだが TypeScript narrowing のため
+      if (publishedAt === null) {
+        throw new Error("unreachable");
+      }
+
+      const milestones: readonly Milestone[] = [
+        { date: "2025-03-01", label: "x", tone: "neutral" },
+      ];
+      const result = computeCoordinates(publishedAt, milestones);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].daysSince).toBe(0);
+    });
+  });
 });
 
 describe("computeElapsed: 層2=経過 (暦上の経過日数)", () => {

--- a/src/lib/__tests__/anchors.test.ts
+++ b/src/lib/__tests__/anchors.test.ts
@@ -100,10 +100,16 @@ describe("inferPublishedAt: ファイル名からの ISO 8601 推定 (JST 固定
   });
 
   describe("既存16記事すべての解決", () => {
-    it("datasources/ 配下の全 .md ファイルで publishedAt が解決できる", () => {
+    /**
+     * 対象は `YYYYMMDDhhmmss.md` 命名のファイルのみに絞る。
+     * 命名外のファイル (例: `non-yyyymmddhhmmss.md`) が将来追加されても
+     * inferPublishedAt の解決確認テストが壊れないようにする。
+     * 件数しきい値 (>= 16) と全件解決を担保する点は変わらない。
+     */
+    it("datasources/ 配下の YYYYMMDDhhmmss.md ファイル全件で publishedAt が解決できる", () => {
       const datasourcesDir = join(__dirname, "../../../datasources");
       const files = readdirSync(datasourcesDir).filter((file) =>
-        file.endsWith(".md"),
+        /^\d{14}\.md$/.test(file),
       );
 
       // 前提: 16 記事以上存在する (本 Issue の前提)

--- a/src/lib/anchors.ts
+++ b/src/lib/anchors.ts
@@ -1,0 +1,223 @@
+/**
+ * 個人史座標エンジン (Anchor 機能の土台)
+ *
+ * 設計書: epic #487 / Issue #488
+ *
+ * - 純粋関数のみで構成し、モジュールスコープの可変状態を持たない
+ * - publishedAt はファイル名 (`YYYYMMDDhhmmss.md`) から ISO 8601 (JST +09:00 固定)
+ *   を推定する純粋関数で解決する。`meta.ts` (parseMetaSection/createDefaultMeta)
+ *   は死蔵モジュール扱いで import しない (Anchor は meta.ts に一切触れない方針)
+ * - 「座標」(層1=computeCoordinates) と「経過」(層2=computeElapsed) を
+ *   別関数・別型として命名区別する
+ * - status / tags / updatedAt は本モジュールの出力に露出させない
+ */
+
+/**
+ * 節目の感情トーン
+ *
+ * - neutral: 中立な事実 (例: サイト開設)
+ * - light: 軽めの節目 (例: 復帰、節目イベント)
+ * - heavy: 重い節目 (例: 喪失体験など)。Coordinate 表示には出さない方針
+ */
+export type MilestoneTone = "neutral" | "light" | "heavy";
+
+/**
+ * 節目データのスキーマ (datasources/milestones.json に登録される単位)
+ *
+ * - date: YYYY-MM-DD (JST 想定)
+ * - label: 表示用ラベル (例: "社会復帰" / "サイト開設")
+ * - tone: 表示時の扱いを切り替えるための感情タグ
+ */
+export interface Milestone {
+  readonly date: string;
+  readonly label: string;
+  readonly tone: MilestoneTone;
+}
+
+/**
+ * 層1=座標
+ *
+ * 登録された節目 (Milestone) と publishedAt の差分日数を保持する。
+ * 節目が登録されている限りで意味を持つ「座標」を名乗れる層。
+ */
+export interface Coordinate {
+  readonly label: string;
+  readonly tone: MilestoneTone;
+  readonly daysSince: number;
+}
+
+/**
+ * 層2=経過
+ *
+ * 節目が未登録または記事が全節目より前のときのフォールバック。
+ * 「座標」ではなく「経過」と用語を厳密区別する。tone は持たない。
+ */
+export interface Elapsed {
+  readonly label: string;
+  readonly daysSince: number;
+}
+
+/**
+ * ISO 8601 形式 (日時、タイムゾーン必須) の検証用正規表現
+ *
+ * 例: 2025-01-01T12:00:00+09:00
+ */
+const ISO_8601_DATETIME =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * ISO 8601 形式かどうかを判定する
+ *
+ * 形式の表面上のチェックに加え、Date でパース可能な実在日付であることを確認する
+ */
+const isIso8601 = (value: string): boolean => {
+  if (!ISO_8601_DATETIME.test(value)) {
+    return false;
+  }
+  const time = Date.parse(value);
+  return Number.isFinite(time);
+};
+
+/**
+ * ファイル名 (例: `20250101120000.md` / `20250101120000`) から
+ * publishedAt の ISO 8601 文字列を推定する純粋関数
+ *
+ * - JST (+09:00) で固定する (既存記事は JST 想定)
+ * - 14 桁の数字 + 任意の .md のみ受理する厳格な実装
+ * - 桁数や数値が不正な場合は null を返す
+ * - 月末日や閏年の厳密判定は行わない (Date.parse がロールオーバーしても
+ *   文字列自体は再構築されないため、推定値はそのまま返る)
+ *
+ * @param fileName - ファイル名 (例: `20250101120000.md`)
+ * @returns ISO 8601 文字列 (推定不可なら null)
+ */
+export const inferPublishedAt = (fileName: string): string | null => {
+  const base = fileName.replace(/\.md$/, "");
+  const match = base.match(/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/);
+  if (!match) {
+    return null;
+  }
+  const [, year, month, day, hour, minute, second] = match;
+  const candidate = `${year}-${month}-${day}T${hour}:${minute}:${second}+09:00`;
+  return isIso8601(candidate) ? candidate : null;
+};
+
+/**
+ * ISO 8601 文字列 (publishedAt) から JST のカレンダー上の年月日を抽出する
+ *
+ * - publishedAt 内のタイムゾーンに関係なく、JST (+09:00) の暦上の日付を返す
+ * - 同日内の時刻差は無視される (00:00 と 23:59 で同じ日付を返す)
+ */
+const toJstCalendarDate = (isoDateTime: string): Date => {
+  const time = Date.parse(isoDateTime);
+  if (!Number.isFinite(time)) {
+    throw new Error(`Invalid ISO 8601 datetime: "${isoDateTime}"`);
+  }
+  // JST (+09:00) オフセットを加えて UTC として年月日を取り出すことで、
+  // JST 上のカレンダー日付を表現する Date インスタンスを生成する
+  const jstOffsetMs = 9 * 60 * 60 * 1000;
+  const jstShifted = new Date(time + jstOffsetMs);
+  return new Date(
+    Date.UTC(
+      jstShifted.getUTCFullYear(),
+      jstShifted.getUTCMonth(),
+      jstShifted.getUTCDate(),
+    ),
+  );
+};
+
+/**
+ * 節目の date 文字列 (YYYY-MM-DD) を JST カレンダー上の Date に変換する
+ *
+ * - 年月日のみを保持した UTC 基準の Date インスタンスを返す
+ * - 日数差の計算用 (時分秒は 00:00:00 固定)
+ */
+const toMilestoneCalendarDate = (date: string): Date | null => {
+  const match = date.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    return null;
+  }
+  const [, year, month, day] = match;
+  const utcMs = Date.UTC(Number(year), Number(month) - 1, Number(day));
+  if (!Number.isFinite(utcMs)) {
+    return null;
+  }
+  return new Date(utcMs);
+};
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * 2 つの JST カレンダー日付の差分日数 (publishedAt - origin) を返す
+ *
+ * - 引数はいずれも `toJstCalendarDate` / `toMilestoneCalendarDate` で
+ *   00:00:00 UTC 固定化された Date インスタンスである前提
+ */
+const diffInDays = (origin: Date, target: Date): number => {
+  return Math.round((target.getTime() - origin.getTime()) / MS_PER_DAY);
+};
+
+/**
+ * 層1=座標: publishedAt と登録節目の差分日数を計算する
+ *
+ * - publishedAt より後 (未来) の節目は結果から除外する
+ * - 引数の milestones の順序を保ったまま返す
+ * - 空配列が渡されたら空配列を返す
+ *
+ * @param publishedAt - 記事の公開日時 (ISO 8601 文字列)
+ * @param milestones - 登録された節目の配列
+ * @returns 各節目に対応する Coordinate の配列 (publishedAt より後の節目は除外)
+ */
+export const computeCoordinates = (
+  publishedAt: string,
+  milestones: readonly Milestone[],
+): readonly Coordinate[] => {
+  const publishedDate = toJstCalendarDate(publishedAt);
+
+  const coordinates: Coordinate[] = [];
+  for (const milestone of milestones) {
+    const milestoneDate = toMilestoneCalendarDate(milestone.date);
+    if (milestoneDate === null) {
+      continue;
+    }
+    const days = diffInDays(milestoneDate, publishedDate);
+    if (days < 0) {
+      continue;
+    }
+    coordinates.push({
+      label: milestone.label,
+      tone: milestone.tone,
+      daysSince: days,
+    });
+  }
+  return coordinates;
+};
+
+/**
+ * 層2=経過: publishedAt と origin の暦上の経過日数を計算する
+ *
+ * - 節目が未登録または記事が全節目より前のときのフォールバック
+ * - origin が publishedAt より後ろの場合は 0 を返す (負の値は返さない)
+ * - tone を持たない点で Coordinate と命名区別する
+ *
+ * @param publishedAt - 記事の公開日時 (ISO 8601 文字列)
+ * @param origin - 起点となる日付 (YYYY-MM-DD)
+ * @param label - 表示用ラベル
+ * @returns label と daysSince を保持した Elapsed
+ */
+export const computeElapsed = (
+  publishedAt: string,
+  origin: string,
+  label: string,
+): Elapsed => {
+  const publishedDate = toJstCalendarDate(publishedAt);
+  const originDate = toMilestoneCalendarDate(origin);
+  if (originDate === null) {
+    throw new Error(`Invalid origin date (YYYY-MM-DD): "${origin}"`);
+  }
+  const days = diffInDays(originDate, publishedDate);
+  return {
+    label,
+    daysSince: days < 0 ? 0 : days,
+  };
+};

--- a/src/lib/anchors.ts
+++ b/src/lib/anchors.ts
@@ -131,6 +131,12 @@ const toJstCalendarDate = (isoDateTime: string): Date => {
  *
  * - 年月日のみを保持した UTC 基準の Date インスタンスを返す
  * - 日数差の計算用 (時分秒は 00:00:00 固定)
+ * - 形式が `YYYY-MM-DD` を満たさない (例: "abc-de-fg") 場合のみ null を返す
+ * - 値範囲は検証せず、`Date.UTC` のロールオーバーを許容する
+ *   - 例: "2025-13-32" → 2026-02-01 / "2025-02-29" → 2025-03-01
+ *   - 仕様としての挙動は `anchors.test.ts` の「Milestone.date 不正値の仕様」で固定
+ *
+ * @todo 値範囲検証関数は #489 で別途追加予定。本関数は現状ロールオーバーを許容する
  */
 const toMilestoneCalendarDate = (date: string): Date | null => {
   const match = date.match(/^(\d{4})-(\d{2})-(\d{2})$/);
@@ -160,9 +166,15 @@ const diffInDays = (origin: Date, target: Date): number => {
 /**
  * 層1=座標: publishedAt と登録節目の差分日数を計算する
  *
- * - publishedAt より後 (未来) の節目は結果から除外する
- * - 引数の milestones の順序を保ったまま返す
+ * - publishedAt より後 (未来) の節目は結果から **除外 (filter)** する
+ *   これは「まだ存在しない節目」を Coordinate として返さないためである
+ *   (層2=`computeElapsed` は同じ未来起点を 0 にクランプするだけで除外しない。
+ *    両関数の「未来の起点が来たときの挙動」は意図的に非対称な仕様)
+ * - 引数の milestones の順序を保ったまま返す (`anchors.test.ts` の
+ *   「入力順の保持」で仕様として固定)
  * - 空配列が渡されたら空配列を返す
+ * - Milestone.date の値範囲は検証せず、`Date.UTC` のロールオーバーを許容する
+ *   (`toMilestoneCalendarDate` の JSDoc / テスト「Milestone.date 不正値の仕様」参照)
  *
  * @param publishedAt - 記事の公開日時 (ISO 8601 文字列)
  * @param milestones - 登録された節目の配列
@@ -197,7 +209,12 @@ export const computeCoordinates = (
  * 層2=経過: publishedAt と origin の暦上の経過日数を計算する
  *
  * - 節目が未登録または記事が全節目より前のときのフォールバック
- * - origin が publishedAt より後ろの場合は 0 を返す (負の値は返さない)
+ * - origin が publishedAt より後ろ (未来) の場合は 0 に **クランプ** する
+ *   (負の値は返さず、エラーにもしない)
+ *   これは Coordinate と異なり「未来からの経過」をそのまま 0 として扱うことで、
+ *   フォールバック表示が破綻しないようにするためである。
+ *   (層1=`computeCoordinates` は同じ未来起点を結果から filter で除外する。
+ *    両関数の「未来の起点が来たときの挙動」は意図的に非対称な仕様)
  * - tone を持たない点で Coordinate と命名区別する
  *
  * @param publishedAt - 記事の公開日時 (ISO 8601 文字列)


### PR DESCRIPTION
## 概要

Issue #488 / epic #487 の **個人史座標エンジン土台** を追加する。Anchor 機能の表示層（#491）と区別される、純粋関数のみで構成された層。

`meta.ts` は依存せず、独立したモジュールとして `src/lib/anchors.ts` を新設する。

## 提供する API

### 型

- `Milestone`: `{ date, label, tone }`（`datasources/milestones.json` に登録される単位）
- `MilestoneTone`: `"neutral" | "light" | "heavy"`
- `Coordinate`: `{ label, tone, daysSince }`（層1=座標）
- `Elapsed`: `{ label, daysSince }`（層2=経過）

### 関数

- `inferPublishedAt(fileName)`: `YYYYMMDDhhmmss.md` から ISO 8601（JST +09:00 固定）を推定する純粋関数
- `computeCoordinates(publishedAt, milestones)`: 層1=登録節目との差分日数。未来の節目は filter で除外、入力順は保持
- `computeElapsed(publishedAt, origin, label)`: 層2=暦上の経過日数。未来の origin は 0 にクランプ

## 設計上の意思決定

### 1. 層1（Coordinate）と層2（Elapsed）の用語と命名の厳格区別

- 層1=`Coordinate`: 登録節目に紐づく「座標」。tone を持つ
- 層2=`Elapsed`: フォールバックの「経過」。tone を持たない

両者を別型・別関数として宣言区別し、表示層（#491）で混在が起きにくいインターフェースにする。

### 2. 未来の起点に対する挙動は意図的に非対称

| 関数 | 未来起点の扱い |
|------|---------------|
| `computeCoordinates` | **filter で除外**（「まだ存在しない節目」を Coordinate として返さない） |
| `computeElapsed` | **0 にクランプ**（フォールバック表示の破綻を防ぐため、負値もエラーも返さない） |

意図は両関数の JSDoc に明記。表示層は filter された結果が空配列のとき `computeElapsed` のフォールバックに切り替える設計を取る前提。

### 3. Milestone.date の値範囲検証は本モジュールでは行わない（#489 で対応）

`toMilestoneCalendarDate` は形式 `YYYY-MM-DD` を満たさない（例: `"abc-de-fg"`）のみ null を返し、値範囲は `Date.UTC` のロールオーバーを許容する。これは以下の挙動になる：

| `Milestone.date` | 解釈される日付 |
|------------------|---------------|
| `"2025-13-32"` | `2026-02-01` |
| `"2025-00-01"` | `2024-12-01` |
| `"2025-99-99"` | `2033-06-07` |
| `"2025-02-29"`（非閏年 2/29） | `2025-03-01` |

これは Issue #489（`milestones.json` 値範囲検証関数の追加）で別途扱う前提。本 PR では「ロールオーバー許容」を**仕様としてテストで固定**しているため、将来 #489 で検証関数を呼び出し側に挟むことで安全に値範囲チェックを追加できる。

### 4. 非閏年 2/29 のラウンドトリップ整合性

- `inferPublishedAt("20250229120000.md")` → `"2025-02-29T12:00:00+09:00"`（文字列再構築のためそのまま返す）
- これを `computeCoordinates` に渡すと、JST 暦上では `Date.UTC` のロールオーバーで `2025-03-01` 扱いになる
- 結果として milestone `"2025-03-01"` との `daysSince = 0` になる

この挙動を**ラウンドトリップ整合性テスト**で仕様固定している（`anchors.test.ts` の「inferPublishedAt → computeCoordinates のラウンドトリップ整合性」）。

## フォローアップ事項（別 Issue 化）

### A. `meta.ts` との重複コードの追従計画

`inferPublishedAt` / `isIso8601` / 桁数チェックの正規表現は **`src/lib/meta.ts` と完全重複**している。`meta.ts` は現状 **死蔵モジュール** で、テスト以外どこからも import されていない。

追従計画: `meta.ts` の死蔵化が確定する別タスクで、`anchors.ts` を正本として `meta.ts` 側を削除 or `anchors.ts` への委譲に置き換える（**本 PR では対応しない**）。

### B. `Coordinate` / `Elapsed` の structural typing 縮退の注意喚起

TypeScript の structural typing で `Coordinate` は `Elapsed` を構造的に包含する（`Coordinate = { label, tone, daysSince }`、`Elapsed = { label, daysSince }`）。そのため：

```ts
const coordinate: Coordinate = { label: "x", tone: "neutral", daysSince: 0 };
const elapsed: Elapsed = coordinate; // ← コンパイル通る（構造的に互換）
```

表示層（#491）で誤って `Coordinate` を `Elapsed` として受けてしまう事故を避けるため、実装者は：

- **明示的な型注釈を使う**（`const e: Elapsed = computeElapsed(...)`）
- **個別変数で受ける**（`Coordinate` と `Elapsed` を同一スコープに置く場合は変数名でも区別）

ことを意識する。branded type / discriminator 導入による nominal typing 化は **#497 で別途扱う**。

### C. `milestones.json` 値範囲検証関数の追加（Issue #489）

上述の通り、本モジュールはロールオーバーを許容する。値範囲チェックは #489 で呼び出し側に検証関数を導入することで実現する前提。

## テスト

- `pnpm test:run`: **679 + 8 = 687 tests / 44 files pass**（追加 40 件含む）
- 設計上の不変条件はすべてテストで固定済み：
  - 未来節目の filter / クランプの非対称挙動
  - 入力順の保持
  - 不正値のロールオーバー仕様（`2025-13-32` / `2025-00-01` / `2025-99-99` / `abc-de-fg` / `2025-02-29` の 5 ケース）
  - 非閏年 2/29 のラウンドトリップ整合性
  - 既存 16 記事ファイル全件の `inferPublishedAt` 解決（pattern フィルタ `/^\d{14}\.md$/` で命名外ファイル耐性を担保）

## 動作確認

- `pnpm test:run`: 687 tests / 44 files pass（追加 40 件含む anchors 40 tests）
- `pnpm build`: panda codegen → tsc → vite 全段成功
- `pnpm lint`: clean

## 関連

- epic: #487
- フォローアップ: #489（`milestones.json` データ登録と値範囲検証）、#491（Coordinate 表示）、#497（Coordinate/Elapsed の nominal typing 化）

Closes #488