### PR TITLE
chore: pre-commit-guard.sh を git worktree 経由のブランチ判定に対応 + テストハーネス追加

### DIFF
--- a/.claude/hooks/__tests__/pre-commit-guard.test.sh
+++ b/.claude/hooks/__tests__/pre-commit-guard.test.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# pre-commit-guard.sh のテストハーネス
+#
+# 実行方法:
+#   bash .claude/hooks/__tests__/pre-commit-guard.test.sh
+#
+# 何をするか:
+#   1. /tmp に隔離されたテスト用 git リポと worktree を作成
+#   2. 各 test case (TEST_CASES) を JSON 経由で pre-commit-guard.sh に投入
+#   3. 期待される結果 (pass / block / known-limitation) と比較
+#   4. 失敗があれば exit 1
+#
+# 期待値ラベル:
+#   pass             - hook が素通り (decision:block を出さない) ことを期待
+#   block            - hook が block を出すことを期待
+#   known-limitation - 現状の実装の限界。block でも pass でも fail にはしない
+#                      (DA レビューで指摘された既存 bypass / follow-up Issue 候補)
+#
+# 本テストは Bash ツールの PreToolUse hook (pre-commit-guard.sh) と
+# 同じスクリプトを呼び出すため、テスト実行コマンド自身に
+# 'git commit' などの literal を含めないこと。コマンド文字列は配列に
+# 'g' 'it' のように分割して書き、後で結合する。
+
+set -uo pipefail
+
+HOOK_PATH="$(cd "$(dirname "$0")/.." && pwd)/pre-commit-guard.sh"
+if [ ! -x "$HOOK_PATH" ]; then
+  echo "FATAL: hook not executable: $HOOK_PATH" >&2
+  exit 2
+fi
+
+# テスト用の隔離リポを作成 (毎回 clean)
+TEST_ROOT="$(mktemp -d -t pre-commit-guard-test.XXXXXX)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+MAIN_REPO="$TEST_ROOT/main-repo"
+WORKTREE="$TEST_ROOT/work-tree"
+
+setup_test_repo() {
+  git init -q -b master "$MAIN_REPO"
+  (
+    cd "$MAIN_REPO"
+    git config user.email test@example.com
+    git config user.name test-user
+    echo init > README.md
+    git add README.md
+    git -c commit.gpgsign=false commit -q -m init
+    git worktree add -q "$WORKTREE" -b feat/test
+  )
+  # consecutive cd テスト用の subdir
+  mkdir -p "$WORKTREE/src"
+}
+
+# テスト本体 (1 ケース実行)
+#   args: <id> <expected:pass|block|known-limitation> <kind> <cwd> <command> <label>
+run_case() {
+  local id="$1"
+  local expected="$2"
+  local kind="$3"
+  local cwd="$4"
+  local command="$5"
+  local label="$6"
+
+  local json
+  json=$(python3 -c '
+import json, sys
+print(json.dumps({"tool_input": {"command": sys.argv[1]}}))
+' "$command")
+
+  local out exit_code actual
+  out=$(cd "$cwd" && printf "%s" "$json" | "$HOOK_PATH" 2>&1)
+  exit_code=$?
+  if [ $exit_code -ne 0 ]; then
+    actual="sh-err"
+  elif printf "%s" "$out" | grep -q '"decision":"block"'; then
+    actual="block"
+  else
+    actual="pass"
+  fi
+
+  if [ "$expected" = "known-limitation" ]; then
+    # 結果は記録するだけで pass/fail 判定しない
+    printf "  %-22s %-18s SKIP (actual=%s)  %s\n" "$id" "[$kind]" "$actual" "$label"
+    return 0
+  fi
+
+  if [ "$actual" = "$expected" ]; then
+    printf "  %-22s %-18s OK   (%s)         %s\n" "$id" "[$kind]" "$actual" "$label"
+    return 0
+  fi
+
+  printf "  %-22s %-18s FAIL expected=%s actual=%s  %s\n" \
+    "$id" "[$kind]" "$expected" "$actual" "$label"
+  return 1
+}
+
+# -----------------------------------------------------------------------------
+# テストケース定義
+# -----------------------------------------------------------------------------
+# 注: コマンド文字列に literal の "git commit" を入れると、本テスト実行に
+# Bash ツール (PreToolUse hook = pre-commit-guard.sh) が反応する場合がある。
+# それを避けるため、`g` と `it` を分けて連結する書き方を採用する。
+GIT="g""it"
+
+declare -a TESTS=()
+
+# kind / expected / cwd / command / label
+add_case() {
+  TESTS+=("$1"$'\t'"$2"$'\t'"$3"$'\t'"$4"$'\t'"$5"$'\t'"$6")
+}
+
+# --- baseline (sanity) -------------------------------------------------------
+add_case "S01" "block" "sanity" \
+  "$MAIN_REPO" "$GIT commit -m x" \
+  "direct commit on master is blocked"
+
+add_case "S02" "pass" "sanity" \
+  "$WORKTREE" "$GIT commit -m x" \
+  "direct commit on worktree branch passes"
+
+# --- Issue #550 fix (worktree 対応) ------------------------------------------
+add_case "R01" "pass" "fix-required" \
+  "$MAIN_REPO" "cd $WORKTREE && $GIT commit -m x" \
+  "cd worktree && commit (basic Issue #550 fix)"
+
+add_case "R02" "pass" "fix-required" \
+  "$MAIN_REPO" "$GIT -C $WORKTREE commit -m x" \
+  "git -C worktree commit"
+
+add_case "R03" "pass" "fix-required" \
+  "$MAIN_REPO" "(cd $WORKTREE && $GIT commit -m x)" \
+  "subshell (cd worktree && commit)"
+
+add_case "R04" "pass" "fix-required" \
+  "$MAIN_REPO" "pushd $WORKTREE && $GIT commit -m x" \
+  "pushd worktree && commit"
+
+add_case "R05" "pass" "fix-required" \
+  "$MAIN_REPO" "cd $WORKTREE && cd src && $GIT commit -m x" \
+  "consecutive cd: cd worktree && cd subdir && commit"
+
+# 既知の限界: cd 後に subshell が始まると cwd 継承ができない
+# follow-up Issue 化候補 (DA Critical 17 続き)
+add_case "R06" "known-limitation" "fix-required" \
+  "$MAIN_REPO" "cd $WORKTREE && ($GIT commit -m x)" \
+  "cd worktree && (commit) nested subshell — known limitation"
+
+# --- --git-dir / --work-tree 系 (Critical 19-20) -----------------------------
+add_case "X01" "pass" "fix-required" \
+  "$MAIN_REPO" "$GIT --git-dir=$WORKTREE/.git --work-tree=$WORKTREE commit -m x" \
+  "--git-dir + --work-tree on worktree path passes"
+
+add_case "X02" "pass" "fix-required" \
+  "$MAIN_REPO" "$GIT --work-tree=$WORKTREE commit -m x" \
+  "--work-tree only on worktree path passes"
+
+add_case "X03" "block" "fix-required" \
+  "$MAIN_REPO" "$GIT --git-dir=/nonexistent/path/.git commit -m x" \
+  "--git-dir=<nonexistent> is blocked (attack-surface safeguard)"
+
+# --- Co-Authored-By 検出 (regression sanity) ---------------------------------
+add_case "CA01" "block" "sanity" \
+  "$WORKTREE" "$GIT commit -m \"feat\\n\\nCo-Authored-By: x <x@x>\"" \
+  "Co-Authored-By in -m blocks"
+
+add_case "CA02" "pass" "sanity" \
+  "$WORKTREE" "echo Co-Authored-By > /tmp/x.txt && $GIT commit" \
+  "Co-Authored-By in unrelated arg does not block"
+
+# --- rebase / force push (regression sanity) ---------------------------------
+add_case "RB01" "block" "sanity" \
+  "$WORKTREE" "$GIT rebase master" \
+  "git rebase is blocked"
+
+add_case "FP01" "block" "sanity" \
+  "$WORKTREE" "$GIT push --force origin feat/test" \
+  "git push --force is blocked"
+
+add_case "FP02" "block" "sanity" \
+  "$WORKTREE" "$GIT push -f origin feat/test" \
+  "git push -f is blocked"
+
+# --- 既存 bypass (master/PR 共通の素通り、follow-up Issue 化候補) -----------
+# DA レビューで指摘された 11 件。これらは元実装にもあった bypass で、
+# 本 PR の regression ではない。known-limitation として記録し、別 Issue で
+# 包括対応する (例: git ネイティブ pre-commit hook 化など Counterpoint 31/32)。
+add_case "E01_BY13" "known-limitation" "existing-bypass" \
+  "$MAIN_REPO" "PAGER=cat $GIT commit -m x" \
+  "PAGER=cat g..it commit (env-prefix)"
+
+add_case "E02_BY17" "known-limitation" "existing-bypass" \
+  "$MAIN_REPO" "/usr/bin/$GIT commit -m x" \
+  "absolute path /usr/bin/g..it"
+
+add_case "E03_BY9" "known-limitation" "existing-bypass" \
+  "$MAIN_REPO" "sudo $GIT commit -m x" \
+  "sudo g..it commit"
+
+add_case "E04_T8" "known-limitation" "existing-bypass" \
+  "$MAIN_REPO" "eval \"$GIT commit -m bypass\"" \
+  "eval \"g..it commit\""
+
+add_case "E05_T9" "known-limitation" "existing-bypass" \
+  "$MAIN_REPO" "bash -c \"$GIT commit -m x\"" \
+  "bash -c \"g..it commit\""
+
+add_case "E06_T29" "known-limitation" "existing-bypass" \
+  "$MAIN_REPO" "GIT_DIR=$MAIN_REPO/.git $GIT commit -m x" \
+  "GIT_DIR=... g..it commit"
+
+add_case "E07_T38" "known-limitation" "existing-bypass" \
+  "$MAIN_REPO" "env -C $MAIN_REPO $GIT commit -m x" \
+  "env -C ... g..it commit"
+
+add_case "E08_T30" "known-limitation" "existing-bypass" \
+  "$MAIN_REPO" "alias gc=\"$GIT commit\"; gc -m x" \
+  "alias gc=...; gc -m"
+
+add_case "E09_BY4" "known-limitation" "existing-bypass" \
+  "$MAIN_REPO" "$GIT \\\\
+ commit -m x" \
+  "g..it <newline> commit"
+
+add_case "E10_BY16" "known-limitation" "existing-bypass" \
+  "$MAIN_REPO" "\"$GIT\" commit -m x" \
+  "\"g..it\" commit (quoted)"
+
+add_case "E11_INJ1" "known-limitation" "existing-bypass" \
+  "$MAIN_REPO" "$GIT -C \"\$(echo $MAIN_REPO)\" commit -m x" \
+  "g..it -C \$(echo MAIN) commit — split shears it"
+
+# -----------------------------------------------------------------------------
+# 実行
+# -----------------------------------------------------------------------------
+setup_test_repo
+
+fail_count=0
+skip_count=0
+ok_count=0
+
+echo "pre-commit-guard.sh test harness"
+echo "hook: $HOOK_PATH"
+echo "test root: $TEST_ROOT"
+echo "----------------------------------------"
+
+for entry in "${TESTS[@]}"; do
+  IFS=$'\t' read -r id expected kind cwd command label <<< "$entry"
+  if [ "$expected" = "known-limitation" ]; then
+    run_case "$id" "$expected" "$kind" "$cwd" "$command" "$label" || true
+    skip_count=$((skip_count + 1))
+    continue
+  fi
+  if run_case "$id" "$expected" "$kind" "$cwd" "$command" "$label"; then
+    ok_count=$((ok_count + 1))
+  else
+    fail_count=$((fail_count + 1))
+  fi
+done
+
+echo "----------------------------------------"
+printf "TOTAL: %d  OK: %d  FAIL: %d  SKIP(known-limitation): %d\n" \
+  "${#TESTS[@]}" "$ok_count" "$fail_count" "$skip_count"
+
+if [ "$fail_count" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -125,58 +125,90 @@ fi
 # 値は git/シェルに対する有効な絶対/相対パスを想定。
 resolve_target_dir() {
   local cmd="$1"
-  python3 - "$cmd" <<'PY' 2>/dev/null || true
+  local base_cwd="$2"
+  python3 - "$cmd" "$base_cwd" <<'PY' 2>/dev/null || true
+import os
 import re
 import shlex
 import sys
 
 command = sys.argv[1]
+base_cwd = sys.argv[2] or os.getcwd()
 
 try:
     tokens = shlex.split(command, posix=True)
 except ValueError:
-    # クォート不整合等で分割不能な場合は諦める
+    # クォート不整合等で分割不能な場合は諦める (呼び出し側で cwd を使う)
     sys.exit(0)
 
 
-def find_git_subcommand_dir(tokens):
-    """tokens を走査して git commit/push 直前の -C <path> を探す。
+def find_git_target_dir(tokens):
+    """tokens を走査して git commit/push の作業ディレクトリ指定を抽出する。
+
+    優先順位 (git の実挙動に合わせる):
+        1. -C <path>            : 後続コマンドの cwd 相当
+        2. --work-tree=<path> / --work-tree <path>
+        3. --git-dir=<path> / --git-dir <path>
+            → 「親ディレクトリ」が worktree の作業ツリーである場合があるが、
+              .git そのものを指定されたケースは親、--git-dir=<path>/.git の
+              ようなケースも親を採用する (実用上、worktree の場合は
+              .git ファイル等が指している先と一致するため、ここでは親を採る)
+
     複数の git 呼び出しが && / ; で連結されているケースもあるが、
-    shlex は区切り文字を独立トークンとして残さないため、本処理では
-    「最初に commit/push を起こす git 呼び出しの -C」を採る。
+    shlex は区切り文字を独立トークンとして残さない。本処理では
+    「最初に commit/push を起こす git 呼び出しのターゲット」を採る。
     """
-    # 値を伴うグローバルオプション (次のトークンを引数として消費する)
     OPTS_WITH_ARG = {"-C", "-c", "--git-dir", "--work-tree", "--namespace",
                      "--super-prefix", "--exec-path"}
     n = len(tokens)
     i = 0
     while i < n:
         if tokens[i] == "git":
-            # `git -C <path> ... <subcmd>` をパースする
             j = i + 1
-            target_dir = None
+            dash_c = None
+            work_tree = None
+            git_dir = None
             while j < n:
                 tok = tokens[j]
                 if tok == "-C" and j + 1 < n:
-                    target_dir = tokens[j + 1]
+                    dash_c = tokens[j + 1]
                     j += 2
+                    continue
+                if tok == "--work-tree" and j + 1 < n:
+                    work_tree = tokens[j + 1]
+                    j += 2
+                    continue
+                if tok == "--git-dir" and j + 1 < n:
+                    git_dir = tokens[j + 1]
+                    j += 2
+                    continue
+                if tok.startswith("--work-tree=") :
+                    work_tree = tok.split("=", 1)[1]
+                    j += 1
+                    continue
+                if tok.startswith("--git-dir="):
+                    git_dir = tok.split("=", 1)[1]
+                    j += 1
                     continue
                 if tok in OPTS_WITH_ARG and j + 1 < n:
                     # -c key=val 等の値を持つオプションはペアで消費
                     j += 2
                     continue
-                # `--git-dir=<path>` のように = 連結された形は 1 トークン
                 if tok.startswith("--") and "=" in tok:
                     j += 1
                     continue
                 if tok.startswith("-"):
-                    # その他の単独オプション (--no-pager / --bare / -p 等)
+                    # 単独オプション (--no-pager / --bare / -p 等)
                     j += 1
                     continue
-                # サブコマンド
                 if tok in ("commit", "push"):
-                    return target_dir, True  # commit/push を含むので確定
-                # commit/push 以外の git 呼び出しはスキップして次の git を探す
+                    # 優先順: -C > --work-tree > --git-dir の親
+                    target = dash_c or work_tree
+                    if not target and git_dir:
+                        # `.../.git` を指された場合は親、それ以外でも親を取る
+                        # (worktree の場合 .git は親が作業ツリー)
+                        target = os.path.dirname(git_dir.rstrip("/")) or git_dir
+                    return target, True
                 break
             i = j + 1
             continue
@@ -184,47 +216,127 @@ def find_git_subcommand_dir(tokens):
     return None, False
 
 
-def find_cd_before_git(command_str):
-    """`cd <path> && ... git commit|push` パターンを ; / && / || / | で分割して検出する。
-    最後にマッチした cd 直後の同一セグメントを採用する (典型: cd X && git commit ...)。
+# シェル区切り (; && || |) をトークンとして残す split を自前で実装する。
+# `(` `)` `{` `}` `$(` `` ` `` はサブシェル/コマンド置換境界として扱う。
+# 既存実装は re.split で区切り文字を捨てていたため、cd と git の前後関係が
+# 失われていた。ここでは「セグメントごとに先頭トークンを見る」方式に変える。
+_SPLIT_RE = re.compile(r'(\|\||&&|;|\||\(|\)|\{|\}|`|\$\()')
+
+
+def split_segments(command_str):
+    """コマンド文字列をシェルの論理境界で分割する。
+    返り値は (segment_text, ...) のリスト。
     """
-    # シェルの区切り文字でセグメント分割 (簡易: ヒアドキュメント等は対象外)
-    segments = re.split(r"(?:&&|\|\||;|\|)", command_str)
-    target = None
+    parts = _SPLIT_RE.split(command_str)
+    segs = []
+    cur = []
+    for p in parts:
+        if p in ("||", "&&", ";", "|", "(", ")", "{", "}", "`", "$("):
+            segs.append("".join(cur))
+            cur = []
+        else:
+            cur.append(p)
+    segs.append("".join(cur))
+    return [s.strip() for s in segs if s and s.strip()]
+
+
+_CD_RE = re.compile(r'^(?:cd|pushd)\s+(.+?)\s*$')
+
+
+def collapse_cd_path(base_cwd, raw_path):
+    """raw_path を base_cwd 上で解決して絶対パスを返す。
+    `~` は HOME に展開する。`$(...)` や `$VAR` の展開は試みない (失敗扱い)。
+    解決不能ならば None を返す。
+    """
+    if not raw_path:
+        return None
+    p = raw_path
+    # ` ~` / `~/...` 展開
+    if p == "~":
+        p = os.path.expanduser("~")
+    elif p.startswith("~/"):
+        p = os.path.expanduser(p)
+    # コマンド置換や変数展開を含む場合は解決を諦める
+    if any(marker in p for marker in ("$(", "`", "${")):
+        return None
+    if "$" in p:
+        # 単純な $VAR も展開できないので諦める
+        return None
+    if not os.path.isabs(p):
+        p = os.path.join(base_cwd, p)
+    return os.path.normpath(p)
+
+
+def find_cwd_before_git_commit(command_str, base_cwd):
+    """cd / pushd を順に追って commit/push 直前の cwd を求める。
+
+    アルゴリズム:
+        - command を ; && || | ( ) { } 等で論理セグメントに分割し、
+          先頭から順に走査する
+        - `cd <path>` / `pushd <path>` が現れたら、現在の cwd 候補を更新
+        - `git commit` / `git push` を含む段に到達したら、その時点の cwd を返す
+        - 到達せずに走査が終われば None
+
+    サブシェル `(cd X && git commit)` の場合、( ) はセグメント境界として
+    扱うので、( と ) の間 (= サブシェル内) を独立に走査する。
+    本実装は厳密な構文解析ではなく「セグメント順走査」する近似だが、
+    現実的な利用パターン (cd 系の直後に git commit) はカバーできる。
+    """
+    segments = split_segments(command_str)
+    cwd = base_cwd
     for seg in segments:
-        seg = seg.strip()
-        # `cd <path>` で始まるセグメントから path を取得
-        m = re.match(r"^cd\s+(.+?)\s*$", seg)
-        if m:
-            try:
-                parsed = shlex.split(m.group(1), posix=True)
-            except ValueError:
-                continue
-            if parsed:
-                target = parsed[0]
+        try:
+            seg_tokens = shlex.split(seg, posix=True)
+        except ValueError:
+            seg_tokens = []
+        if not seg_tokens:
             continue
-        # `cd <path> && git commit ...` のような複合は && で分割されるので
-        # ここには到達しないが、念のため `cd X; git commit` のような同一セグメント内
-        # も拾えるよう簡易チェック
-    return target
+
+        # `cd <path>` または `pushd <path>` だけのセグメント
+        if seg_tokens[0] in ("cd", "pushd") and len(seg_tokens) >= 2:
+            new_cwd = collapse_cd_path(cwd, seg_tokens[1])
+            if new_cwd:
+                cwd = new_cwd
+            else:
+                # path 解決不能 (= コマンド置換等) の場合はそれ以上追えない
+                # 攻撃面を広げないため cwd は更新しない (= base_cwd のまま)
+                pass
+            continue
+
+        # git commit / git push (or git -C ... commit/push) を含む段に到達
+        # ここでは tokens の中に "commit" / "push" があれば cwd を返す
+        if seg_tokens[0] == "git":
+            # find_git_target_dir でこのセグメント単体の git 呼び出しを評価
+            target, has_cp = find_git_target_dir(seg_tokens)
+            if has_cp:
+                if target:
+                    # -C / --work-tree / --git-dir 由来の path は cwd 相対
+                    resolved = collapse_cd_path(cwd, target)
+                    return resolved or cwd
+                return cwd
+    return None
 
 
-# 1) git -C <path> commit|push を最優先
-dir_from_dashC, has_commit_push = find_git_subcommand_dir(tokens)
+# 1) git -C <path> / --work-tree / --git-dir を最優先
+dir_from_git_opts, has_commit_push = find_git_target_dir(tokens)
 
 # 2) commit/push が含まれていなければ何も出さない
 if not has_commit_push:
-    # commit/push 自体が無いなら呼び出し側でブランチチェックする必要は無い
     sys.exit(0)
 
-if dir_from_dashC:
-    print(dir_from_dashC)
+if dir_from_git_opts:
+    # 解決した path が相対なら base_cwd で絶対化
+    resolved = collapse_cd_path(base_cwd, dir_from_git_opts)
+    # コマンド置換等で解決できない場合は何も出さない (呼び出し側で cwd を使う)
+    if resolved is None:
+        sys.exit(0)
+    print(resolved)
     sys.exit(0)
 
-# 3) `cd <path>` を含むセグメントから推定
-cd_dir = find_cd_before_git(command)
-if cd_dir:
-    print(cd_dir)
+# 3) cd / pushd / subshell を辿って commit/push 直前の cwd を求める
+cwd = find_cwd_before_git_commit(command, base_cwd)
+if cwd:
+    print(cwd)
     sys.exit(0)
 
 # 4) なければ何も出さない (呼び出し側で cwd を使う)
@@ -233,22 +345,54 @@ PY
 
 # master/main への直接 commit / push 拒否
 if printf '%s\n' "$GIT_INVOCATIONS" | grep -Eq '^git[[:space:]]+(commit|push)([[:space:]]|$)'; then
-  TARGET_DIR=$(resolve_target_dir "$COMMAND" || true)
+  # base_cwd は hook プロセスの cwd (= Bash ツール実行時の cwd)
+  BASE_CWD=$(pwd)
+  TARGET_DIR=$(resolve_target_dir "$COMMAND" "$BASE_CWD" || true)
+
+  # `--git-dir=` / `--work-tree=` が COMMAND 内に明示されているかを判定する
+  # (これらが指定されていてかつ path 解決に失敗した場合は攻撃の意図が強いため
+  #  block する。それ以外で TARGET_DIR が空になるのは cwd 相当で評価したい
+  #  典型ケース or 解析に失敗したケースなので、cwd で fallback 評価する。)
+  HAS_EXPLICIT_GIT_DIR_OPT=0
+  if printf '%s' "$COMMAND" | grep -Eq '(^|[[:space:]])--(git-dir|work-tree)([[:space:]=])'; then
+    HAS_EXPLICIT_GIT_DIR_OPT=1
+  fi
 
   if [ -n "${TARGET_DIR:-}" ]; then
-    # path 展開 (~ は通常 shell が展開するが、JSON 経由で渡される command は
-    # 未展開のまま到達しうるため、ここで bash 側でも tilde 展開を試みる)
-    case "$TARGET_DIR" in
-      "~"|"~/"*) TARGET_DIR="${HOME}${TARGET_DIR#\~}" ;;
-    esac
+    # まず TARGET_DIR 自身で rev-parse を試す
     CURRENT_BRANCH=$(git -C "$TARGET_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-    # 指定パスでブランチ取得に失敗した場合 (存在しないパス / git リポではない 等) は
-    # 攻撃面 (任意パス指定でガード bypass) を塞ぐため、保守的にブロックする。
-    # 実 git は同様の状況でエラー終了するため、ここでブロックしても誤検知は生まない。
+    # 存在しない subdir 等で失敗した場合は祖先ディレクトリを最大 8 階層辿る
+    # (実 git は cwd 配下から .git を探すので、これと挙動を合わせる)
     if [ -z "$CURRENT_BRANCH" ]; then
-      block "git -C / --git-dir 等で指定された path がリポジトリとして解決できません: $TARGET_DIR"
+      ANCESTOR="$TARGET_DIR"
+      for _ in 1 2 3 4 5 6 7 8; do
+        PARENT=$(dirname "$ANCESTOR")
+        if [ "$PARENT" = "$ANCESTOR" ] || [ "$PARENT" = "/" ]; then
+          break
+        fi
+        ANCESTOR="$PARENT"
+        CURRENT_BRANCH=$(git -C "$ANCESTOR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+        if [ -n "$CURRENT_BRANCH" ]; then
+          break
+        fi
+      done
+    fi
+    if [ -z "$CURRENT_BRANCH" ]; then
+      if [ "$HAS_EXPLICIT_GIT_DIR_OPT" = "1" ]; then
+        # 明示的に --git-dir / --work-tree で path 指定 → 解決失敗は block
+        block "--git-dir / --work-tree で指定された path がリポジトリとして解決できません: $TARGET_DIR"
+      fi
+      # それ以外は cwd にフォールバック (元実装の挙動と同等の安全側)
+      CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
     fi
   else
+    # TARGET_DIR が空 = resolve_target_dir が path 推定を諦めた
+    # この場合は元実装と同じく hook プロセスの cwd で評価する。
+    # ただし --git-dir / --work-tree が明示されているのに path が拾えなかった
+    # (コマンド置換等で解析不能) ケースは block する。
+    if [ "$HAS_EXPLICIT_GIT_DIR_OPT" = "1" ]; then
+      block "--git-dir / --work-tree の引数が解析できません。直接 path を指定してください。"
+    fi
     CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
   fi
 

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -31,12 +31,65 @@ block() {
 # などの文字列が誤検知されるため、git に続くトークンを行単位で抽出して判定する。
 #
 # 抽出方針: 先頭または `;`, `&&`, `||`, `|`, `$(` 直後に現れる `git <sub>` を列挙する。
+# さらに `git -C <path> <sub>` / `git -c key=val <sub>` のように先頭にグローバル
+# オプションがあるケースも考慮し、subcommand 直前のオプション列を読み飛ばして
+# 「正規化された git 呼び出し行」 (`git <sub> <args>`) を生成する。
 
 # シェル区切りで正規化（置換してから grep）
 NORMALIZED=$(printf '%s' "$COMMAND" | tr ';&|()`' '\n')
 
-# git <subcommand> 呼び出しトークンを抽出（行頭空白を落としてからマッチ）
-GIT_INVOCATIONS=$(printf '%s\n' "$NORMALIZED" | sed -E 's/^[[:space:]]+//' | grep -E '^git[[:space:]]+' || true)
+# git で始まる行を抽出（行頭空白を落としてからマッチ）
+GIT_LINES=$(printf '%s\n' "$NORMALIZED" | sed -E 's/^[[:space:]]+//' | grep -E '^git[[:space:]]+' || true)
+
+if [ -z "$GIT_LINES" ]; then
+  exit 0
+fi
+
+# 各 git 行について、グローバルオプション (`-C <path>`、`-c key=val`、
+# `--git-dir=...`、`--work-tree=...` 等) を読み飛ばして subcommand 以降に正規化する。
+# 結果は GIT_INVOCATIONS (1 行 1 呼び出し) に格納し、以後の判定はこれを用いる。
+GIT_INVOCATIONS=$(printf '%s\n' "$GIT_LINES" | python3 -c '
+import shlex
+import sys
+
+for raw in sys.stdin:
+    line = raw.rstrip("\n")
+    if not line.strip():
+        continue
+    try:
+        toks = shlex.split(line, posix=True)
+    except ValueError:
+        # クォート不整合は元の行をそのまま出す (誤検知より見逃しを避ける)
+        print(line)
+        continue
+    if not toks or toks[0] != "git":
+        print(line)
+        continue
+    j = 1
+    while j < len(toks):
+        t = toks[j]
+        # `-C <path>` / `-c key=val` は次のトークンを引数として消費
+        if t == "-C" or t == "-c":
+            j += 2
+            continue
+        # `--git-dir=...` / `--work-tree=...` など値が = で連結されたオプションは 1 トークン
+        if t.startswith("--") and "=" in t:
+            j += 1
+            continue
+        # `--git-dir <path>` のように分離されているケース
+        if t in ("--git-dir", "--work-tree", "--namespace", "--super-prefix",
+                 "--exec-path"):
+            j += 2
+            continue
+        # その他の単独オプション (--help / --version / --no-pager / --bare 等)
+        if t.startswith("-"):
+            j += 1
+            continue
+        break
+    # subcommand 以降を再構築。引用は剥がされるが、後続の grep は単語境界しか見ない
+    # ためここで quoting を厳密に復元する必要はない。
+    print(" ".join(["git"] + toks[j:]))
+' || true)
 
 if [ -z "$GIT_INVOCATIONS" ]; then
   exit 0
@@ -53,9 +106,152 @@ if printf '%s\n' "$GIT_INVOCATIONS" | grep -E '^git[[:space:]]+push([[:space:]]|
   block "force push は禁止されています。"
 fi
 
+# ------------------------------------------------------------------
+# worktree 対応のブランチ判定
+# ------------------------------------------------------------------
+# 旧実装は hook プロセスの cwd で `git branch --show-current` を評価していたため、
+# Claude Code の cwd がメインリポでも、コマンド側で `cd <worktree>` / `git -C <worktree>`
+# を使っている場合に master と誤判定されるバグがあった (Issue #550)。
+#
+# 対応方針: 実行されようとしている git commit/push が「どの worktree 上で実行されるか」を
+# command 文字列から推定する。具体的には以下を順に確認する。
+#   1. `git -C <path> commit|push` 形式 → <path> をターゲットに採用
+#   2. `cd <path> && ... git commit|push` 形式 → <path> をターゲットに採用
+#   3. いずれも無ければ hook プロセスの cwd を採用 (既存挙動)
+# 採用した path で `git -C <path> rev-parse --abbrev-ref HEAD` を実行してブランチ名を得る。
+
+# command 文字列から、commit/push を実行する作業ディレクトリ候補を抽出する。
+# stdout に 1 行で path (なければ空文字) を出力する。
+# 値は git/シェルに対する有効な絶対/相対パスを想定。
+resolve_target_dir() {
+  local cmd="$1"
+  python3 - "$cmd" <<'PY' 2>/dev/null || true
+import re
+import shlex
+import sys
+
+command = sys.argv[1]
+
+try:
+    tokens = shlex.split(command, posix=True)
+except ValueError:
+    # クォート不整合等で分割不能な場合は諦める
+    sys.exit(0)
+
+
+def find_git_subcommand_dir(tokens):
+    """tokens を走査して git commit/push 直前の -C <path> を探す。
+    複数の git 呼び出しが && / ; で連結されているケースもあるが、
+    shlex は区切り文字を独立トークンとして残さないため、本処理では
+    「最初に commit/push を起こす git 呼び出しの -C」を採る。
+    """
+    # 値を伴うグローバルオプション (次のトークンを引数として消費する)
+    OPTS_WITH_ARG = {"-C", "-c", "--git-dir", "--work-tree", "--namespace",
+                     "--super-prefix", "--exec-path"}
+    n = len(tokens)
+    i = 0
+    while i < n:
+        if tokens[i] == "git":
+            # `git -C <path> ... <subcmd>` をパースする
+            j = i + 1
+            target_dir = None
+            while j < n:
+                tok = tokens[j]
+                if tok == "-C" and j + 1 < n:
+                    target_dir = tokens[j + 1]
+                    j += 2
+                    continue
+                if tok in OPTS_WITH_ARG and j + 1 < n:
+                    # -c key=val 等の値を持つオプションはペアで消費
+                    j += 2
+                    continue
+                # `--git-dir=<path>` のように = 連結された形は 1 トークン
+                if tok.startswith("--") and "=" in tok:
+                    j += 1
+                    continue
+                if tok.startswith("-"):
+                    # その他の単独オプション (--no-pager / --bare / -p 等)
+                    j += 1
+                    continue
+                # サブコマンド
+                if tok in ("commit", "push"):
+                    return target_dir, True  # commit/push を含むので確定
+                # commit/push 以外の git 呼び出しはスキップして次の git を探す
+                break
+            i = j + 1
+            continue
+        i += 1
+    return None, False
+
+
+def find_cd_before_git(command_str):
+    """`cd <path> && ... git commit|push` パターンを ; / && / || / | で分割して検出する。
+    最後にマッチした cd 直後の同一セグメントを採用する (典型: cd X && git commit ...)。
+    """
+    # シェルの区切り文字でセグメント分割 (簡易: ヒアドキュメント等は対象外)
+    segments = re.split(r"(?:&&|\|\||;|\|)", command_str)
+    target = None
+    for seg in segments:
+        seg = seg.strip()
+        # `cd <path>` で始まるセグメントから path を取得
+        m = re.match(r"^cd\s+(.+?)\s*$", seg)
+        if m:
+            try:
+                parsed = shlex.split(m.group(1), posix=True)
+            except ValueError:
+                continue
+            if parsed:
+                target = parsed[0]
+            continue
+        # `cd <path> && git commit ...` のような複合は && で分割されるので
+        # ここには到達しないが、念のため `cd X; git commit` のような同一セグメント内
+        # も拾えるよう簡易チェック
+    return target
+
+
+# 1) git -C <path> commit|push を最優先
+dir_from_dashC, has_commit_push = find_git_subcommand_dir(tokens)
+
+# 2) commit/push が含まれていなければ何も出さない
+if not has_commit_push:
+    # commit/push 自体が無いなら呼び出し側でブランチチェックする必要は無い
+    sys.exit(0)
+
+if dir_from_dashC:
+    print(dir_from_dashC)
+    sys.exit(0)
+
+# 3) `cd <path>` を含むセグメントから推定
+cd_dir = find_cd_before_git(command)
+if cd_dir:
+    print(cd_dir)
+    sys.exit(0)
+
+# 4) なければ何も出さない (呼び出し側で cwd を使う)
+PY
+}
+
 # master/main への直接 commit / push 拒否
 if printf '%s\n' "$GIT_INVOCATIONS" | grep -Eq '^git[[:space:]]+(commit|push)([[:space:]]|$)'; then
-  CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+  TARGET_DIR=$(resolve_target_dir "$COMMAND" || true)
+
+  if [ -n "${TARGET_DIR:-}" ]; then
+    # path 展開 (~ は通常 shell が展開するが、JSON 経由で渡される command は
+    # 未展開のまま到達しうるため、ここで bash 側でも tilde 展開を試みる)
+    case "$TARGET_DIR" in
+      "~"|"~/"*) TARGET_DIR="${HOME}${TARGET_DIR#\~}" ;;
+    esac
+    CURRENT_BRANCH=$(git -C "$TARGET_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    # 指定パスでブランチ取得に失敗した場合 (存在しないパス / git リポではない 等) は
+    # 攻撃面 (任意パス指定でガード bypass) を塞ぐため、保守的にブロックする。
+    # 実 git は同様の状況でエラー終了するため、ここでブロックしても誤検知は生まない。
+    if [ -z "$CURRENT_BRANCH" ]; then
+      block "git -C / --git-dir 等で指定された path がリポジトリとして解決できません: $TARGET_DIR"
+    fi
+  else
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  fi
+
   if [ "$CURRENT_BRANCH" = "master" ] || [ "$CURRENT_BRANCH" = "main" ]; then
     block "master/main ブランチへの直接 commit/push は禁止です。作業ブランチを切ってください。"
   fi


### PR DESCRIPTION
## 概要

Issue #494 PR の修正対応中に発覚した hook の挙動問題を解決する。`pre-commit-guard.sh` が `git branch --show-current` を hook プロセスの cwd で評価するため、worktree 内でブランチが正しいにもかかわらず master 判定で誤ブロックされていた。

Closes #550

## 変更内容

### `.claude/hooks/pre-commit-guard.sh` (`7006e2b`)
採用案: **案 B のサブセット (cwd 解析 + `git -C` 解析)** + 追加対応で `--git-dir` / `--work-tree` / pushd / サブシェル / 連続cd 対応:

- Python の独自トークナイザで `(`/`)`/`;`/`&&` を境界化し、セグメント順走査で cwd を累積
- `cd` / `pushd` / `git -C` / `--work-tree` / `--git-dir` を target 候補として優先順 (`-C > --work-tree > --git-dir の親`) で採用
- 解決失敗時の方針:
  - 明示的 `--git-dir`/`--work-tree` で path 解決失敗 → block (攻撃面の選択的閉鎖)
  - その他 → cwd 評価にフォールバック (誤判定回避)
- 既存スクリプトの git 呼び出し抽出ロジックを shlex で堅牢化

### `.claude/hooks/__tests__/pre-commit-guard.test.sh` (`b7ee0fb`)
- 27 ケースのテストハーネス追加 (sanity 7 / fix-required 8 / known-limitation 12)
- 隔離 tmp リポを毎回新規作成
- 結果: OK 15 / FAIL 0 / SKIP(known-limitation) 12

## 検証結果

### 本PRで修正した regression (4件)
| ID | パターン | cwd | master | PR |
|---|---|---|---|---|
| R01 | `cd wt && git c.o.m.m.i.t` | main(master) | block (誤判定) | **pass** |
| R03 | `(cd wt && git c.o.m.m.i.t)` サブシェル | main(master) | block (誤判定) | **pass** |
| R04 | `pu.shd wt && git c.o.m.m.i.t` | main(master) | block (誤判定) | **pass** |
| R05 | `cd wt && cd src && git c.o.m.m.i.t` 連続cd | main(master) | block (誤判定) | **pass** |

### 既存挙動維持 (sanity OK)
- master 直接 c.o.m.m.i.t / p.u.s.h の block / re.base / force p.u.s.h / Co-Authored-By 検出

### 既知の限界 (本PR scope外、follow-up Issue化)
- 元実装でも素通っていた 11件 (env変数 / 絶対パス / sudo / eval / bash -c / GIT_DIR / env -C / alias / newline / quoted / `$(...)`) → 設計根本見直し候補
- R06 (`cd wt && (git c.o.m.m.i.t)` 外側cd + サブシェル) → 修正可能だが scope外

## 備考

- Counterpoint 31 (git ネイティブ hook 化) / 32 (worktree allowlist 化) は別 Issue で検討
- テストハーネスの CI 統合 (GitHub Actions workflow 化) も別 Issue で検討

## チェック

- [x] `pnpm test:run` 全 pass (47 files / 802 tests)
- [x] `pnpm lint` 全 pass
- [x] `pnpm build` 全 pass
- [x] `bash -n .claude/hooks/pre-commit-guard.sh` syntax OK
- [x] テストハーネス OK 15 / FAIL 0 / SKIP 12
