### PR TITLE
chore: AnchorPage に publishedAt 推定不可な記事のスキップ件数を画面注記

### DIFF
--- a/src/components/pages/AnchorPage.tsx
+++ b/src/components/pages/AnchorPage.tsx
@@ -79,8 +79,13 @@ interface AnchorPageProps {
  * - `inferPublishedAt(post.id) === null` で除外された記事の件数を、各記事の座標
  *   section 末尾に「publishedAt 推定不可でスキップした記事: N 件」と控えめに表示する
  * - 0 件のときは注記そのものを出さない (= ノイズ削減 + 運用画面の静かなトーン維持)
- * - `role="note"` で補助情報であることを意味的に示し、`data-skipped-count` を
- *   Tripwire 用の構造属性として吐く
+ * - `role="note"` で補助情報であることを意味的に示す。件数は注記テキスト本体に
+ *   埋め込まれるため、Tripwire 検証は `toHaveTextContent` で行う (= 数値メトリクス
+ *   用の data-* カテゴリが CLAUDE.md 規約未確定のため、テキストでの検証に統一)
+ * - 全記事が publishedAt 推定不可で `postEntries` が空になった場合は、「各記事の座標」
+ *   見出し配下に空 `<ul>` を出さず、穏やかな空状態テキスト
+ *   (「全記事が publishedAt 推定不可のためスキップしました (N 件)」) にフォールバック
+ *   する (= 不自然な空 list 表示を回避)
  *
  * デザイン語彙:
  * - Resurface / Coordinate と同じ補助情報トーン (fg.muted / border.subtle)
@@ -258,6 +263,11 @@ interface PostCoordinatesEntry {
  * publishedAt 推定不可な id を持つ記事 (例: テスト用 "test-post") は素直に
  * スキップする (= 結果配列に含めない)。これは「壊れた id の記事はそもそも
  * 座標を計算できない」という anchors.ts の責務境界に整合させた仕様。
+ *
+ * スキップ件数 (= 注記用) は、本関数の呼び出し側で
+ * `posts.length - entries.length` として算出する (Issue #544)。これにより
+ * 「publishedAt 推定不可」の判定軸を本関数 1 箇所に集約し、二重定義による
+ * 将来の乖離リスクを排除する。
  */
 const buildPostCoordinatesEntries = (
   posts: readonly PostSummary[],
@@ -276,34 +286,15 @@ const buildPostCoordinatesEntries = (
 };
 
 /**
- * publishedAt 推定不可でスキップされた記事の件数を数える純粋関数 (Issue #544)。
- *
- * 「壊れた id を持つ記事」が無音で消える状況を運用画面の末尾に注記として
- * 出すために使う。`buildPostCoordinatesEntries` と判定軸を揃え、`inferPublishedAt`
- * が `null` を返す件数を素直にカウントする。
- *
- * 注: ここで件数算出を別関数に切り出しているのは、`buildPostCoordinatesEntries`
- * の戻り値型を肥大化させずに「描画対象エントリ」と「注記の数値」という別関心を
- * 分離するため。
- */
-const countSkippedByPublishedAt = (posts: readonly PostSummary[]): number => {
-  let count = 0;
-  for (const post of posts) {
-    if (inferPublishedAt(post.id) === null) {
-      count += 1;
-    }
-  }
-  return count;
-};
-
-/**
  * AnchorPage コンポーネント本体。
  */
 export const AnchorPage = memo(({ posts, milestones }: AnchorPageProps) => {
   const postEntries = buildPostCoordinatesEntries(posts, milestones);
-  // publishedAt 推定不可でスキップされた記事の件数 (Issue #544)
-  // 0 件のときは注記そのものを出さない (= ノイズ削減)。
-  const skippedCount = countSkippedByPublishedAt(posts);
+  // publishedAt 推定不可でスキップされた記事の件数 (Issue #544)。
+  // 「publishedAt 推定不可」の判定軸は `buildPostCoordinatesEntries` 内に集約
+  // されており、ここでは入力件数と描画対象件数の差分で算出する (= 二重定義の
+  // 乖離リスクを排除)。0 件のときは注記そのものを出さない (= ノイズ削減)。
+  const skippedCount = posts.length - postEntries.length;
 
   return (
     <div className={containerStyles}>
@@ -376,49 +367,58 @@ export const AnchorPage = memo(({ posts, milestones }: AnchorPageProps) => {
             <h2 id="anchor-posts-heading" className={sectionHeadingStyles}>
               各記事の座標
             </h2>
-            {/* biome-ignore lint/a11y/noRedundantRoles: Safari/VoiceOver で list-style: none を当てた ul の list セマンティクスが剥奪される既知の WebKit バグへの防御として role="list" を明示する */}
-            <ul className={postListStyles} role="list">
-              {postEntries.map((entry) => (
-                <li
-                  key={entry.post.id}
-                  className={postItemStyles}
-                  data-token-border="border.subtle"
-                >
-                  <span className={postTitleStyles}>
-                    {entry.post.title || "無題の記事"}
-                  </span>
-                  {entry.coordinates.length === 0 ? (
-                    <span className={emptyStateStyles}>
-                      まだ通過した節目はありません
-                    </span>
-                  ) : (
-                    <div className={postCoordinatesStyles}>
-                      {entry.coordinates.map((coordinate) => (
-                        <span
-                          key={`${coordinate.label}-${coordinate.daysSince}`}
-                          data-tone={coordinate.tone}
-                        >
-                          {buildCoordinateLabel(coordinate)}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </li>
-              ))}
-            </ul>
-            {/* publishedAt 推定不可な記事のスキップ件数注記 (Issue #544)
-                運用画面として「壊れた id がある事実」を画面に出すための添え書き。
-                0 件のときは注記そのものを出さない (= ノイズ削減 + 運用画面の
-                控えめなトーンを維持)。 */}
-            {skippedCount > 0 ? (
-              <p
-                className={skippedNoteStyles}
-                data-skipped-count={skippedCount}
-                role="note"
-              >
-                publishedAt 推定不可でスキップした記事: {skippedCount} 件
+            {postEntries.length === 0 ? (
+              // 全記事が publishedAt 推定不可だった場合のフォールバック (Issue #544)。
+              // 空 `<ul>` を出すと「各記事の座標」見出し + 空 list + 注記という
+              // 不自然な画面になるため、穏やかな空状態テキストにまとめる。
+              // i18n: Issue #534 で定数化候補
+              <p className={emptyStateStyles} role="note">
+                {`全記事が publishedAt 推定不可のためスキップしました (${skippedCount} 件)`}
               </p>
-            ) : null}
+            ) : (
+              <>
+                {/* biome-ignore lint/a11y/noRedundantRoles: Safari/VoiceOver で list-style: none を当てた ul の list セマンティクスが剥奪される既知の WebKit バグへの防御として role="list" を明示する */}
+                <ul className={postListStyles} role="list">
+                  {postEntries.map((entry) => (
+                    <li
+                      key={entry.post.id}
+                      className={postItemStyles}
+                      data-token-border="border.subtle"
+                    >
+                      <span className={postTitleStyles}>
+                        {entry.post.title || "無題の記事"}
+                      </span>
+                      {entry.coordinates.length === 0 ? (
+                        <span className={emptyStateStyles}>
+                          まだ通過した節目はありません
+                        </span>
+                      ) : (
+                        <div className={postCoordinatesStyles}>
+                          {entry.coordinates.map((coordinate) => (
+                            <span
+                              key={`${coordinate.label}-${coordinate.daysSince}`}
+                              data-tone={coordinate.tone}
+                            >
+                              {buildCoordinateLabel(coordinate)}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+                {/* publishedAt 推定不可な記事のスキップ件数注記 (Issue #544)
+                    運用画面として「壊れた id がある事実」を画面に出すための添え書き。
+                    0 件のときは注記そのものを出さない (= ノイズ削減 + 運用画面の
+                    控えめなトーンを維持)。
+                    i18n: Issue #534 で定数化候補 */}
+                {skippedCount > 0 ? (
+                  <p className={skippedNoteStyles} role="note">
+                    publishedAt 推定不可でスキップした記事: {skippedCount} 件
+                  </p>
+                ) : null}
+              </>
+            )}
           </section>
         )}
       </div>

--- a/src/components/pages/AnchorPage.tsx
+++ b/src/components/pages/AnchorPage.tsx
@@ -75,6 +75,13 @@ interface AnchorPageProps {
  * - 各記事の座標 section に `aria-labelledby` で見出しを紐付け SR 読み上げを統一
  * - 節目の tone は `data-tone` 属性で表現する (色だけに依存させない)
  *
+ * publishedAt 推定不可なスキップ件数注記 (Issue #544):
+ * - `inferPublishedAt(post.id) === null` で除外された記事の件数を、各記事の座標
+ *   section 末尾に「publishedAt 推定不可でスキップした記事: N 件」と控えめに表示する
+ * - 0 件のときは注記そのものを出さない (= ノイズ削減 + 運用画面の静かなトーン維持)
+ * - `role="note"` で補助情報であることを意味的に示し、`data-skipped-count` を
+ *   Tripwire 用の構造属性として吐く
+ *
  * デザイン語彙:
  * - Resurface / Coordinate と同じ補助情報トーン (fg.muted / border.subtle)
  * - Editorial 雑誌風の小型見出し (uppercase + tracking) で章間を意識
@@ -210,6 +217,18 @@ const emptyStateStyles = css({
   paddingY: "md",
 });
 
+// publishedAt 推定不可でスキップした記事の件数注記。Issue #544 で追加。
+// 運用画面の透明性を優先するため、件数 N >= 1 のとき末尾に小さく出す。
+// emptyStateStyles と同じ補助情報トーン (fg.muted) に揃え、過剰可視化を避ける。
+// section の枠 (= border.subtle の境界) は重ねず、文章として控えめに添える。
+const skippedNoteStyles = css({
+  fontSize: "xs",
+  color: "fg.muted",
+  lineHeight: "relaxed",
+  paddingTop: "md",
+  fontVariantNumeric: "tabular-nums",
+});
+
 /**
  * 座標 1 件の表示文言を構築する純粋関数。
  *
@@ -257,10 +276,34 @@ const buildPostCoordinatesEntries = (
 };
 
 /**
+ * publishedAt 推定不可でスキップされた記事の件数を数える純粋関数 (Issue #544)。
+ *
+ * 「壊れた id を持つ記事」が無音で消える状況を運用画面の末尾に注記として
+ * 出すために使う。`buildPostCoordinatesEntries` と判定軸を揃え、`inferPublishedAt`
+ * が `null` を返す件数を素直にカウントする。
+ *
+ * 注: ここで件数算出を別関数に切り出しているのは、`buildPostCoordinatesEntries`
+ * の戻り値型を肥大化させずに「描画対象エントリ」と「注記の数値」という別関心を
+ * 分離するため。
+ */
+const countSkippedByPublishedAt = (posts: readonly PostSummary[]): number => {
+  let count = 0;
+  for (const post of posts) {
+    if (inferPublishedAt(post.id) === null) {
+      count += 1;
+    }
+  }
+  return count;
+};
+
+/**
  * AnchorPage コンポーネント本体。
  */
 export const AnchorPage = memo(({ posts, milestones }: AnchorPageProps) => {
   const postEntries = buildPostCoordinatesEntries(posts, milestones);
+  // publishedAt 推定不可でスキップされた記事の件数 (Issue #544)
+  // 0 件のときは注記そのものを出さない (= ノイズ削減)。
+  const skippedCount = countSkippedByPublishedAt(posts);
 
   return (
     <div className={containerStyles}>
@@ -363,6 +406,19 @@ export const AnchorPage = memo(({ posts, milestones }: AnchorPageProps) => {
                 </li>
               ))}
             </ul>
+            {/* publishedAt 推定不可な記事のスキップ件数注記 (Issue #544)
+                運用画面として「壊れた id がある事実」を画面に出すための添え書き。
+                0 件のときは注記そのものを出さない (= ノイズ削減 + 運用画面の
+                控えめなトーンを維持)。 */}
+            {skippedCount > 0 ? (
+              <p
+                className={skippedNoteStyles}
+                data-skipped-count={skippedCount}
+                role="note"
+              >
+                publishedAt 推定不可でスキップした記事: {skippedCount} 件
+              </p>
+            ) : null}
           </section>
         )}
       </div>

--- a/src/components/pages/__tests__/AnchorPage.test.tsx
+++ b/src/components/pages/__tests__/AnchorPage.test.tsx
@@ -208,6 +208,169 @@ describe("AnchorPage", () => {
     });
   });
 
+  describe("publishedAt 推定不可な記事のスキップ件数注記 (Issue #544)", () => {
+    it("スキップ対象が 0 件のとき注記は表示しない", () => {
+      // basePosts は 2 件とも YYYYMMDDhhmmss 形式の正常 id なので、
+      // スキップは発生しない。このとき注記は描画されない。
+      render(
+        <MemoryRouter>
+          <AnchorPage posts={basePosts} milestones={baseMilestones} />
+        </MemoryRouter>,
+      );
+
+      expect(
+        screen.queryByText(/publishedAt 推定不可でスキップした記事/),
+      ).not.toBeInTheDocument();
+      // role="note" でも検出されないこと (= ノイズ削減の意図)
+      expect(screen.queryByRole("note")).not.toBeInTheDocument();
+    });
+
+    it("スキップ対象が 1 件のとき件数注記を表示する", () => {
+      const invalidPost: PostSummary = {
+        id: "test-invalid-id",
+        title: "壊れた id の記事",
+        createdAt: "2025-09-05",
+        author: "amkkr",
+        excerpt: "テスト",
+        readingTimeMinutes: 1,
+      };
+
+      render(
+        <MemoryRouter>
+          <AnchorPage
+            posts={[invalidPost, ...basePosts]}
+            milestones={baseMilestones}
+          />
+        </MemoryRouter>,
+      );
+
+      // 注記が role="note" として検出できる
+      const note = screen.getByRole("note");
+      expect(note).toBeInTheDocument();
+      expect(note).toHaveTextContent(
+        "publishedAt 推定不可でスキップした記事: 1 件",
+      );
+    });
+
+    it("スキップ対象が複数件のとき件数を正しく集計して表示する", () => {
+      const invalidPosts: PostSummary[] = [
+        {
+          id: "test-invalid-1",
+          title: "壊れた id 1",
+          createdAt: "2025-09-05",
+          author: "amkkr",
+          excerpt: "テスト1",
+          readingTimeMinutes: 1,
+        },
+        {
+          id: "broken",
+          title: "壊れた id 2",
+          createdAt: "2025-09-05",
+          author: "amkkr",
+          excerpt: "テスト2",
+          readingTimeMinutes: 1,
+        },
+        {
+          id: "12345",
+          title: "桁数が足りない id",
+          createdAt: "2025-09-05",
+          author: "amkkr",
+          excerpt: "テスト3",
+          readingTimeMinutes: 1,
+        },
+      ];
+
+      render(
+        <MemoryRouter>
+          <AnchorPage
+            posts={[...invalidPosts, ...basePosts]}
+            milestones={baseMilestones}
+          />
+        </MemoryRouter>,
+      );
+
+      const note = screen.getByRole("note");
+      expect(note).toHaveTextContent(
+        "publishedAt 推定不可でスキップした記事: 3 件",
+      );
+    });
+
+    it("全記事が publishedAt 推定不可のとき全件をスキップ件数として注記する", () => {
+      const invalidPosts: PostSummary[] = [
+        {
+          id: "test-invalid-1",
+          title: "壊れた id 1",
+          createdAt: "2025-09-05",
+          author: "amkkr",
+          excerpt: "テスト1",
+          readingTimeMinutes: 1,
+        },
+        {
+          id: "test-invalid-2",
+          title: "壊れた id 2",
+          createdAt: "2025-09-05",
+          author: "amkkr",
+          excerpt: "テスト2",
+          readingTimeMinutes: 1,
+        },
+      ];
+
+      render(
+        <MemoryRouter>
+          <AnchorPage posts={invalidPosts} milestones={baseMilestones} />
+        </MemoryRouter>,
+      );
+
+      // 各記事の座標 section 自体は出る (posts.length > 0 なので)
+      const postSection = screen.getByRole("region", {
+        name: "各記事の座標",
+      });
+      expect(postSection).toBeInTheDocument();
+      // 注記は posts 全件 (= 2 件) を反映する
+      const note = screen.getByRole("note");
+      expect(note).toHaveTextContent(
+        "publishedAt 推定不可でスキップした記事: 2 件",
+      );
+    });
+
+    it("posts が 0 件のとき注記そのものを出さない (各記事の座標 section ごと非表示のため)", () => {
+      render(
+        <MemoryRouter>
+          <AnchorPage posts={[]} milestones={baseMilestones} />
+        </MemoryRouter>,
+      );
+
+      // 各記事の座標 region 自体が出ないため、注記も同伴して出ない
+      expect(screen.queryByRole("note")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/publishedAt 推定不可でスキップした記事/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("スキップ件数注記の Tripwire 属性 (data-skipped-count) が件数と一致する", () => {
+      const invalidPost: PostSummary = {
+        id: "broken-id",
+        title: "壊れた id",
+        createdAt: "2025-09-05",
+        author: "amkkr",
+        excerpt: "テスト",
+        readingTimeMinutes: 1,
+      };
+
+      render(
+        <MemoryRouter>
+          <AnchorPage
+            posts={[invalidPost, ...basePosts]}
+            milestones={baseMilestones}
+          />
+        </MemoryRouter>,
+      );
+
+      const note = screen.getByRole("note");
+      expect(note).toHaveAttribute("data-skipped-count", "1");
+    });
+  });
+
   describe("過剰可視化の禁止", () => {
     it("投稿頻度に関する文言を含まない", () => {
       const { container } = render(

--- a/src/components/pages/__tests__/AnchorPage.test.tsx
+++ b/src/components/pages/__tests__/AnchorPage.test.tsx
@@ -295,7 +295,11 @@ describe("AnchorPage", () => {
       );
     });
 
-    it("全記事が publishedAt 推定不可のとき全件をスキップ件数として注記する", () => {
+    it("全記事が publishedAt 推定不可のとき空 list を出さず穏やかな空状態テキストにフォールバックする", () => {
+      // 全 posts が壊れた id の場合、`postEntries.length === 0` となる。
+      // ここで空 `<ul>` を描画すると「各記事の座標」見出し + 空 list + 注記の
+      // 不自然な画面になるため、フォールバックとして 1 行の空状態テキスト
+      // (= 全件スキップである事実を件数とともに伝える) のみを出す。
       const invalidPosts: PostSummary[] = [
         {
           id: "test-invalid-1",
@@ -326,11 +330,20 @@ describe("AnchorPage", () => {
         name: "各記事の座標",
       });
       expect(postSection).toBeInTheDocument();
-      // 注記は posts 全件 (= 2 件) を反映する
-      const note = screen.getByRole("note");
+      // フォールバックテキストが描画される
+      const note = within(postSection).getByRole("note");
       expect(note).toHaveTextContent(
-        "publishedAt 推定不可でスキップした記事: 2 件",
+        "全記事が publishedAt 推定不可のためスキップしました (2 件)",
       );
+      // 空 `<ul>` (= 各記事を並べる list) は出さない
+      expect(within(postSection).queryByRole("list")).not.toBeInTheDocument();
+      // 通常の件数注記 (「publishedAt 推定不可でスキップした記事: N 件」) は出さない
+      // (= フォールバックテキストに件数を埋め込んでいるため二重表示を避ける)
+      expect(
+        within(postSection).queryByText(
+          /publishedAt 推定不可でスキップした記事:/,
+        ),
+      ).not.toBeInTheDocument();
     });
 
     it("posts が 0 件のとき注記そのものを出さない (各記事の座標 section ごと非表示のため)", () => {
@@ -345,29 +358,6 @@ describe("AnchorPage", () => {
       expect(
         screen.queryByText(/publishedAt 推定不可でスキップした記事/),
       ).not.toBeInTheDocument();
-    });
-
-    it("スキップ件数注記の Tripwire 属性 (data-skipped-count) が件数と一致する", () => {
-      const invalidPost: PostSummary = {
-        id: "broken-id",
-        title: "壊れた id",
-        createdAt: "2025-09-05",
-        author: "amkkr",
-        excerpt: "テスト",
-        readingTimeMinutes: 1,
-      };
-
-      render(
-        <MemoryRouter>
-          <AnchorPage
-            posts={[invalidPost, ...basePosts]}
-            milestones={baseMilestones}
-          />
-        </MemoryRouter>,
-      );
-
-      const note = screen.getByRole("note");
-      expect(note).toHaveAttribute("data-skipped-count", "1");
     });
   });
 


### PR DESCRIPTION
## 概要

Issue #544: AnchorPage は `publishedAt === null` の post を無音でスキップしているため、運用画面なのに「壊れた id がある事実」が画面に出ないバグの温床になっていた。スキップ件数の小さな注記を追加して運用透明性を担保する。

採用案: **案A** (件数注記、N=0 のときは非表示)

## 変更内容

### 初期実装 (3f7de49)

- `src/components/pages/AnchorPage.tsx`: `inferPublishedAt === null` でスキップした件数を末尾に `role="note"` で表示
- `src/components/pages/__tests__/AnchorPage.test.tsx`: 0件 / 1件 / 複数件 / 全件スキップ / posts=0 / Tripwire の境界テスト追加

### DA レビュー対応 fixup (b29082f)

- **判定軸統一 (必須)**: `countSkippedByPublishedAt` を削除し `skippedCount = posts.length - postEntries.length` の差分で算出。`buildPostCoordinatesEntries` 1 箇所にスキップ判定軸を集約 (将来の判定軸乖離リスクを排除)
- **空 ul フォールバック (推奨)**: `postEntries.length === 0` のとき空 `<ul>` を出さず、`role="note"` 付きフォールバックテキスト「全記事が publishedAt 推定不可のためスキップしました (N 件)」に置換
- **data-skipped-count 削除 (任意)**: CLAUDE.md の data-* 規約に「数値メトリクス属性」カテゴリが未確定のため、属性を削除し `toHaveTextContent` で同等検証
- **i18n コメント追記 (任意)**: 注記文言 2 箇所に「i18n: Issue #534 で定数化候補」JSDoc コメントを追加

## 備考

- 検証: `pnpm test:run` 50 files / 816 件 全 pass、`pnpm lint` clean、axe a11y 違反 0 件
- テスト件数 (本機能分): 6 → 5 (data-skipped-count Tripwire テスト削除分、AnchorPage.test.tsx 全体は 20 → 19 件)
- `role="note"` はプロジェクト初導入。axe は pass、`<aside>` への移行は将来検討の余地あり (Weak)
- Reviewer: APPROVE / DA: CONDITIONAL (全条件対応済み)

Closes #544