### PR TITLE
fix: computeSiteOpeningFallback テストの期待値を Elapsed.kind に追従させる (Closes #514)

### DIFF
--- a/scripts/__tests__/newPost.test.ts
+++ b/scripts/__tests__/newPost.test.ts
@@ -582,7 +582,7 @@ describe("computeSiteOpeningFallback: milestones.json 不在時のサイト開�
       tempDir,
       "2025-01-11T12:00:00+09:00",
     );
-    expect(result).toEqual({ label: "サイト開設", daysSince: 10 });
+    expect(result).toEqual({ kind: "elapsed", label: "サイト開設", daysSince: 10 });
   });
 });
 


### PR DESCRIPTION
## 概要

master (`86bf153`) の `pnpm test:run` で 1 件 red のまま放置されていた既存バグ ([Issue #514](https://github.com/amkkr/lazy-note/issues/514)) を最小修正で解消する。

PR #499 (`d6fe754 refactor: Anchor の Coordinate / Elapsed を discriminator field で nominal 化`, Closes #497) で `computeElapsed` の戻り値型が `{ label, daysSince }` → `Elapsed = { kind: "elapsed", label, daysSince }` に nominal 化された際、`scripts/__tests__/newPost.test.ts` の `computeSiteOpeningFallback > 最古記事日付からの経過日数を サイト開設 ラベルで返す` テストだけが期待値の更新を取りこぼしていた。

```
FAIL scripts/__tests__/newPost.test.ts:585
AssertionError: expected { kind: 'elapsed', …(2) } to deeply equal { label: 'サイト開設', daysSince: 10 }
```

連鎖影響: dependabot PR #503 / #505 / #506 / #508 / #509 の `test` job が本件で連鎖 red になっていたが、master 緑化により再 run で green に戻る前提が揃う。

Closes #514

## 変更内容

- `scripts/__tests__/newPost.test.ts:585`: テストの期待値オブジェクトに `kind: "elapsed"` を追加し、`Elapsed` の現行 shape に追従させた

## 備考

### スコープ外 (フォローアップ Issue #515)

`scripts/newPost.ts` 側にも nominal 化未追従の箇所が 2 つ残置している:

- `scripts/newPost.ts:284-287` `computeSiteOpeningFallback` の戻り値型注釈 `{ label: string; daysSince: number } | null` (実体は `computeElapsed` の戻り値で `Elapsed | null` 相当)
- `scripts/newPost.ts:64-67` 付近の `IgnitionInput.siteOpeningElapsed: { label: string; daysSince: number } | null`

両者は structural typing で型エラーが出ていないため放置されていた。CLAUDE.md「A bug fix doesn't need surrounding cleanup」「Don't add features...beyond what the task requires」原則に従い、本 PR では意図的にスコープ外として、[Issue #515](https://github.com/amkkr/lazy-note/issues/515) で別 PR として一括整合化する。

### t-wada 的 TDD 観点

- テスト名「最古記事日付からの経過日数を サイト開設 ラベルで返す」は CLAUDE.md「テストケース名のルール」(具体的な振る舞いを記述する) に準拠しているため変更しない
- 期待値が discriminator field `kind` を含むことで、将来 `Coordinate` への取り違えや `kind` 削除をテスト時に検出できる
- `toEqual` で十分 (構造的等価比較、`toStrictEqual` への変更は不要)
- コード内に経緯コメントは追加しない (CLAUDE.md「Don't reference the current task, fix, or callers」原則。経緯は commit message と本 PR description に集約)

### ローカル検証

worktree `/Users/amkkr/repos/lazy-note/.claude/worktrees/pensive-germain-7b8033` で実施済み:

- `pnpm test:run` — 47 files / **795 passed** (exit 0)
- `pnpm lint` — Biome `./src ./scripts` 112 files clean (exit 0)
- `pnpm type-check` — `tsc --noEmit` exit 0
- `pnpm type-check:test` — `tsc --noEmit --project tsconfig.test.json` exit 0

### レビュー

- 実装担当 (Opus, general-purpose) + devils-advocate (Opus, general-purpose) のチームを編成し、ローカルで合意形成
- 当初実装担当は `scripts/newPost.ts` の型注釈も同時修正する案を提示したが、devils-advocate の指摘 (CLAUDE.md 「Don't add ... beyond what the task requires」違反 / `IgnitionInput.siteOpeningElapsed` 取りこぼし発見) を採用して revert し、Issue #515 に分離
- `/review` および `/security-review` skill 双方で Approve 取得済み