### PR TITLE
refactor: Coordinate.allPosts.test.tsx の期待値を fixture 化して仕様の二重実装を解消

### DIFF
--- a/src/components/common/__tests__/Coordinate.allPosts.test.tsx
+++ b/src/components/common/__tests__/Coordinate.allPosts.test.tsx
@@ -54,6 +54,24 @@ interface CoordinateExpectation {
  *
  * 記事を追加した場合は本 fixture も更新する。記事数と fixture 件数が
  * 一致するかは「fixture の網羅性」テストでアサートする。
+ *
+ * **fixture 検算スニペット (新規記事追加時)**:
+ * 新しい post.id (YYYYMMDDhhmmss 形式) に対する expectedRows を埋めるとき、
+ * 手計算ではなく以下を一時ファイル (例: scripts/_calcFixture.ts) として
+ * 書いて `node scripts/_calcFixture.ts` で実行し、値を写し取ると安全。
+ * Node v22+ はネイティブで `.ts` を実行できる (既存 scripts/ 配下と同方式)。
+ * 検算用途のみで本テストの期待値とはしない。
+ *
+ *   import { computeCoordinates, inferPublishedAt } from "../src/lib/anchors";
+ *   import milestones from "../datasources/milestones.json";
+ *   const id = "20260307120000"; // 追加した post.id
+ *   const publishedAt = inferPublishedAt(id);
+ *   const rows = computeCoordinates(publishedAt!, milestones as never)
+ *     .filter((c) => c.tone !== "heavy")
+ *     .map((c) => ({ label: c.label, daysSince: c.daysSince }));
+ *   console.log(JSON.stringify({ postId: id, publishedAt, expectedRows: rows }, null, 2));
+ *
+ * 出力された JSON を expectations 配列に追記すれば fixture が更新できる。
  */
 const expectations: readonly CoordinateExpectation[] = [
   {
@@ -194,6 +212,14 @@ const postIds = postFilePaths
  *
  * 本番 milestones.json を更新したら、`expectations` と本 `testMilestones` の
  * 両方を同時に書き直すこと (fixture の更新ルール)。
+ *
+ * **trade-off (両刃の性質)**:
+ * 本番 JSON との切り離しにより「本番 JSON 改変でテスト道連れ失敗を防ぐ」
+ * メリットがある一方で、「本番 milestone の label rename / tone 変更 /
+ * 日付変更などの意味的変更が本テスト上で silent pass する」リスクを孕む。
+ * 本番 milestones.json と本テスト fixture のずれは、本番 JSON を直接 import
+ * している `AnchorPage.allPosts.test.tsx` / `anchors.test.ts` および開発者の
+ * 意識的な fixture 更新 (上述「fixture の更新ルール」) で担保する設計とする。
  */
 const testMilestones: readonly Milestone[] = [
   { date: "2025-08-05", label: "休職開始", tone: "heavy" },

--- a/src/components/common/__tests__/Coordinate.allPosts.test.tsx
+++ b/src/components/common/__tests__/Coordinate.allPosts.test.tsx
@@ -1,11 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import milestonesData from "../../../../datasources/milestones.json";
-import {
-  computeCoordinates,
-  inferPublishedAt,
-  type Milestone,
-} from "../../../lib/anchors";
+import { inferPublishedAt, type Milestone } from "../../../lib/anchors";
 import { Coordinate } from "../Coordinate";
 
 /**
@@ -23,9 +18,161 @@ import { Coordinate } from "../Coordinate";
  *
  * 実記事ファイル名は import.meta.glob で動的列挙する。これにより記事を
  * 追加・削除しても再生成不要で常に最新の 16 件 (現在) を検査する。
+ *
+ * Issue #535: 期待値は computeCoordinates の戻り値を再計算するのではなく、
+ *   「実際にこの publishedAt と milestones.json でどう描画されるはずか」を
+ *   ハードコードした fixture (CoordinateExpectation[]) と直接比較する。
+ *   これにより `computeCoordinates(...).filter((c) => c.tone !== "heavy")`
+ *   という実装の写経が無くなり、フィルタ条件 (heavy 除外) や未来除外仕様を
+ *   変えると本テストの期待値とずれて失敗するようになる (= 仕様の二重実装解消)。
  */
 
-const milestones: readonly Milestone[] = milestonesData as readonly Milestone[];
+/**
+ * 1 記事ぶんの期待表示。
+ *
+ * - publishedAt: ファイル名 (post.id) から推定される ISO 8601 文字列
+ * - expectedRows: 描画される li の順序どおりに並べた節目テキスト
+ *   (heavy 除外・未来除外を反映済み)
+ */
+interface CoordinateExpectation {
+  readonly postId: string;
+  readonly publishedAt: string;
+  readonly expectedRows: readonly { label: string; daysSince: number }[];
+}
+
+/**
+ * datasources/milestones.json と各記事の publishedAt を入力にして、
+ * Coordinate が「実際にどう描画されるはずか」をハードコードした fixture。
+ *
+ * - 現行 datasources/milestones.json:
+ *   - 2025-08-05 休職開始 (heavy) ← 表示対象から除外
+ *   - 2025-08-26 サイト開設 (neutral)
+ *   - 2025-09-05 社会復帰 (light)
+ * - 各記事の expectedRows は milestones.json の登録順を保ち、heavy を除外し、
+ *   publishedAt 当日以降のものを除外した結果である
+ *   (anchors.ts の computeCoordinates 仕様 + Coordinate.tsx の heavy 除外仕様)
+ *
+ * 記事を追加した場合は本 fixture も更新する。記事数と fixture 件数が
+ * 一致するかは「fixture の網羅性」テストでアサートする。
+ */
+const expectations: readonly CoordinateExpectation[] = [
+  {
+    postId: "20250826031705",
+    publishedAt: "2025-08-26T03:17:05+09:00",
+    expectedRows: [{ label: "サイト開設", daysSince: 0 }],
+  },
+  {
+    postId: "20250827082145",
+    publishedAt: "2025-08-27T08:21:45+09:00",
+    expectedRows: [{ label: "サイト開設", daysSince: 1 }],
+  },
+  {
+    postId: "20250829065256",
+    publishedAt: "2025-08-29T06:52:56+09:00",
+    expectedRows: [{ label: "サイト開設", daysSince: 3 }],
+  },
+  {
+    postId: "20250829094053",
+    publishedAt: "2025-08-29T09:40:53+09:00",
+    expectedRows: [{ label: "サイト開設", daysSince: 3 }],
+  },
+  {
+    postId: "20250908234321",
+    publishedAt: "2025-09-08T23:43:21+09:00",
+    expectedRows: [
+      { label: "サイト開設", daysSince: 13 },
+      { label: "社会復帰", daysSince: 3 },
+    ],
+  },
+  {
+    postId: "20250916111939",
+    publishedAt: "2025-09-16T11:19:39+09:00",
+    expectedRows: [
+      { label: "サイト開設", daysSince: 21 },
+      { label: "社会復帰", daysSince: 11 },
+    ],
+  },
+  {
+    postId: "20250923112419",
+    publishedAt: "2025-09-23T11:24:19+09:00",
+    expectedRows: [
+      { label: "サイト開設", daysSince: 28 },
+      { label: "社会復帰", daysSince: 18 },
+    ],
+  },
+  {
+    postId: "20250929121839",
+    publishedAt: "2025-09-29T12:18:39+09:00",
+    expectedRows: [
+      { label: "サイト開設", daysSince: 34 },
+      { label: "社会復帰", daysSince: 24 },
+    ],
+  },
+  {
+    postId: "20251014141439",
+    publishedAt: "2025-10-14T14:14:39+09:00",
+    expectedRows: [
+      { label: "サイト開設", daysSince: 49 },
+      { label: "社会復帰", daysSince: 39 },
+    ],
+  },
+  {
+    postId: "20251105100114",
+    publishedAt: "2025-11-05T10:01:14+09:00",
+    expectedRows: [
+      { label: "サイト開設", daysSince: 71 },
+      { label: "社会復帰", daysSince: 61 },
+    ],
+  },
+  {
+    postId: "20251108111702",
+    publishedAt: "2025-11-08T11:17:02+09:00",
+    expectedRows: [
+      { label: "サイト開設", daysSince: 74 },
+      { label: "社会復帰", daysSince: 64 },
+    ],
+  },
+  {
+    postId: "20251129142242",
+    publishedAt: "2025-11-29T14:22:42+09:00",
+    expectedRows: [
+      { label: "サイト開設", daysSince: 95 },
+      { label: "社会復帰", daysSince: 85 },
+    ],
+  },
+  {
+    postId: "20251220064951",
+    publishedAt: "2025-12-20T06:49:51+09:00",
+    expectedRows: [
+      { label: "サイト開設", daysSince: 116 },
+      { label: "社会復帰", daysSince: 106 },
+    ],
+  },
+  {
+    postId: "20260110011222",
+    publishedAt: "2026-01-10T01:12:22+09:00",
+    expectedRows: [
+      { label: "サイト開設", daysSince: 137 },
+      { label: "社会復帰", daysSince: 127 },
+    ],
+  },
+  {
+    postId: "20260221104801",
+    publishedAt: "2026-02-21T10:48:01+09:00",
+    expectedRows: [
+      { label: "サイト開設", daysSince: 179 },
+      { label: "社会復帰", daysSince: 169 },
+    ],
+  },
+  {
+    postId: "20260307120000",
+    publishedAt: "2026-03-07T12:00:00+09:00",
+    expectedRows: [
+      { label: "サイト開設", daysSince: 193 },
+      { label: "社会復帰", daysSince: 183 },
+    ],
+  },
+];
 
 // datasources/*.md のファイル名を動的列挙する。
 // import.meta.glob は eager:false 既定で path のみ取得する。
@@ -37,58 +184,76 @@ const postIds = postFilePaths
   .filter((id): id is string => typeof id === "string" && id.length > 0)
   .sort();
 
+/**
+ * テスト本体で使う milestones。
+ *
+ * fixture (expectations) は **現行の datasources/milestones.json** の内容に
+ * 基づいてハードコードされている。テスト時に再 import すると、本番 JSON が
+ * 更新された瞬間に fixture と乖離して全件失敗する。これを防ぐため、本テスト
+ * 専用の不変スナップショットをここで定義する (= fixture と一対の入力データ)。
+ *
+ * 本番 milestones.json を更新したら、`expectations` と本 `testMilestones` の
+ * 両方を同時に書き直すこと (fixture の更新ルール)。
+ */
+const testMilestones: readonly Milestone[] = [
+  { date: "2025-08-05", label: "休職開始", tone: "heavy" },
+  { date: "2025-08-26", label: "サイト開設", tone: "neutral" },
+  { date: "2025-09-05", label: "社会復帰", tone: "light" },
+];
+
 describe("Coordinate (実16記事での回帰テスト)", () => {
   it("datasources/*.md を全件取得できる (テスト前提の健全性)", () => {
-    // 16 件存在する前提を担保 (本テストの実機性を保つため)
+    // 1 件以上存在する前提を担保 (本テストの実機性を保つため)
     expect(postIds.length).toBeGreaterThanOrEqual(1);
   });
 
-  describe.each(postIds)("post.id=%s", (postId) => {
-    const publishedAt = inferPublishedAt(postId);
+  it("fixture (expectations) が datasources/*.md の実ファイル名と完全一致する", () => {
+    // 記事を追加・削除したら fixture も同時に更新する義務を仕組みで担保する。
+    // 「fixture が古くなって実ファイルとずれている」状態をテストで検知する。
+    const fixturePostIds = expectations.map((e) => e.postId).sort();
+    expect(fixturePostIds).toEqual(postIds);
+  });
 
-    it("post.id からタイムスタンプを推定できる (実ファイル名の構造検査)", () => {
-      // 既存 16 記事はすべて YYYYMMDDhhmmss 形式
-      expect(publishedAt).not.toBeNull();
-    });
+  describe.each(expectations)(
+    "post.id=$postId",
+    ({ postId, publishedAt, expectedRows }) => {
+      it("post.id からタイムスタンプを推定でき、fixture の publishedAt と一致する", () => {
+        // 既存記事はすべて YYYYMMDDhhmmss 形式で、fixture と整合する
+        const inferred = inferPublishedAt(postId);
+        expect(inferred).toBe(publishedAt);
+      });
 
-    it("Coordinate が computeCoordinates 結果と整合して描画される (heavy 除外含む)", () => {
-      if (publishedAt === null) {
-        // 推定不可なら本テストはスキップ (上の it でアサート済み)
-        return;
-      }
+      it("fixture の expectedRows どおりの順序・件数・テキストで描画される", () => {
+        const { container } = render(
+          <Coordinate
+            publishedAt={publishedAt}
+            milestones={testMilestones}
+          />,
+        );
 
-      // 期待される描画: tone:heavy を除外した過去の節目のみ
-      const expectedCoordinates = computeCoordinates(
-        publishedAt,
-        milestones,
-      ).filter((c) => c.tone !== "heavy");
+        if (expectedRows.length === 0) {
+          // 0 件記事 (= 全節目が未来 or 全節目が heavy) は非表示
+          expect(container.firstChild).toBeNull();
+          return;
+        }
 
-      const { container } = render(
-        <Coordinate publishedAt={publishedAt} milestones={milestones} />,
-      );
-
-      if (expectedCoordinates.length === 0) {
-        // 0 件記事 (= 全節目が未来 or 全節目が heavy) は非表示
-        expect(container.firstChild).toBeNull();
-      } else {
         // 1 件以上ある記事は ul (aria-label="個人史座標") が描画される
-        const list = screen.getByRole("list", {
-          name: "個人史座標",
-        });
+        const list = screen.getByRole("list", { name: "個人史座標" });
         expect(list).toBeInTheDocument();
+
         // 期待件数の li が並ぶ
         const items = list.querySelectorAll("li");
-        expect(items).toHaveLength(expectedCoordinates.length);
+        expect(items).toHaveLength(expectedRows.length);
 
-        // 各 li のテキストに対応する label と日数が含まれる
-        for (const [index, coord] of expectedCoordinates.entries()) {
+        // 各 li に fixture どおりの label と日数が含まれる
+        for (const [index, row] of expectedRows.entries()) {
           const item = items[index];
-          expect(item.textContent).toContain(coord.label);
-          expect(item.textContent).toContain(String(coord.daysSince));
+          expect(item.textContent).toContain(row.label);
+          expect(item.textContent).toContain(String(row.daysSince));
         }
-      }
-    });
-  });
+      });
+    },
+  );
 
   describe("0 件記事の非表示 (フォールバック)", () => {
     it("milestones が空配列なら全 16 記事で非表示になる", () => {
@@ -108,7 +273,7 @@ describe("Coordinate (実16記事での回帰テスト)", () => {
     });
 
     it("全節目が tone:heavy だけなら全 16 記事で非表示になる", () => {
-      const heavyOnly: readonly Milestone[] = milestones.map((m) => ({
+      const heavyOnly: readonly Milestone[] = testMilestones.map((m) => ({
         ...m,
         tone: "heavy",
       }));


### PR DESCRIPTION
## 概要

Issue #535: `Coordinate.allPosts.test.tsx` で `computeCoordinates(publishedAt, milestones).filter((c) => c.tone !== "heavy")` という Coordinate.tsx と同一ロジックを expected として計算していた「仕様の二重実装」を解消。

採用案: **案A** (期待値テーブルを fixture としてハードコード)

- 案A 採用根拠:
  - Issue 本文で推奨されている案
  - 案B (描画破綻のみ件数アサート) は回帰検知力が著しく落ちる (label/daysSince の値が壊れても検知できない)
  - 案A は heavy 除外仕様や未来除外仕様を変えると fixture と乖離して即時失敗するため、本 Issue の主目的「仕様の二重実装解消」と「フィルタ条件の回帰検知」を両立する

## 変更内容

- `src/components/common/__tests__/Coordinate.allPosts.test.tsx`:
  - `CoordinateExpectation` 型 + 16 件分の期待値配列 `expectations` を fixture として導入。各記事の publishedAt と「実描画されるはずの label/daysSince」をハードコード
  - `computeCoordinates` の import を削除し、テスト本体では `inferPublishedAt` のみ残置 (fixture と post.id の整合性確認のため)
  - `import.meta.glob` による動的列挙との整合性を「fixture と datasources/*.md 実ファイル名の完全一致」テストで担保
  - `testMilestones` を本テスト専用の不変スナップショットとして定義 (本番 `datasources/milestones.json` からの decoupling)
  - 変更前後のテスト数: 36 件 → 37 件
- 追加コミット (4659f22): DA Round 1 で指摘された Strong 反論への対応
  - `testMilestones` JSDoc に trade-off を明記 (label rename 等の意味的変更は silent pass する両刃性質、担保責任先を本番 milestones.json を import している側に明示)
  - 新規記事追加時の fixture 計算スニペット (Node + 一時 `.ts` ファイル方式) を `expectations` 直前にコメントとして追加

## 備考

- 検証: `pnpm test:run` 50 files / 812 tests 全 pass、`pnpm lint` clean
- fixture 値はサンプル抽出で全数手計算検算済み (Reviewer により全 10 ケース整合確認)
- 片肺リファクタ点 (`AnchorPage.allPosts.test.tsx` line 97-114 に同種「実装の写経」残存) は follow-up Issue #573 として登録済み
- DA レビュー: CONDITIONAL → 全条件対応済み

Closes #535