### PR TITLE
chore: panda-hash-regression workflow の sed/grep を trailing comma drift に耐性化

### DIFF
--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -38,20 +38,28 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Enable Panda hash:true (temporary in-CI patch)
-        # panda.config.ts の defineConfig 内 `preflight: true,` 直下に
-        # `hash: true,` を 1 行挿入する。リポジトリへは push しない CI 内
-        # 一時パッチ。挿入後に grep で実在を確認し、未挿入なら即 fail する。
+        # panda.config.ts の defineConfig 内 `preflight: true` 行 (末尾カンマ
+        # 任意) 直下に `hash: true,` を 1 行挿入する。リポジトリへは push
+        # しない CI 内一時パッチ。挿入後に grep で実在を確認し、未挿入なら
+        # 即 fail する。
+        #
+        # Issue #527: sed / grep のパターンは `preflight: true` の末尾カンマ
+        # 有無の両方にマッチするよう `,\?` を付与している。これにより
+        # Biome / Prettier 系のフォーマッタが trailing comma を削除する方針に
+        # 変わった場合や、誰かが手動でカンマを消した場合でも検出できる。
+        # 挿入される行は常に `hash: true,` (カンマあり) で固定する。
         run: |
           set -euo pipefail
-          # 末尾カンマまで含めて厳格に判定する。`hash: true` 単独行のような
-          # 部分一致 / 別箇所での hash: true 出現を誤検知しないようにする。
-          if grep -qE '^\s*hash:\s*true,' panda.config.ts; then
+          # 末尾カンマの有無両対応で判定する。`hash: true` 単独行のような
+          # 部分一致 / 別箇所での hash: true 出現を誤検知しないよう、行頭
+          # インデント + key 名 + true + (任意の trailing comma) で限定する。
+          if grep -qE '^\s*hash:\s*true,?\s*$' panda.config.ts; then
             echo "panda.config.ts already has hash:true; skip patch."
           else
-            sed -i 's/^\(\s*\)preflight: true,$/\1preflight: true,\n\1hash: true,/' panda.config.ts
+            sed -i 's/^\(\s*\)preflight: true,\?$/\1preflight: true,\n\1hash: true,/' panda.config.ts
           fi
-          if ! grep -qE '^\s*hash:\s*true,' panda.config.ts; then
-            echo "::error::panda.config.ts への hash:true 挿入に失敗しました。preflight: true, の行が想定どおり存在するか確認してください。"
+          if ! grep -qE '^\s*hash:\s*true,?\s*$' panda.config.ts; then
+            echo "::error::panda.config.ts への hash:true 挿入に失敗しました。preflight 行の書式が想定 (^\\s*preflight: true,?$) と異なる可能性があります。確認ポイント: (1) preflight 行の末尾カンマ有無 (sed の置換失敗) / (2) preflight 行がコメントアウトされていないか / (3) 別記法 (例: preflight: { enabled: true } 等の object 表記) に変わっていないか / (4) 行頭に空白/タブ以外の文字 (YAML マーカー '-' / CR-LF の CR 混入など) が紛れていないか。"
             exit 1
           fi
           echo "--- panda.config.ts (patched head) ---"


### PR DESCRIPTION
## 概要

Issue #527: `.github/workflows/panda-hash-regression.yml` の sed パッチと grep 検証が `preflight: true,` / `hash: true,` の末尾カンマに完全依存していた点を、trailing comma 有無の両対応に変更。Biome / Prettier 系のフォーマッタが trailing comma 方針を変更した場合や、誰かが手動でカンマを削除した場合でも検出できるようにする。

## 変更内容

- `.github/workflows/panda-hash-regression.yml`:
  - sed と grep のパターンに `,\?` (BRE) / `,?` (ERE) を付与し `preflight: true` 行の末尾カンマ有無両方にマッチ
  - 挿入される行は常に `hash: true,` (カンマあり) で固定
  - 挿入失敗時のエラーメッセージに原因切り分けポイントを 4 点列挙 ((1) preflight 行の末尾カンマ有無 / (2) コメントアウト / (3) 別記法 / (4) 行頭に空白/タブ以外の文字混入)
  - step ヘッダコメントの「`preflight: true` 直下」に「(末尾カンマ任意)」を明記

## 備考

- 検証 (DA レビュー Round 1 で perl ベース正規表現等価検算):
  - canonical / no-comma / TAB indent / object 表記 / commented hash 等 8 パターンを検証、いずれも期待通り動作
  - GitHub Actions ubuntu-latest = GNU sed なので `\?` / `\s` / `\n` 右辺すべて動作
- `pnpm test:run` 811 件 全 pass、`pnpm lint` clean
- 失敗時 panda.config.ts 関連行 dump (diagnostic 強化) は別 Issue #572 として follow-up 登録済み
- 関連: #496, #525, #526

Closes #527