### PR TITLE
chore: panda-hash-regression workflow に bundle size 数値レポートを追加

### DIFF
--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -93,3 +93,26 @@ jobs:
         run: |
           echo "::error::hash:true でビルドが失敗しました。Panda 生成物または hook class との整合に regression があります。hash 化された class 名と手書き hook class (index-row-*/copy-btn 等) の衝突可能性も確認してください。"
           exit 1
+
+      - name: Report bundle size (raw / gzip)
+        # CLAUDE.md L75 の「gzip 後 +5.8%」トレードオフを CI 上で追跡可能に
+        # する。本 step は GITHUB_STEP_SUMMARY に Markdown 表として書き出す
+        # のみで、pass/fail 判定には影響しない。閾値での自動 fail は導入せず、
+        # 数値の経時変化は手動 (workflow_dispatch) 実行時に Actions UI 上の
+        # Summary から目視で確認する運用とする。
+        # build が成功した時のみ実行する。test / build いずれかが失敗した
+        # 場合は dist/assets が信頼できないため report をスキップする。
+        if: steps.tests.outcome == 'success' && steps.build.outcome == 'success'
+        run: |
+          set -euo pipefail
+          {
+            echo "## hash:true bundle size";
+            echo "";
+            echo "| File | raw (B) | gzip (B) |";
+            echo "|------|---------|----------|";
+            for f in dist/assets/*.css; do
+              raw=$(stat -c '%s' "$f")
+              gz=$(gzip -c "$f" | wc -c)
+              echo "| \`${f}\` | ${raw} | ${gz} |";
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -105,12 +105,29 @@ jobs:
         if: steps.tests.outcome == 'success' && steps.build.outcome == 'success'
         run: |
           set -euo pipefail
+          # 空 glob ガード: `set -euo pipefail` 下で `for f in dist/assets/*.css`
+          # を直接書くと、CSS が 1 件も emit されないケースで glob がリテラル
+          # 文字列 `dist/assets/*.css` のまま 1 回ループし、`stat` が非 0 で
+          # 終了して job 自体が fail する。これは「pass/fail 判定に影響しない」
+          # という本 step の前提に反するため、nullglob で空配列に展開して
+          # スキップする。
+          shopt -s nullglob
+          files=(dist/assets/*.css)
+          shopt -u nullglob
+          if (( ${#files[@]} == 0 )); then
+            {
+              echo "## hash:true bundle size";
+              echo "";
+              echo "_(no CSS assets emitted under dist/assets/*.css)_";
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           {
             echo "## hash:true bundle size";
             echo "";
             echo "| File | raw (B) | gzip (B) |";
             echo "|------|---------|----------|";
-            for f in dist/assets/*.css; do
+            for f in "${files[@]}"; do
               raw=$(stat -c '%s' "$f")
               gz=$(gzip -c "$f" | wc -c)
               echo "| \`${f}\` | ${raw} | ${gz} |";


### PR DESCRIPTION
## 概要

`.github/workflows/panda-hash-regression.yml` の build 後に、`dist/assets/*.css` の raw / gzip サイズを集計し `GITHUB_STEP_SUMMARY` に Markdown 表形式で出力する step を追加する。CLAUDE.md L75 で「gzip 後 +5.8%」が主たるトレードオフとして明記されている一方、現状の workflow は pass/fail しか吐かず数値が残らないため、手動実行時に Actions UI から数値が読めるよう改善する。

Closes #525

## 変更内容

- `.github/workflows/panda-hash-regression.yml`:
  - "Report bundle size (raw / gzip)" step を追加。test/build 両方成功時のみ走り (`if:` ガード)、既存 pass/fail 判定に影響しない
  - `shopt -s nullglob` + 配列展開で空 glob ガードを実装。CSS が 0 件の場合は note を Summary に書き出して `exit 0` し、`stat` 非 0 終了による job fail を予防 (レビュワー / DA 共通指摘の予防修正)

## 備考

- 閾値での自動 fail は本 Issue では扱わない (判断者に委ねる、Issue 本文明記)
- 出力は単一ファイル想定で `| File | raw (B) | gzip (B) |` の表形式
- ローカル検証: `pnpm build` で `dist/assets/index-0v2u3ICT.css 33,913B / gzip 8,205B` 生成を確認、空 glob ケースも nullglob 経由で `exit 0` を実機検証済
- フォローアップ候補 (本 PR スコープ外): baseline (hash:false) との対比、JS bundle 含む、cron トリガー (#526 と関連) など → 別途 Issue 化

## チェック

- [x] `pnpm test:run` 全 pass (51 files / 891 tests)
- [x] `pnpm lint` 全 pass
- [x] `pnpm build` 成功
- [x] YAML 構文 valid (Python yaml.safe_load で確認)