### PR TITLE
chore: Panda hash:true regression check workflow を追加 (Closes #496)

### DIFF
--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -1,0 +1,75 @@
+name: Panda hash:true regression check
+
+# Issue #496 / Issue #475 の検証で、Tripwire テスト 647 件は `hash: true`
+# 有効化でも全 pass することが確認済み。ただし bundle size のメリットは
+# 小さい (gzip 後 +5.8%) ため本番は `hash: false` (デフォルト) で運用し、
+# regression 検知のため手動 (workflow_dispatch) でのみ実行する。
+#
+# このworkflowは既存 CI に影響を与えないよう push / pull_request トリガーは
+# 持たず、workflow_dispatch のみで起動する。panda.config.ts の書き換えは
+# CI の working tree 上のみで行い、リポジトリには commit / push しない。
+
+on:
+  workflow_dispatch:
+
+jobs:
+  hash-regression:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.5
+        with:
+          version: 11
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Enable Panda hash:true (temporary in-CI patch)
+        # panda.config.ts の defineConfig 内 `preflight: true,` 直下に
+        # `hash: true,` を 1 行挿入する。リポジトリへは push しない CI 内
+        # 一時パッチ。挿入後に grep で実在を確認し、未挿入なら即 fail する。
+        run: |
+          set -euo pipefail
+          if grep -qE '^\s*hash:\s*true' panda.config.ts; then
+            echo "panda.config.ts already has hash:true; skip patch."
+          else
+            sed -i 's/^\(\s*\)preflight: true,$/\1preflight: true,\n\1hash: true,/' panda.config.ts
+          fi
+          if ! grep -qE '^\s*hash:\s*true' panda.config.ts; then
+            echo "::error::panda.config.ts への hash:true 挿入に失敗しました。preflight: true, の行が想定どおり存在するか確認してください。"
+            exit 1
+          fi
+          echo "--- panda.config.ts (patched head) ---"
+          sed -n '20,35p' panda.config.ts
+
+      - name: Regenerate Panda CSS with hash:true
+        run: pnpm prepare
+
+      - name: Run tests with hash:true
+        id: tests
+        run: pnpm test:run
+
+      - name: Report test regression
+        if: failure() && steps.tests.conclusion == 'failure'
+        run: |
+          echo "::error::Tripwire テストの hash 耐性に regression があります。data-* 属性が hash 化に追従していない可能性があります。詳細は Issue #496 / Issue #475 / CLAUDE.md の `Panda hash:true の運用判断` を参照してください。"
+          exit 1
+
+      - name: Build project with hash:true
+        id: build
+        run: pnpm build
+
+      - name: Report build regression
+        if: failure() && steps.build.conclusion == 'failure'
+        run: |
+          echo "::error::hash:true でビルドが失敗しました。Panda 生成物または hook class との整合に regression があります。"
+          exit 1

--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -12,6 +12,10 @@ name: Panda hash:true regression check
 on:
   workflow_dispatch:
 
+# 本 workflow は repo を読むだけで write は不要。明示的に最小権限へ縛る。
+permissions:
+  contents: read
+
 jobs:
   hash-regression:
     runs-on: ubuntu-latest

--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -43,12 +43,14 @@ jobs:
         # 一時パッチ。挿入後に grep で実在を確認し、未挿入なら即 fail する。
         run: |
           set -euo pipefail
-          if grep -qE '^\s*hash:\s*true' panda.config.ts; then
+          # 末尾カンマまで含めて厳格に判定する。`hash: true` 単独行のような
+          # 部分一致 / 別箇所での hash: true 出現を誤検知しないようにする。
+          if grep -qE '^\s*hash:\s*true,' panda.config.ts; then
             echo "panda.config.ts already has hash:true; skip patch."
           else
             sed -i 's/^\(\s*\)preflight: true,$/\1preflight: true,\n\1hash: true,/' panda.config.ts
           fi
-          if ! grep -qE '^\s*hash:\s*true' panda.config.ts; then
+          if ! grep -qE '^\s*hash:\s*true,' panda.config.ts; then
             echo "::error::panda.config.ts への hash:true 挿入に失敗しました。preflight: true, の行が想定どおり存在するか確認してください。"
             exit 1
           fi

--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -56,20 +56,34 @@ jobs:
 
       - name: Run tests with hash:true
         id: tests
+        # continue-on-error を付与しないと test 失敗時に job が abort され、
+        # 後続の Report ステップ (アノテーション出力) に到達しない。
+        continue-on-error: true
         run: pnpm test:run
 
       - name: Report test regression
-        if: failure() && steps.tests.conclusion == 'failure'
+        # outcome は continue-on-error 適用前のステップ結果。conclusion は
+        # continue-on-error 適用後 (success 扱い) になるため outcome を使う。
+        if: steps.tests.outcome == 'failure'
         run: |
           echo "::error::Tripwire テストの hash 耐性に regression があります。data-* 属性が hash 化に追従していない可能性があります。詳細は Issue #496 / Issue #475 / CLAUDE.md の `Panda hash:true の運用判断` を参照してください。"
           exit 1
 
       - name: Build project with hash:true
         id: build
-        run: pnpm build
+        # test が失敗した場合は build を走らせない。test 通過時のみ build を
+        # 走らせて build regression を切り分ける。
+        if: steps.tests.outcome == 'success'
+        continue-on-error: true
+        # pnpm build は内部で `pnpm run lint && pnpm run test:run && pnpm run
+        # type-check && panda && tsc && vite build` を呼ぶため、上の test step
+        # と二重実行になる。さらに build 内 test 失敗が build regression として
+        # 通知されると原因切り分けが崩れるため、ここでは pnpm exec で生成 /
+        # 型チェック / バンドルだけを 1 回ずつ実行する。
+        run: pnpm exec panda && pnpm exec tsc && pnpm exec vite build
 
       - name: Report build regression
-        if: failure() && steps.build.conclusion == 'failure'
+        if: steps.tests.outcome == 'success' && steps.build.outcome == 'failure'
         run: |
-          echo "::error::hash:true でビルドが失敗しました。Panda 生成物または hook class との整合に regression があります。"
+          echo "::error::hash:true でビルドが失敗しました。Panda 生成物または hook class との整合に regression があります。hash 化された class 名と手書き hook class (index-row-*/copy-btn 等) の衝突可能性も確認してください。"
           exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Tripwire テスト用に吐く data-* 属性の命名は以下を指針とする
 - **Tripwire テストは `hash:true` 耐性あり**: PR #474 で導入した `data-*` 属性方式により、`hash:true` を一時有効化しても Tripwire テスト 647 件は全 pass（Issue #475 にて master `d609ef0` で実機検証、2026-05-15）。Issue #422 の構造的耐性は実機で担保された
 - **bundle size はトレードオフ**: 生 CSS は `-25.6%` だが、hash 化で class 名のエントロピーが上がり gzip 圧縮率が低下するため、**gzip 後は `+5.8%`**。実環境は gzip 配信が標準なので、転送量で見るとほぼ等価
 - **手書き hook class（`index-row-*` / `copy-btn` 等）は Panda hash 化対象外**: `hash:true` を有効化しても影響を受けない
-- **再評価したい場合**: 別 Issue として切り出すこと。CI で `hash:true` 実機検証を回すための workflow_dispatch トリガーは Issue #496 で検討中
+- **再評価したい場合**: 別 Issue として切り出すこと。CI で `hash:true` 実機検証を回すための workflow_dispatch トリガー (`.github/workflows/panda-hash-regression.yml`) は Issue #496 で追加済み。GitHub Actions の "Panda hash:true regression check" workflow から手動 (workflow_dispatch) で実行できる (test:run と build を `hash: true` で 1 回回し、Tripwire 耐性の regression を検知する)
 
 ### 設定ファイル
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,10 @@ Tripwire テスト用に吐く data-* 属性の命名は以下を指針とする
 - **Tripwire テストは `hash:true` 耐性あり**: PR #474 で導入した `data-*` 属性方式により、`hash:true` を一時有効化しても Tripwire テスト 647 件は全 pass（Issue #475 にて master `d609ef0` で実機検証、2026-05-15）。Issue #422 の構造的耐性は実機で担保された
 - **bundle size はトレードオフ**: 生 CSS は `-25.6%` だが、hash 化で class 名のエントロピーが上がり gzip 圧縮率が低下するため、**gzip 後は `+5.8%`**。実環境は gzip 配信が標準なので、転送量で見るとほぼ等価
 - **手書き hook class（`index-row-*` / `copy-btn` 等）は Panda hash 化対象外**: `hash:true` を有効化しても影響を受けない
-- **再評価したい場合**: 別 Issue として切り出すこと。CI で `hash:true` 実機検証を回すための workflow_dispatch トリガー (`.github/workflows/panda-hash-regression.yml`) は Issue #496 で追加済み。GitHub Actions の "Panda hash:true regression check" workflow から手動 (workflow_dispatch) で実行できる (test:run と build を `hash: true` で 1 回回し、Tripwire 耐性の regression を検知する)
+- **再評価したい場合**: 別 Issue として切り出すこと
+  - CI で `hash:true` 実機検証を回すための workflow は `.github/workflows/panda-hash-regression.yml`（Issue #496 で追加済み）
+  - GitHub Actions の "Panda hash:true regression check" workflow から手動 (workflow_dispatch) で実行できる
+  - 実行内容: `pnpm test:run` と `panda + tsc + vite build` を `hash: true` で 1 回ずつ実行し、Tripwire 耐性の regression を検知する
 
 ### 設定ファイル
 


### PR DESCRIPTION
## 概要

CLAUDE.md L70-79「Panda `hash:true` の運用判断（2026-05-15 時点）」の AC「CI で 1 回 `hash:true` で実行可能な workflow_dispatch トリガーを検討（任意）」を実装する。Tripwire テスト 647 件は `hash:true` 耐性ありが Issue #475 で実証済みだが、手動検証コストを下げ regression 検知を CI 側に押し付けるため、`workflow_dispatch` のみで起動する 検証用 workflow を追加する。

Closes #496

## 変更内容

- `.github/workflows/panda-hash-regression.yml`: 新規追加。`workflow_dispatch` のみで起動し、panda.config.ts に `preflight: true,` 直下へ `hash: true,` を sed で挿入後、`pnpm prepare` → `pnpm test:run` → `pnpm exec panda && pnpm exec tsc && pnpm exec vite build` を順次実行。tests/build 双方で `continue-on-error: true` を付与し、`steps.<id>.outcome == 'failure'` 判定で Report ステップが必ず到達するよう設計。各 Report で `exit 1` を発行して job 全体を失敗扱いにする。workflow level に `permissions: contents: read` を明示し、最小権限で動作させる
- `CLAUDE.md`: L70-79「Panda hash:true の運用判断」セクションの「再評価したい場合」項を、workflow の場所・手動実行手段・実行内容の 3 子 bullet 構成に分割。workflow 名と実行内容（`pnpm test:run` と `panda + tsc + vite build` を 1 回ずつ実行）を実態に合わせて記載

## 備考

- 既存 CI workflow（ci/test/a11y/playwright/deploy/reviewdog）には一切影響を与えない（push / pull_request トリガーを意図的に持たない）
- `pnpm build` 内で `pnpm test:run` が二重実行される問題を避けるため、workflow の build step は `pnpm exec panda && pnpm exec tsc && pnpm exec vite build` を直接呼び出す。これにより build step での失敗が純粋な build 失敗（Panda 生成物 / hook class 整合の regression）のみを表すよう責務分離している
- ローカル実機検証で panda.config.ts → hash:true 挿入 → `pnpm test:run` 802 件 pass → `pnpm exec panda && pnpm exec tsc && pnpm exec vite build` 成功を確認済み（panda.config.ts はバックアップから復元、リポジトリには変更を残さない）
- フォローアップ事項（別 Issue で対応）:
  - #525 bundle size 数値レポート追加
  - #526 schedule トリガー検討（手動のみだと腐るリスクへの対応）
  - #527 sed パッチを trailing comma 変化に耐性化
  - #528 workflow build と package.json build の drift 検出機構
  - #529 yamllint 導入時の長行分割