### PR TITLE
chore: pnpm 11へ移行

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.4
         with:
-          version: 11.1.2
+          version: 11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.4
         with:
-          version: latest
+          version: 11.1.2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.4
         with:
-          version: 11.1.2
+          version: 11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.4
         with:
-          version: latest
+          version: 11.1.2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.4
         with:
-          version: 11.1.2
+          version: 11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.4
         with:
-          version: latest
+          version: 11.1.2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.4
         with:
-          version: 11.1.2
+          version: 11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.4
         with:
-          version: latest
+          version: 11.1.2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.4
         with:
-          version: 11.1.2
+          version: 11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.4
         with:
-          version: latest
+          version: 11.1.2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "lazy-note",
   "private": true,
   "version": "0.0.0",
-  "packageManager": "pnpm@11.1.2",
   "type": "module",
   "scripts": {
     "dev": "panda --watch & vite",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lazy-note",
   "private": true,
   "version": "0.0.0",
+  "packageManager": "pnpm@11.1.2",
   "type": "module",
   "scripts": {
     "dev": "panda --watch & vite",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,2 @@
-# pnpm 11+ では allowBuilds は pnpm-workspace.yaml に書く必要がある
-# (package.json の pnpm フィールドは pnpm 11 で読まれない)
-# https://pnpm.io/blog/releases/11.0
-onlyBuiltDependencies:
-  - esbuild
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
## 概要

pnpm 11 に合わせて build script 承認設定を整理し、CI / deploy で利用する pnpm を 11 系に固定します。

## 変更内容

- `pnpm-workspace.yaml` から pnpm 10 互換の `onlyBuiltDependencies` を削除し、`allowBuilds` を正本にしました
- GitHub Actions の `pnpm/action-setup` で `latest` ではなく `11` を使うようにしました
- Dependabot の通常更新対象ではない pnpm の exact version 固定を避けました

## 備考

検証:

- `pnpm install --frozen-lockfile`
- `pnpm prepare`
- `pnpm lint`
- `pnpm lint:tokens`
- `pnpm test:run`
- `pnpm type-check`
