### PR TITLE
refactor: Coordinate.tsx で computeCoordinates の戻り値に discriminator narrowing を効かせる

### DIFF
--- a/src/components/common/Coordinate.tsx
+++ b/src/components/common/Coordinate.tsx
@@ -129,8 +129,28 @@ export const Coordinate = memo(
 
     // 過去の節目に絞った座標 (computeCoordinates が未来は除外する)
     const coordinates = computeCoordinates(publishedAt, milestones);
-    // tone: "heavy" は Coordinate に表示しない (重い節目は静かに隠す)
-    const displayable = coordinates.filter((c) => c.tone !== "heavy");
+    // tone: "heavy" は Coordinate に表示しない (重い節目は静かに隠す)。
+    //
+    // Issue #497 で `Coordinate` 型に discriminator field `kind: "coordinate"`
+    // を導入した狙いは、表示層 (#491 / 本ファイル) で `switch (x.kind)` /
+    // 型ガードによる discriminated union narrowing を効かせ、`tone` への
+    // アクセスをサイレント縮退から守ることだった。
+    //
+    // 現状 `computeCoordinates` の戻り値は `readonly Coordinate[]` で
+    // `kind === "coordinate"` に確定しているため `kind` の判定は冗長に見えるが、
+    // ここで discriminator を明示的に検査することで:
+    //   1. discriminator を表示層で本当に使う実装になり、#497 の意図が完成する
+    //   2. 将来 `computeCoordinates` の戻り値が `Coordinate | Elapsed` のような
+    //      mixed union に拡張されても、本フィルタが Coordinate のみを安全に
+    //      narrowing して `tone` を参照する形になっている (Elapsed には tone が
+    //      存在せず、現状のまま `c.tone` を触ると型エラーで早期検出される)
+    //
+    // → discriminator 由来の防御を表示層側で発火させるため、`kind` の判定を
+    //    型ガードとして残す。Issue #531 / DA Round 1 推奨。
+    const displayable = coordinates.filter(
+      (c): c is CoordinateData =>
+        c.kind === "coordinate" && c.tone !== "heavy",
+    );
 
     if (displayable.length === 0) {
       return null;

--- a/src/components/common/Coordinate.tsx
+++ b/src/components/common/Coordinate.tsx
@@ -129,24 +129,10 @@ export const Coordinate = memo(
 
     // 過去の節目に絞った座標 (computeCoordinates が未来は除外する)
     const coordinates = computeCoordinates(publishedAt, milestones);
-    // tone: "heavy" は Coordinate に表示しない (重い節目は静かに隠す)。
-    //
-    // Issue #497 で `Coordinate` 型に discriminator field `kind: "coordinate"`
-    // を導入した狙いは、表示層 (#491 / 本ファイル) で `switch (x.kind)` /
-    // 型ガードによる discriminated union narrowing を効かせ、`tone` への
-    // アクセスをサイレント縮退から守ることだった。
-    //
-    // 現状 `computeCoordinates` の戻り値は `readonly Coordinate[]` で
-    // `kind === "coordinate"` に確定しているため `kind` の判定は冗長に見えるが、
-    // ここで discriminator を明示的に検査することで:
-    //   1. discriminator を表示層で本当に使う実装になり、#497 の意図が完成する
-    //   2. 将来 `computeCoordinates` の戻り値が `Coordinate | Elapsed` のような
-    //      mixed union に拡張されても、本フィルタが Coordinate のみを安全に
-    //      narrowing して `tone` を参照する形になっている (Elapsed には tone が
-    //      存在せず、現状のまま `c.tone` を触ると型エラーで早期検出される)
-    //
-    // → discriminator 由来の防御を表示層側で発火させるため、`kind` の判定を
-    //    型ガードとして残す。Issue #531 / DA Round 1 推奨。
+    // `heavy` を除外して表示候補に絞る。
+    // `Coordinate` は現状単型のため `kind` 判定は型レベルで tautology だが、
+    // 将来 `Coordinate | Elapsed` mixed union に拡張された際の narrowing 防御として
+    // 型ガード形式を採用する (Issue #497 の discriminator 設計意図に対応)。
     const displayable = coordinates.filter(
       (c): c is CoordinateData =>
         c.kind === "coordinate" && c.tone !== "heavy",


### PR DESCRIPTION
## 概要

Issue #491 PR の DA レビューで新規指摘された設計整合事項。`anchors.ts` の `Coordinate` 型は Issue #497 で `kind: "coordinate"` discriminator を導入したが、本実装 `Coordinate.tsx` の filter は `coordinates.filter((c) => c.tone !== "heavy")` で tone のみを参照し `kind` を一切利用していなかった。

Closes #531

## 変更内容

- `src/components/common/Coordinate.tsx`:
  - filter を `(c): c is CoordinateData => c.kind === "coordinate" && c.tone !== "heavy"` の型ガード形式に書き換え
  - 短い JSDoc コメント (4 行) で「現状単型のため `kind` 判定は型レベル tautology だが、`Coordinate | Elapsed` mixed union 拡張時の narrowing 防御として残す」旨を明記 (Issue #497 設計意図に対応)

## 設計判断

- 採用案: **案 A (型ガード)** + 短い JSDoc
- 案 B (JSDoc コメントのみ) ではなく型ガードを採用した理由: 将来 `Coordinate | Elapsed` mixed union 化があった際に表示層側でサイレント縮退を防ぐ
- 現時点では `computeCoordinates` の戻り値が `readonly Coordinate[]` 単型のため型述語は redundant (tautology) だが、JSDoc で「将来防御」目的であることを明記

## 備考

- DA レビューで「JSDoc 過剰」「型述語が現状 redundant」等の指摘あり、JSDoc を 17 行 → 4 行に圧縮
- フォローアップ候補 (本 PR スコープ外、別 Issue 化検討):
  - 表示層に narrowing ヘルパ (`onlyCoordinates`) を `anchors.ts` 側に抽出する案
  - `kind !== "coordinate"` 要素の除外を担保するテスト (現状は型システム上不可能)

## チェック

- [x] `pnpm test:run` 全 pass (51 files / 891 tests)
- [x] `pnpm lint` 全 pass
- [x] `pnpm build` 全 pass