### PR TITLE
chore: CLAUDE.md に Panda hash:true 運用判断ログを追記 (Closes #495)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,15 @@ Tripwire テスト用に吐く data-* 属性の命名は以下を指針とする
 
 > Issue #477 で、`data-token-*` を「Panda token 名のみを吐く」スキーマに統一し（CSS キーワード `inherit` 等は `data-color-inherit="true"` のような bool 属性へ分離）、`data-divider` を `data-token-border` へ統合する整理を進めている。確定後にこの規約へ反映する。
 
+#### Panda `hash:true` の運用判断（2026-05-15 時点）
+
+`panda.config.ts` の `hash:true` は**本番では無効（デフォルト）**で運用する。将来再評価する開発者向けの判断材料を残す。
+
+- **Tripwire テストは `hash:true` 耐性あり**: PR #474 で導入した `data-*` 属性方式により、`hash:true` を一時有効化しても Tripwire テスト 647 件は全 pass（Issue #475 にて master `d609ef0` で実機検証、2026-05-15）。Issue #422 の構造的耐性は実機で担保された
+- **bundle size はトレードオフ**: 生 CSS は `-25.6%` だが、hash 化で class 名のエントロピーが上がり gzip 圧縮率が低下するため、**gzip 後は `+5.8%`**。実環境は gzip 配信が標準なので、転送量で見るとほぼ等価
+- **手書き hook class（`index-row-*` / `copy-btn` 等）は Panda hash 化対象外**: `hash:true` を有効化しても影響を受けない
+- **再評価したい場合**: 別 Issue として切り出すこと。CI で `hash:true` 実機検証を回すための workflow_dispatch トリガーは Issue #496 で検討中
+
 ### 設定ファイル
 
 - TypeScript: 厳格モード、ES2020ターゲット、バンドラー解決


### PR DESCRIPTION
## 概要

Issue #475（panda.config.ts hash:true 実機検証）と PR #485（Tripwire テスト hash 耐性の移行漏れ修正）で得た運用知見を、プロジェクトの正本（CLAUDE.md）に記録します。Closes #495。

## 追記内容

CLAUDE.md「アーキテクチャ概要 > スタイリングパターン > data-* 属性命名規約」直下、「設定ファイル」の前に \`#### Panda hash:true の運用判断（2026-05-15 時点）\` を新設。9 行追記:

- **結論**: 本番では \`hash:true\` は無効で運用
- **根拠**: Tripwire 647 件全 pass（Issue #475、master \`d609ef0\`、2026-05-15 検証）/ bundle size 生 CSS -25.6% / gzip 後 +5.8% のトレードオフ / 手書き hook class は Panda hash 化対象外 / 再評価は別 Issue、CI workflow_dispatch は Issue #496 で検討中

## 検証

- 9 行挿入のみ、コード変更なし
- \`pnpm lint\` clean / \`pnpm test:run\` 687 pass / \`pnpm build\` 成功

## ローカルレビュー結果

- DA: 指摘 1 件（**Issue #496 と CLAUDE.md の同じ位置に追記、git 3-way merge でコンフリクト発生**。内容は重複なし）
- Reviewer: 承認可（HARD EXCLUSION ドキュメントのため security findings 0 件）

## マージ順序の推奨

本 PR (#495) を先にマージ → Issue #496 の PR (後続) は master を merge してコンフリクト解消するフロー。両者の追記内容は意味的に重複していない（#495=判断ログ、#496=操作手順）ため、順序解決のみで統合可能。