### PR TITLE
refactor: scripts/newPost.ts の Anchor 型未追従箇所を Elapsed に統一 (Closes #515)

### DIFF
--- a/scripts/__tests__/newPost.test.ts
+++ b/scripts/__tests__/newPost.test.ts
@@ -143,7 +143,7 @@ describe("buildIgnitionComment: 火種 HTML コメントの構築", () => {
   it("siteOpeningElapsed (フォールバック) があるとサイト開設行を含む", () => {
     const result = buildIgnitionComment({
       coordinates: [],
-      siteOpeningElapsed: { label: "サイト開設", daysSince: 42 },
+      siteOpeningElapsed: { kind: "elapsed", label: "サイト開設", daysSince: 42 },
       previousPost: null,
       publishedAt: "2025-10-01T12:00:00+09:00",
     });

--- a/scripts/newPost.ts
+++ b/scripts/newPost.ts
@@ -37,6 +37,7 @@ import { basename, join } from "node:path";
 import {
   computeCoordinates,
   computeElapsed,
+  type Elapsed,
   inferPublishedAt,
   type Milestone,
 } from "../src/lib/anchors.ts";
@@ -63,7 +64,7 @@ export interface PreviousPost {
  */
 export interface IgnitionInput {
   readonly coordinates: readonly { label: string; tone: Milestone["tone"]; daysSince: number }[];
-  readonly siteOpeningElapsed: { label: string; daysSince: number } | null;
+  readonly siteOpeningElapsed: Elapsed | null;
   readonly previousPost: PreviousPost | null;
   readonly publishedAt: string;
 }
@@ -284,7 +285,7 @@ export const findPreviousPost = (
 export const computeSiteOpeningFallback = (
   datasourcesDir: string,
   publishedAt: string,
-): { label: string; daysSince: number } | null => {
+): Elapsed | null => {
   const files = listPostFileNames(datasourcesDir);
   if (files.length === 0) {
     return null;


### PR DESCRIPTION
## 概要

PR #499 で導入された `Elapsed` 型に未追従だった `scripts/newPost.ts` の 2 箇所を統一する。`computeSiteOpeningFallback` の戻り値型と `IgnitionInput.siteOpeningElapsed` を `Elapsed | null` に揃え、structural typing で受け流していた旧 shape のテストリテラルにも discriminator `kind: "elapsed"` を追記する。

Closes #515

## 変更内容

- `scripts/newPost.ts`: `import type { Elapsed }` を追加（Biome organizeImports による alphabetical 配置）。`computeSiteOpeningFallback` の戻り値型を `Elapsed | null` に変更し、`IgnitionInput.siteOpeningElapsed` も `Elapsed | null` に変更。これにより `Coordinate` を取り違えて `tone` フィールドを欠落させる構造的縮退をコンパイル時に検出可能にする
- `scripts/__tests__/newPost.test.ts`: `siteOpeningElapsed` リテラル箇所（line 146 付近）に `kind: "elapsed"` を追加し、新しい型シグネチャに整合させる

## 備考

- 本変更は型整合のみで外部から観測可能な振る舞いは変えないため、新規テストは追加せず既存 802 件の green 維持を回帰指標とした。型変更による既存テストの shape mismatch をコンパイラエラーとして観測する形を Red サイクルの代替としている
- `IgnitionInput.coordinates` 側にも同種の構造的縮退（`Coordinate` の `kind` discriminator が剥がれる）が残っているが、Issue #515 のスコープは A/B（`siteOpeningElapsed` 周り）に限定されていたため本 PR には含めない。フォローアップとして Issue #523 を起票済み
- Anchor 関連型（`Elapsed` / `Coordinate` / `Milestone`）を全ファイル grep し、本 PR 後に残る未追従は `IgnitionInput.coordinates`（#523）のみと確認
- ローカルで `pnpm test:run`（802 件全 pass）/ `pnpm lint` / `pnpm type-check` / `pnpm type-check:test` 全 pass を確認