### PR TITLE
refactor: Anchor の Coordinate / Elapsed を discriminator field で nominal 化 (Closes #497)

### DIFF
--- a/src/lib/__tests__/anchors.test.ts
+++ b/src/lib/__tests__/anchors.test.ts
@@ -1,11 +1,12 @@
 /**
  * 個人史座標エンジン (anchors.ts) のテスト
  *
- * 設計書: epic #487 / Issue #488
+ * 設計書: epic #487 / Issue #488 / Issue #497 (nominal 化)
  *
  * - publishedAt 推定 (ファイル名 → ISO 8601 JST 固定)
  * - 層1=座標 (computeCoordinates): 登録節目との差分日数
  * - 層2=経過 (computeElapsed): フォールバックの暦上経過日数
+ * - 型の nominal 化 (Coordinate / Elapsed の discriminator field `kind`)
  *
  * `meta.ts` には依存しない (death module 扱い、本 Issue の制約)
  */
@@ -137,6 +138,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
 
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual<Coordinate>({
+        kind: "coordinate",
         label: "社会復帰",
         tone: "neutral",
         daysSince: 9,
@@ -421,6 +423,7 @@ describe("computeElapsed: 層2=経過 (暦上の経過日数)", () => {
     );
 
     expect(result).toEqual<Elapsed>({
+      kind: "elapsed",
       label: "サイト開設",
       daysSince: 9,
     });
@@ -468,8 +471,9 @@ describe("computeElapsed: 層2=経過 (暦上の経過日数)", () => {
 });
 
 describe("型定義: status / tags / updatedAt を露出しない", () => {
-  it("Coordinate 型は label / tone / daysSince のみを公開し、メタ情報を持たない", () => {
+  it("Coordinate 型は kind / label / tone / daysSince のみを公開し、メタ情報を持たない", () => {
     const coordinate: Coordinate = {
+      kind: "coordinate",
       label: "ラベル",
       tone: "neutral",
       daysSince: 0,
@@ -477,17 +481,20 @@ describe("型定義: status / tags / updatedAt を露出しない", () => {
 
     // status / tags / updatedAt のキーは存在しない
     expect(Object.keys(coordinate).sort()).toEqual(
-      ["daysSince", "label", "tone"].sort(),
+      ["daysSince", "kind", "label", "tone"].sort(),
     );
   });
 
-  it("Elapsed 型は label / daysSince のみを公開し、tone も含まない", () => {
+  it("Elapsed 型は kind / label / daysSince のみを公開し、tone も含まない", () => {
     const elapsed: Elapsed = {
+      kind: "elapsed",
       label: "ラベル",
       daysSince: 0,
     };
 
-    expect(Object.keys(elapsed).sort()).toEqual(["daysSince", "label"].sort());
+    expect(Object.keys(elapsed).sort()).toEqual(
+      ["daysSince", "kind", "label"].sort(),
+    );
   });
 
   it("Milestone 型は date / label / tone のみを公開する", () => {
@@ -500,5 +507,118 @@ describe("型定義: status / tags / updatedAt を露出しない", () => {
     expect(Object.keys(milestone).sort()).toEqual(
       ["date", "label", "tone"].sort(),
     );
+  });
+});
+
+/**
+ * Issue #497: Coordinate と Elapsed の nominal 化
+ *
+ * `Coordinate` (label/tone/daysSince) は構造的に `Elapsed` (label/daysSince) を
+ * 包含するため、structural typing の TypeScript では「Coordinate を Elapsed
+ * として受けて tone を捨てる」サイレント縮退が起きうる。
+ *
+ * 対策として両型に discriminator field `kind` を持たせ、型レベルで両者を
+ * 不整合にしている。本テスト群はその不整合がコンパイル時に検出されることを
+ * `@ts-expect-error` で固定する。
+ *
+ * Vitest の `// @ts-expect-error` ディレクティブは型エラーが発生しなければ
+ * 「Unused @ts-expect-error directive」として `pnpm type-check` (tsc --noEmit)
+ * が失敗するため、回帰テストとして機能する。
+ *
+ * 実行時アサーションは行わない (型レベルでの検証が目的)。
+ */
+describe("型レベル: Coordinate / Elapsed の nominal 化 (Issue #497)", () => {
+  it("Coordinate を Elapsed に直接代入するとコンパイルエラーになる", () => {
+    const coordinate: Coordinate = {
+      kind: "coordinate",
+      label: "ラベル",
+      tone: "neutral",
+      daysSince: 0,
+    };
+
+    // @ts-expect-error - Coordinate (kind: "coordinate") を Elapsed (kind: "elapsed")
+    // に代入することは discriminator の不一致でコンパイル時に検出される
+    const elapsed: Elapsed = coordinate;
+
+    // void で参照することで「未使用変数」警告を回避しつつ、型エラーが
+    // 発生していることを保証する
+    void elapsed;
+  });
+
+  it("Elapsed を Coordinate に直接代入するとコンパイルエラーになる (tone 欠落 + kind 不一致)", () => {
+    const elapsed: Elapsed = {
+      kind: "elapsed",
+      label: "ラベル",
+      daysSince: 0,
+    };
+
+    // @ts-expect-error - Elapsed (kind: "elapsed", tone なし) を
+    // Coordinate (kind: "coordinate", tone あり) に代入することは
+    // discriminator 不一致と tone 欠落の両方でコンパイル時に検出される
+    const coordinate: Coordinate = elapsed;
+
+    void coordinate;
+  });
+
+  it("kind を持たないオブジェクトを Coordinate に代入するとコンパイルエラーになる (structural 包含の塞ぎ)", () => {
+    // @ts-expect-error - discriminator `kind` が欠落しているため Coordinate
+    // として代入できない (Issue #497 で導入した nominal 化の主目的)
+    const coordinate: Coordinate = {
+      label: "ラベル",
+      tone: "neutral",
+      daysSince: 0,
+    };
+
+    void coordinate;
+  });
+
+  it("kind を持たないオブジェクトを Elapsed に代入するとコンパイルエラーになる (structural 包含の塞ぎ)", () => {
+    // @ts-expect-error - discriminator `kind` が欠落しているため Elapsed
+    // として代入できない (Issue #497 で導入した nominal 化の主目的)
+    const elapsed: Elapsed = {
+      label: "ラベル",
+      daysSince: 0,
+    };
+
+    void elapsed;
+  });
+
+  it("computeCoordinates の戻り値要素は Coordinate として narrow でき、Elapsed には代入できない", () => {
+    const milestones: readonly Milestone[] = [
+      { date: "2025-01-01", label: "x", tone: "neutral" },
+    ];
+    const result = computeCoordinates("2025-01-10T12:00:00+09:00", milestones);
+    const first = result[0];
+
+    // discriminated union narrowing が効くことを確認
+    if (first.kind === "coordinate") {
+      // tone への安全なアクセス
+      expect(first.tone).toBe("neutral");
+    }
+
+    // @ts-expect-error - computeCoordinates の戻り値要素 (Coordinate) を
+    // Elapsed として受けるのは Issue #497 で禁止された
+    const elapsed: Elapsed = first;
+
+    void elapsed;
+  });
+
+  it("computeElapsed の戻り値は Elapsed として narrow でき、Coordinate には代入できない", () => {
+    const result = computeElapsed(
+      "2025-01-10T12:00:00+09:00",
+      "2025-01-01",
+      "x",
+    );
+
+    if (result.kind === "elapsed") {
+      // discriminator が "elapsed" であることを確認
+      expect(result.daysSince).toBe(9);
+    }
+
+    // @ts-expect-error - computeElapsed の戻り値 (Elapsed) を Coordinate
+    // として受けるのは Issue #497 で禁止された (tone 欠落 + kind 不一致)
+    const coordinate: Coordinate = result;
+
+    void coordinate;
   });
 });

--- a/src/lib/anchors.ts
+++ b/src/lib/anchors.ts
@@ -1,7 +1,7 @@
 /**
  * 個人史座標エンジン (Anchor 機能の土台)
  *
- * 設計書: epic #487 / Issue #488
+ * 設計書: epic #487 / Issue #488 / Issue #497 (nominal 化)
  *
  * - 純粋関数のみで構成し、モジュールスコープの可変状態を持たない
  * - publishedAt はファイル名 (`YYYYMMDDhhmmss.md`) から ISO 8601 (JST +09:00 固定)
@@ -10,6 +10,21 @@
  * - 「座標」(層1=computeCoordinates) と「経過」(層2=computeElapsed) を
  *   別関数・別型として命名区別する
  * - status / tags / updatedAt は本モジュールの出力に露出させない
+ *
+ * 型の nominal 化 (Issue #497):
+ * - `Coordinate` (label/tone/daysSince) は構造的に `Elapsed` (label/daysSince) を
+ *   包含する。TypeScript の structural typing で `Coordinate` を `Elapsed` として
+ *   誤って受けて `tone` を捨てるサイレント縮退が表示層 (#491) で起きうる
+ * - 対策として両型に **discriminator field `kind`** を持たせる
+ *   (`"coordinate"` / `"elapsed"`)。Coordinate を Elapsed に代入すると
+ *   `kind` の不一致でコンパイル時に検出され、サイレント縮退を防げる
+ * - branded type ではなく discriminator を採用した理由:
+ *   1. 表示層 (#491) で `switch (x.kind)` による discriminated union narrowing が
+ *      効くため、`tone` への安全なアクセスが書ける (branded type では不可能)
+ *   2. branded type は `as` キャストで突破可能だが、discriminator は実行時にも
+ *      検証可能で防御力が高い
+ *   3. `kind` の JSON シリアライズへの混入は本モジュールでは問題にならない
+ *      (`anchors.ts` の戻り値は内部表現で、外部 API としてシリアライズされない)
  */
 
 /**
@@ -39,8 +54,17 @@ export interface Milestone {
  *
  * 登録された節目 (Milestone) と publishedAt の差分日数を保持する。
  * 節目が登録されている限りで意味を持つ「座標」を名乗れる層。
+ *
+ * - `kind: "coordinate"` を **discriminator field** として実体に持つ
+ *   (Elapsed との混同 = `Coordinate` を構造的互換で `Elapsed` として
+ *   受けて `tone` を捨てるサイレント縮退をコンパイル時に検出するため)
+ * - 設計判断: branded type ではなく discriminator を採用した理由は
+ *   `anchors.ts` 冒頭の JSDoc または Issue #497 のコミットメッセージを参照
+ * - 表示層 (#491) は `switch (x.kind)` で TypeScript の
+ *   discriminated union narrowing を効かせて分岐することを想定している
  */
 export interface Coordinate {
+  readonly kind: "coordinate";
   readonly label: string;
   readonly tone: MilestoneTone;
   readonly daysSince: number;
@@ -51,8 +75,13 @@ export interface Coordinate {
  *
  * 節目が未登録または記事が全節目より前のときのフォールバック。
  * 「座標」ではなく「経過」と用語を厳密区別する。tone は持たない。
+ *
+ * - `kind: "elapsed"` を **discriminator field** として実体に持つ
+ *   (Coordinate との混同をコンパイル時に検出するため)
+ * - 設計判断の詳細は Coordinate の JSDoc を参照
  */
 export interface Elapsed {
+  readonly kind: "elapsed";
   readonly label: string;
   readonly daysSince: number;
 }
@@ -197,6 +226,7 @@ export const computeCoordinates = (
       continue;
     }
     coordinates.push({
+      kind: "coordinate",
       label: milestone.label,
       tone: milestone.tone,
       daysSince: days,
@@ -234,6 +264,7 @@ export const computeElapsed = (
   }
   const days = diffInDays(originDate, publishedDate);
   return {
+    kind: "elapsed",
     label,
     daysSince: days < 0 ? 0 : days,
   };


### PR DESCRIPTION
## 概要

N-1 (PR #498, Issue #488) で導入した `Coordinate` と `Elapsed` 型を discriminator field (`kind: "coordinate"` / `kind: "elapsed"`) で nominal 化します。Closes #497。

## 背景

`Coordinate = { label, tone, daysSince }` が `Elapsed = { label, daysSince }` を **structural typing で包含**するため、表示層（N-4 / #491）で `Coordinate` を `Elapsed` として誤って受け、`tone` を捨てるサイレント縮退が起きうる。N-4 着手前に決着させる。

## 採用案: discriminator field（案 2）

| 観点 | discriminator (採用) | branded type |
|---|---|---|
| narrowing | `switch(x.kind)` で安全に narrow | 不可 |
| `as` キャスト突破 | 困難 (ランタイムにフィールド) | 容易 |
| ランタイムコスト | 1 フィールド | ゼロ |
| JSON シリアライズへの混入 | 出る | 出ない |

判断理由:
1. 表示層 (#491) で discriminated union narrowing が使える → `switch(x.kind)` で `tone` への安全なアクセス
2. `as` キャストで突破されにくい (防御力が高い)
3. anchors.ts は内部表現で **外部にシリアライズされる経路が無い** (`grep` で確認)

## 変更内容

- `src/lib/anchors.ts` (+33 行): `Coordinate` に `readonly kind: "coordinate"`、`Elapsed` に `readonly kind: "elapsed"` を追加、`computeCoordinates` / `computeElapsed` で `kind` を構築。冒頭 JSDoc に nominal 化セクション追加
- `src/lib/__tests__/anchors.test.ts` (+130 行): 既存 `toEqual` / `Object.keys` テストを `kind` 追従、新規 describe「型レベル: Coordinate / Elapsed の nominal 化」に **6 件の @ts-expect-error 型レベルテスト**を追加

## 検証

- `pnpm test:run`: **693 tests pass** (44 files)
- `pnpm lint` / `pnpm type-check` / `pnpm type-check:test` / `pnpm build`: 全 pass
- **probe 検証**: @ts-expect-error を1つ外して `tsc --noEmit --project tsconfig.test.json` が `Type 'Coordinate' is not assignable to type 'Elapsed'. Types of property 'kind' are incompatible.` で fail することを確認 (回帰テストとして正しく機能)

## ローカルレビュー結果

- DA: 指摘なし、AC 達成、discriminator 採用は妥当
- Reviewer: 模範的、承認可（指摘なし、軽微な任意提案2点のみ）