### PR TITLE
chore: scripts/newPost.ts の IgnitionInput 新フィールド追加時の Anchor 型縮退再発を構造的に防ぐ

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,23 @@
 -
 
 ## 備考
+
+## チェックリスト (Anchor 型を扱うとき) (Issue #556)
+
+<!--
+`scripts/newPost.ts` の `IgnitionInput` などに「Coordinate / Elapsed (Anchor 型)
+を要素として含むフィールド」を新規追加・変更する場合のみ以下を確認する。
+無関係な PR ではセクションごと削除してよい。
+-->
+
+- [ ] 新フィールドの型宣言で `Coordinate` / `Elapsed` (またはそれらを要素とする
+      `readonly Coordinate[]` / `Elapsed | null` 等) を `src/lib/anchors.ts` から
+      `import type` で参照しているか
+- [ ] 構造的リテラル `{ label, tone, daysSince }[]` のようなハンドメイドな
+      型宣言になっていないか (discriminator `kind` の欠落 = サイレント縮退の
+      入口になるため。`scripts/newPost.ts` の
+      `EnforceAnchorDiscriminatorFields` 型レベルガードが `type-check:test` で
+      検知するが、ガード追加忘れを防ぐためレビュー時点でも確認すること)
+- [ ] 必要に応じて `scripts/__tests__/newPost.test.ts` の「型レベル: Anchor
+      field 構造的縮退の予防ガード (Issue #556)」ブロックに、追加した
+      フィールド向けの `@ts-expect-error` 回帰固定テストを足したか

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,12 +6,13 @@
 
 ## 備考
 
-## チェックリスト (Anchor 型を扱うとき) (Issue #556)
+<details>
+<summary>Anchor 型を扱う PR のみチェック (Issue #556)</summary>
 
 <!--
 `scripts/newPost.ts` の `IgnitionInput` などに「Coordinate / Elapsed (Anchor 型)
 を要素として含むフィールド」を新規追加・変更する場合のみ以下を確認する。
-無関係な PR ではセクションごと削除してよい。
+dependabot / chore など Anchor 型と無関係な PR では本ブロックは無視してよい。
 -->
 
 - [ ] 新フィールドの型宣言で `Coordinate` / `Elapsed` (またはそれらを要素とする
@@ -25,3 +26,5 @@
 - [ ] 必要に応じて `scripts/__tests__/newPost.test.ts` の「型レベル: Anchor
       field 構造的縮退の予防ガード (Issue #556)」ブロックに、追加した
       フィールド向けの `@ts-expect-error` 回帰固定テストを足したか
+
+</details>

--- a/scripts/__tests__/newPost.test.ts
+++ b/scripts/__tests__/newPost.test.ts
@@ -37,14 +37,19 @@ import {
   buildIgnitionComment,
   buildPostMarkdown,
   computeSiteOpeningFallback,
+  type EnforceAnchorDiscriminatorField_ForTest,
+  type EnforceAnchorDiscriminatorFields_ForTest,
   escapeHtmlCommentLabel,
   extractMarkdownTitle,
   findPreviousPost,
   formatMilestonesSummary,
+  type HasAnchorDiscriminator_ForTest,
   type IgnitionInput,
+  type IsAnchorShape_ForTest,
   listPostFileNames,
   loadMilestones,
 } from "../newPost.ts";
+import type { Coordinate, Elapsed } from "../../src/lib/anchors.ts";
 
 // =============================================================================
 // 一時ディレクトリ用ヘルパ
@@ -728,5 +733,191 @@ describe("型レベル: IgnitionInput.coordinates の discriminator 化 (Issue #
     };
 
     void input;
+  });
+});
+
+// =============================================================================
+// 型レベル: Anchor field 構造的縮退の予防ガード (Issue #556)
+// =============================================================================
+//
+// 目的: PR #555 (Issue #523) の DA レビュー F2 で指摘された follow-up を
+// 解決する。`IgnitionInput` に「将来 Coordinate / Elapsed を含む新フィールド
+// (例: `resurfaceCoordinates: readonly Coordinate[]`) を追加するとき」に、
+// `kind` discriminator を欠いた構造的リテラル型で書いてしまうと型エラーに
+// なる仕組みを `EnforceAnchorDiscriminatorFields_ForTest` として持っている
+// ことを、型レベルで回帰固定する。
+//
+// 検証手段: Issue #523 と同じ `@ts-expect-error` パターン。ガードロジックの
+// Conditional Type が「Anchor 型らしい (label + daysSince) のに kind を
+// 欠いている」フィールドを `never` に潰すことで、`IgnitionInput` への代入が
+// 不可能になることを利用する。
+//
+// 本 Issue で導入したヘルパ (`IsAnchorShape_ForTest` 等) はテスト専用 export
+// として扱い、本体 `IgnitionInput` の interface 定義はそのまま維持する。
+// これにより既存呼び出し側 (scripts/newPost.ts 自身および 12 ヶ所のテスト)
+// との完全な後方互換を保つ。
+describe("型レベル: Anchor field 構造的縮退の予防ガード (Issue #556)", () => {
+  it("正規の Coordinate / Elapsed を含む shape は `EnforceAnchorDiscriminatorFields_ForTest` を通過する (= IgnitionInput と互換)", () => {
+    // 現行の `IgnitionInput` 自身が、ガードを通したあとの型と互換である
+    // ことを `extends` で確認する。
+    // (ガードが壊れて余分なフィールドを `never` に潰すと、この代入が
+    //  unused @ts-expect-error 化されて type-check:test が失敗する)
+    type GuardedIgnitionInput =
+      EnforceAnchorDiscriminatorFields_ForTest<IgnitionInput>;
+    const guarded: GuardedIgnitionInput = {
+      coordinates: [
+        { kind: "coordinate", label: "x", tone: "neutral", daysSince: 1 },
+      ],
+      siteOpeningElapsed: { kind: "elapsed", label: "y", daysSince: 2 },
+      previousPost: null,
+      publishedAt: "2025-01-01T12:00:00+09:00",
+    };
+
+    // 現行 IgnitionInput をそのまま代入できる ≒ ガードが既存 shape を
+    // 何ら壊していないこと。
+    const input: IgnitionInput = guarded;
+    void input;
+  });
+
+  it("Coordinate 単独要素は `kind` discriminator を持つため `IsAnchorShape_ForTest` + `HasAnchorDiscriminator_ForTest` の両方を通過する", () => {
+    // 「Anchor 型らしい (label + daysSince)」かつ「discriminator を持つ」=
+    // ガード判定上 ESCAPABLE な要素であることを型レベルで固定。
+    type IsShape = IsAnchorShape_ForTest<Coordinate>;
+    type HasKind = HasAnchorDiscriminator_ForTest<Coordinate>;
+    const isShape: IsShape = true;
+    const hasKind: HasKind = true;
+    void isShape;
+    void hasKind;
+  });
+
+  it("Elapsed 単独要素も同様に `IsAnchorShape_ForTest` + `HasAnchorDiscriminator_ForTest` の両方を通過する", () => {
+    type IsShape = IsAnchorShape_ForTest<Elapsed>;
+    type HasKind = HasAnchorDiscriminator_ForTest<Elapsed>;
+    const isShape: IsShape = true;
+    const hasKind: HasKind = true;
+    void isShape;
+    void hasKind;
+  });
+
+  it("構造的リテラル `{ label, tone, daysSince }` (Anchor 型らしいが kind 欠落) は `HasAnchorDiscriminator_ForTest` で false 判定される", () => {
+    type LooseCoord = {
+      readonly label: string;
+      readonly tone: "neutral";
+      readonly daysSince: number;
+    };
+    type IsShape = IsAnchorShape_ForTest<LooseCoord>;
+    type HasKind = HasAnchorDiscriminator_ForTest<LooseCoord>;
+    // Anchor 型らしい (label + daysSince を持つ) と判定される
+    const isShape: IsShape = true;
+    // しかし kind discriminator が無いため false
+    const hasKind: HasKind = false;
+    void isShape;
+    void hasKind;
+  });
+
+  it("`kind: string` (wide string) では `HasAnchorDiscriminator_ForTest` が false を返す (string literal narrowing 必須)", () => {
+    // `kind: string` を許容してしまうと「kind 必須」のはずが any string で
+    // 通ってしまい構造的縮退に逆戻りする。string literal narrowing が
+    // 必須であることをガードロジックの仕様として固定する。
+    type WideKindCoord = {
+      readonly kind: string;
+      readonly label: string;
+      readonly tone: "neutral";
+      readonly daysSince: number;
+    };
+    type HasKind = HasAnchorDiscriminator_ForTest<WideKindCoord>;
+    const hasKind: HasKind = false;
+    void hasKind;
+  });
+
+  it("Anchor 型と無関係なフィールド型 (`string` / `PreviousPost`) には何も制約を課さない", () => {
+    // ガードは「Anchor 型らしい」フィールドにのみ作用する。Anchor 型と
+    // 構造が違うフィールド (publishedAt: string / previousPost: object) は
+    // そのまま通過する。これにより `IgnitionInput` 拡張時に Anchor 型と
+    // 無関係な新フィールド (例: `siteVersion: string`) を追加する自由は
+    // 維持される。
+    type PassThroughString =
+      EnforceAnchorDiscriminatorField_ForTest<string>;
+    type PassThroughPreviousPost = EnforceAnchorDiscriminatorField_ForTest<{
+      readonly fileName: string;
+      readonly title: string;
+      readonly publishedAt: string;
+    }>;
+    const s: PassThroughString = "x";
+    const p: PassThroughPreviousPost = {
+      fileName: "a.md",
+      title: "t",
+      publishedAt: "2025-01-01T12:00:00+09:00",
+    };
+    void s;
+    void p;
+  });
+
+  it("新フィールド (例: `resurfaceCoordinates`) を `IgnitionInput` 風の interface に追加する想定で、Anchor 型を import すれば通過する", () => {
+    // Issue #556 の想定シナリオ:
+    //   IgnitionInput に `resurfaceCoordinates: readonly Coordinate[]` を
+    //   追加する場合、`Coordinate` 型を import していればガードを通る。
+    interface FutureIgnitionInput {
+      readonly coordinates: readonly Coordinate[];
+      readonly resurfaceCoordinates: readonly Coordinate[];
+      readonly siteOpeningElapsed: Elapsed | null;
+      readonly publishedAt: string;
+    }
+    // ガードを通した結果が元と一致する = 構造的に Anchor 型らしいフィールド
+    // がすべて kind 必須を満たしている。
+    type Guarded = EnforceAnchorDiscriminatorFields_ForTest<FutureIgnitionInput>;
+    const ok: Guarded = {
+      coordinates: [
+        { kind: "coordinate", label: "x", tone: "neutral", daysSince: 1 },
+      ],
+      resurfaceCoordinates: [
+        { kind: "coordinate", label: "y", tone: "light", daysSince: 2 },
+      ],
+      siteOpeningElapsed: null,
+      publishedAt: "2025-01-01T12:00:00+09:00",
+    };
+    void ok;
+  });
+
+  it("新フィールドを `Coordinate` を import せず構造的リテラル `{ label, tone, daysSince }[]` で宣言した場合、ガードはそのフィールド型を `never` に潰す", () => {
+    // Issue #556 の中心 AC:
+    //   新フィールド追加時に Anchor 型を import せず構造的リテラルで
+    //   書いてしまうと、ガードがそのフィールドを `never` に潰す。
+    //   never[] への代入は不可能なので、開発者は型エラーで気付ける。
+    interface BadFutureIgnitionInput {
+      readonly resurfaceCoordinates: readonly {
+        label: string;
+        tone: "neutral";
+        daysSince: number;
+      }[];
+    }
+    type Guarded =
+      EnforceAnchorDiscriminatorFields_ForTest<BadFutureIgnitionInput>;
+    // ガード適用後 `resurfaceCoordinates` は `readonly never[]` に潰される
+    // ため、構造的リテラル値の代入は失敗する。
+    const bad: Guarded = {
+      // @ts-expect-error - kind 欠落の構造的リテラル型は never[] に
+      // 潰されるためここに代入できない (Issue #556 回帰防止: ガードが
+      // 弱まり Anchor field が素通しに戻ると unused @ts-expect-error
+      // になって type-check:test が失敗する)
+      resurfaceCoordinates: [{ label: "x", tone: "neutral", daysSince: 1 }],
+    };
+    void bad;
+  });
+
+  it("新フィールドを `kind: \"elapsed\"` (Elapsed 由来) で宣言した場合は discriminator を持つため通過する (Coordinate / Elapsed 横断対応)", () => {
+    // ガードは特定の discriminator 値 (例: `\"coordinate\"`) ではなく
+    // 「kind が string literal で存在すること」を判定する。これにより
+    // 将来 `Resurface` 等の新しい Anchor 系 layer (`kind: \"resurface\"` 等)
+    // が追加されても破綻しない。
+    interface ElapsedFieldIgnitionInput {
+      readonly secondaryElapsed: Elapsed | null;
+    }
+    type Guarded =
+      EnforceAnchorDiscriminatorFields_ForTest<ElapsedFieldIgnitionInput>;
+    const ok: Guarded = {
+      secondaryElapsed: { kind: "elapsed", label: "x", daysSince: 1 },
+    };
+    void ok;
   });
 });

--- a/scripts/newPost.ts
+++ b/scripts/newPost.ts
@@ -56,12 +56,137 @@ export interface PreviousPost {
   readonly publishedAt: string;
 }
 
+// -----------------------------------------------------------------------------
+// 型レベルガード (Issue #556): Anchor 型 (Coordinate / Elapsed) 縮退の構造的予防
+// -----------------------------------------------------------------------------
+//
+// 目的:
+//   PR #555 (Issue #523) で `IgnitionInput.coordinates` を `readonly Coordinate[]`
+//   に統一して discriminator (`kind`) 縮退を解消したが、将来 `IgnitionInput` に
+//   新フィールド (例: `resurfaceCoordinates: readonly Coordinate[]`) が増えたとき
+//   に、開発者が `Coordinate` を import せず構造的リテラル
+//   (`{ label, tone, daysSince }[]`) で書いてしまうと、再び discriminator が
+//   剥がれた縮退状態に逆戻りする可能性がある。
+//
+// 防御方針:
+//   `IgnitionInput` の各フィールドを Conditional Type で走査し、
+//   「Anchor 型らしいフィールド (= Coordinate / Elapsed と構造的に互換)」が
+//   `kind` discriminator を持たないと型エラーになる制約を課す。
+//   これにより、`IgnitionInput` に新フィールドを追加する際:
+//   - `readonly Coordinate[]` / `readonly Elapsed[]` 等の Anchor 型由来の宣言
+//     なら `kind` が自然に含まれるため pass
+//   - 構造的リテラル `{ label, tone, daysSince }[]` 等の hand-rolled な宣言は
+//     コンパイル時に rejected され、必ず Anchor 型を import するよう誘導される
+//
+// 設計判断:
+//   - branded type / 別名 import 強制ではなく Conditional Type を採用したのは、
+//     既存呼び出し側 (scripts/newPost.ts 自身) と完全な後方互換を保ち、新規
+//     フィールド追加時のみ effective に働く「opt-in 不要のゼロコストガード」
+//     にするため。
+//   - lint rule (案 B) は新規開発が必要で重く、メモリ「外部ライブラリの追加は
+//     原則しない」と整合しない。Conditional Type なら型システムだけで完結する。
+//   - 完全な「Coordinate-like 自動判定」は型システムだけでは難しいが、
+//     `label` + `daysSince` を持つ要素型を抽出して discriminator の存在を
+//     必須化する程度には現実的に書ける。
+
+/**
+ * Anchor 型 (Coordinate / Elapsed) が共通で持つ discriminator field の名前
+ *
+ * - Coordinate: `kind: "coordinate"`
+ * - Elapsed:    `kind: "elapsed"`
+ *
+ * 新しい Anchor 系 layer が追加された場合 (例: `Resurface` で
+ * `kind: "resurface"` を持つ等) も、`kind` discriminator field を持っている
+ * 限り本ガードは破綻しない (`HasAnchorDiscriminator` の判定が string literal
+ * の存在チェックに留まるため、新しい discriminator 値を許容する設計)。
+ */
+type AnchorDiscriminatorKey = "kind";
+
+/**
+ * Anchor 型らしい要素型かどうかを判定する Conditional Type
+ *
+ * - 「Anchor 型らしい」を `label: string` と `daysSince: number` の両方を
+ *   持つこと、と定義する (Coordinate / Elapsed の共通最小スキーマ)。
+ * - これに該当する要素型のみ discriminator 必須を強制する。該当しない型
+ *   (例: `string` / `PreviousPost`) には何も制約を課さない。
+ */
+type IsAnchorShape<T> = T extends { readonly label: string; readonly daysSince: number }
+  ? true
+  : false;
+
+/**
+ * Anchor 型らしい要素が discriminator `kind` を string literal で
+ * 持っているかどうかを判定する
+ *
+ * - `kind: string` のような wide string では unsafe (構造的縮退に
+ *   逆戻りする) ため、string literal (= `"coordinate"` / `"elapsed"` 等)
+ *   のみを「持っている」とみなす。
+ */
+type HasAnchorDiscriminator<T> = T extends {
+  readonly [K in AnchorDiscriminatorKey]: infer Kind;
+}
+  ? Kind extends string
+    ? string extends Kind
+      ? false
+      : true
+    : false
+  : false;
+
+/**
+ * フィールド単位での Anchor 型ガード判定
+ *
+ * - `readonly T[]` の場合は要素型 T に対して判定を再帰する
+ * - `T | null` の場合は非 null 部分のみで判定する
+ * - 上記の組み合わせ (`readonly T[] | null` 等) も同様にハンドリングする
+ *
+ * 戻り値:
+ *   - フィールドが Anchor 型らしくない → そのフィールド型をそのまま返す
+ *   - Anchor 型らしく、かつ discriminator を持つ → そのフィールド型をそのまま返す
+ *   - Anchor 型らしいのに discriminator を持たない → never に潰す
+ *     (= プロパティが never の object には代入できない = コンパイル時 reject)
+ */
+type EnforceAnchorDiscriminatorField<T> = T extends readonly (infer U)[]
+  ? IsAnchorShape<U> extends true
+    ? HasAnchorDiscriminator<U> extends true
+      ? T
+      : never
+    : T
+  : T extends null
+    ? T
+    : IsAnchorShape<T> extends true
+      ? HasAnchorDiscriminator<T> extends true
+        ? T
+        : never
+      : T;
+
+/**
+ * オブジェクト型 (interface) の全フィールドに `EnforceAnchorDiscriminatorField`
+ * を適用するヘルパ
+ *
+ * - フィールド単位で型を写像する mapped type
+ * - フィールドの readonly 修飾は維持する
+ */
+type EnforceAnchorDiscriminatorFields<T> = {
+  readonly [K in keyof T]: EnforceAnchorDiscriminatorField<T[K]>;
+};
+
 /**
  * `buildIgnitionComment` 入力
  *
  * - coordinates: 登録済み節目から算出された座標
  * - siteOpeningElapsed: milestones.json 不在時のフォールバック (最古記事日付からの経過)
  * - previousPost: 直近記事 (タイトル + 日付)。存在しない場合は null
+ *
+ * 型レベルガード (Issue #556):
+ *   - 直下にある `_IgnitionInputAnchorFieldGuard` が、`IgnitionInput` の各
+ *     フィールドが「Anchor 型らしい (label + daysSince を持つ) のに
+ *     discriminator `kind` を欠いている」場合にコンパイルエラーになる
+ *     構造的回帰防止を提供する。
+ *   - 新フィールド追加時に `readonly { label, tone, daysSince }[]` のような
+ *     ハンドメイドな構造的リテラルを書くと、`type-check:test` で
+ *     "Type '...' is not assignable to type 'never'" 系の型エラーになる
+ *     ため、必ず `Coordinate` / `Elapsed` 等の Anchor 型を import するよう
+ *     誘導される。
  */
 export interface IgnitionInput {
   readonly coordinates: readonly Coordinate[];
@@ -69,6 +194,45 @@ export interface IgnitionInput {
   readonly previousPost: PreviousPost | null;
   readonly publishedAt: string;
 }
+
+/**
+ * 型レベルガード本体 (Issue #556)
+ *
+ * `IgnitionInput` を `EnforceAnchorDiscriminatorFields` に通した結果と一致
+ * することを `_IgnitionInputAnchorFieldGuard` の型として固定する。
+ * いずれかのフィールドが Anchor 型らしいのに discriminator `kind` を欠いて
+ * いると、対応するフィールド型が `never` に潰れて代入不可能となり、本宣言
+ * 自体が型エラーになる。
+ *
+ * - underscore prefix の型エイリアスとして残すことで、`IgnitionInput` の
+ *   定義そのものを汚さずに型レベル契約だけを表明する。
+ * - 値レベルの export は持たない (実行時オーバーヘッドゼロ)。
+ */
+type _IgnitionInputAnchorFieldGuard =
+  IgnitionInput extends EnforceAnchorDiscriminatorFields<IgnitionInput>
+    ? IgnitionInput
+    : never;
+
+// 上記ガード型を「定義したまま使わない」ことによる unused 警告を避けるため、
+// 自身を IgnitionInput に再代入可能なことを型レベルで宣言する (実行時には
+// 何も起きない)。
+type _IgnitionInputAnchorFieldGuardAssert =
+  _IgnitionInputAnchorFieldGuard extends IgnitionInput ? true : never;
+
+/**
+ * 型レベルガードヘルパの公開 export (Issue #556)
+ *
+ * - テスト (`scripts/__tests__/newPost.test.ts`) から `@ts-expect-error`
+ *   ベースの回帰固定で参照する目的で公開する。
+ * - 値レベルの export は無く、型のみのため tree shaking 不要。
+ * - 通常のアプリケーションコードからの使用は想定していない (内部 utility)。
+ */
+export type IsAnchorShape_ForTest<T> = IsAnchorShape<T>;
+export type HasAnchorDiscriminator_ForTest<T> = HasAnchorDiscriminator<T>;
+export type EnforceAnchorDiscriminatorField_ForTest<T> =
+  EnforceAnchorDiscriminatorField<T>;
+export type EnforceAnchorDiscriminatorFields_ForTest<T> =
+  EnforceAnchorDiscriminatorFields<T>;
 
 // =============================================================================
 // 純粋関数 (テスト可能)

--- a/scripts/newPost.ts
+++ b/scripts/newPost.ts
@@ -178,15 +178,15 @@ type EnforceAnchorDiscriminatorFields<T> = {
  * - previousPost: 直近記事 (タイトル + 日付)。存在しない場合は null
  *
  * 型レベルガード (Issue #556):
- *   - 直下にある `_IgnitionInputAnchorFieldGuard` が、`IgnitionInput` の各
- *     フィールドが「Anchor 型らしい (label + daysSince を持つ) のに
- *     discriminator `kind` を欠いている」場合にコンパイルエラーになる
- *     構造的回帰防止を提供する。
+ *   - 直下にある `_ignitionInputAnchorFieldGuardCheck` の宣言で、
+ *     `IgnitionInput` の各フィールドが「Anchor 型らしい (label + daysSince
+ *     を持つ) のに discriminator `kind` を欠いている」場合にコンパイル
+ *     エラーになる構造的回帰防止を提供する。
  *   - 新フィールド追加時に `readonly { label, tone, daysSince }[]` のような
  *     ハンドメイドな構造的リテラルを書くと、`type-check:test` で
- *     "Type '...' is not assignable to type 'never'" 系の型エラーになる
- *     ため、必ず `Coordinate` / `Elapsed` 等の Anchor 型を import するよう
- *     誘導される。
+ *     `AssertEqual` の不一致オブジェクト型 (`{ error; expected; actual }`)
+ *     が露出して `true` の代入が失敗し、必ず `Coordinate` / `Elapsed` 等の
+ *     Anchor 型を import するよう誘導される。
  */
 export interface IgnitionInput {
   readonly coordinates: readonly Coordinate[];
@@ -196,28 +196,46 @@ export interface IgnitionInput {
 }
 
 /**
+ * 型レベル等価性アサーション (Issue #556)
+ *
+ * `A` と `B` が双方向に extends 可能なら `true`、そうでないなら
+ * 失敗内容を示すオブジェクト型を返す。`const _x: AssertEqual<A, B> = true;`
+ * の形で代入することで、A と B が等しくないときに `true` をオブジェクト型に
+ * 代入できず型エラーになる。
+ *
+ * 旧実装の `A extends B ? A : never` 形は違反時に `never` に評価される
+ * だけでエラーにならず、ガードが空回りしていた。本実装は失敗時に `true`
+ * が代入できない非互換型を返すため、実機能化されている。
+ */
+type AssertEqual<A, B> = [A] extends [B]
+  ? [B] extends [A]
+    ? true
+    : { error: "A is not B"; expected: B; actual: A }
+  : { error: "B is not A"; expected: B; actual: A };
+
+/**
  * 型レベルガード本体 (Issue #556)
  *
- * `IgnitionInput` を `EnforceAnchorDiscriminatorFields` に通した結果と一致
- * することを `_IgnitionInputAnchorFieldGuard` の型として固定する。
- * いずれかのフィールドが Anchor 型らしいのに discriminator `kind` を欠いて
- * いると、対応するフィールド型が `never` に潰れて代入不可能となり、本宣言
- * 自体が型エラーになる。
+ * `IgnitionInput` を `EnforceAnchorDiscriminatorFields` に通した型と、
+ * 元の `IgnitionInput` が双方向に互換であることを `AssertEqual` で
+ * 検証する。いずれかのフィールドが Anchor 型らしいのに discriminator
+ * `kind` を欠いていると、対応するフィールド型が `never` に潰れて
+ * `IgnitionInput` と不一致となり、`_ignitionInputAnchorFieldGuardCheck`
+ * への `true` 代入が型エラーになる。
  *
- * - underscore prefix の型エイリアスとして残すことで、`IgnitionInput` の
- *   定義そのものを汚さずに型レベル契約だけを表明する。
- * - 値レベルの export は持たない (実行時オーバーヘッドゼロ)。
+ * - underscore prefix の定数として残すことで、`IgnitionInput` の定義
+ *   そのものを汚さずに型レベル契約だけを表明する。
+ * - 値は `true` リテラルだが値レベルの export は持たないため、実行時
+ *   オーバーヘッドはゼロ。
+ * - `void` 文で参照することで、将来 `scripts/` が `tsconfig.json` の
+ *   `include` 対象になった場合 (Issue #522) でも `noUnusedLocals`
+ *   警告を避ける。
  */
-type _IgnitionInputAnchorFieldGuard =
-  IgnitionInput extends EnforceAnchorDiscriminatorFields<IgnitionInput>
-    ? IgnitionInput
-    : never;
-
-// 上記ガード型を「定義したまま使わない」ことによる unused 警告を避けるため、
-// 自身を IgnitionInput に再代入可能なことを型レベルで宣言する (実行時には
-// 何も起きない)。
-type _IgnitionInputAnchorFieldGuardAssert =
-  _IgnitionInputAnchorFieldGuard extends IgnitionInput ? true : never;
+const _ignitionInputAnchorFieldGuardCheck: AssertEqual<
+  EnforceAnchorDiscriminatorFields<IgnitionInput>,
+  IgnitionInput
+> = true;
+void _ignitionInputAnchorFieldGuardCheck;
 
 /**
  * 型レベルガードヘルパの公開 export (Issue #556)


### PR DESCRIPTION
## 概要

Issue #556: PR #555 (Issue #523) で `IgnitionInput.coordinates` の Coordinate 縮退は解消されたが、将来 `IgnitionInput` に新フィールドが追加されたときに同じ構造的縮退が再発する可能性を構造的に防ぐ。

採用案: **案A (Conditional Type 型ガード) + 案C (PR テンプレート補完)** の二段構え

## 採用案の根拠 (DA レビュー Strong 反論への明示的回答)

DA レビューで「Issue 本文に『対応不要 (close) も選択肢』と明記、case study 1 件に +375 行は over-engineering」と指摘された。これに対する判断:

- **案D (close) を採用しない理由**: 構造的縮退は型システムを使わない限り「人間のレビュー注意力」に依存する。case study 1 件 (PR #555) で実害が表面化した事実は「コードレビューで担保」が現実に破綻したことを示しており、構造的予防の必要性は実証済み
- **案A を採用する理由**: 案C (PR テンプレート) 単独だと「テンプレートを読まない / チェックを忘れる」regression が起きる。案A の Conditional Type ガードは `pnpm type-check:test` で自動検知され、PR テンプレートが規律で守られなくても再発を捕捉する
- **案A + 案C の二段構え**: 案A は build 時自動検知の最終防衛線、案C は PR レビュー時の早期注意喚起。役割が補完的で重複ではない

## 変更内容

### 案A 型ガード本体 (e7bf74a → e501aae)

- `scripts/newPost.ts`:
  - `IsAnchorShape<T>`: label + daysSince の両方を持つ型を Anchor 型らしいと判定
  - `HasAnchorDiscriminator<T>`: kind が string literal (wide string でない) で存在するかを判定
  - `EnforceAnchorDiscriminatorField<T>`: readonly T[] / T | null / 単独要素を再帰ハンドリング
  - `EnforceAnchorDiscriminatorFields<T>`: オブジェクト全フィールドに mapped type で適用
  - `AssertEqual<A, B>` パターンで本体側ガードを実機能化 (fixup e501aae): `const _ignitionInputAnchorFieldGuardCheck: AssertEqual<EnforceAnchorDiscriminatorFields<IgnitionInput>, IgnitionInput> = true;` の代入式が違反時に型エラーになる
  - `void _ignitionInputAnchorFieldGuardCheck;` で将来の noUnusedLocals 警告を先回り防止
- `scripts/__tests__/newPost.test.ts`:
  - 9 件のテスト追加 (positive / negative / pass-through / Elapsed 横断 / 新フィールドシナリオ)
  - `@ts-expect-error` でテスト側からの型レベル assertion を網羅

### 案C PR テンプレート補完 (42c0c78 → e501aae)

- `.github/pull_request_template.md`:
  - 「Anchor 型を扱う PR のみチェック」セクションを `<details>` 折り畳みで追加 (Anchor 関連でない PR のノイズを最小化)
  - チェックリスト 3 項目: import 強制 / 型ガード型チェック / テスト追加

## DA レビュー対応 fixup (e501aae)

- **必須**: 本体側ガードを AssertEqual パターンで実機能化 (Reviewer 重要指摘の「`never extends T = true` で素通り」を解消)
- **推奨**: `_IgnitionInputAnchorFieldGuard` / `_IgnitionInputAnchorFieldGuardAssert` の 2 type alias を削除 (AssertEqual で代替)
- **推奨**: PR テンプレートを `<details>` 折り畳みに変更
- **任意**: JSDoc 表現を「本体ガード `_ignitionInputAnchorFieldGuardCheck` の代入式が型エラーになる」に正確化
- **`_ForTest` 削減 (DA Moderate) は見送り**: 4 つの `_ForTest` export はテスト側で個別の primitive ガードを直接 assert しており、minimum-invasive な削減量がゼロ。テストロジック大幅書き換えのコストが見合わないため現状維持

## 実機検証

- 一時的に `IgnitionInput` に `_testBad: readonly { label: string; tone: "neutral"; daysSince: number }[]` (kind 欠落の構造リテラル) を追加
- `pnpm type-check:test` 実行 → `scripts/newPost.ts(236,7): error TS2322: Type 'boolean' is not assignable to type '{ error: "A is not B"; expected: IgnitionInput; actual: EnforceAnchorDiscriminatorFields<IgnitionInput>; }'` がガード本体のエラーとして発火
- 確認後 `_testBad` を除去して元に戻し、再度 `pnpm type-check:test` が pass

## 備考

- 検証: `pnpm test:run` 50 files / 820 件 全 pass、`pnpm tsc --noEmit` / `pnpm type-check:test` pass、`pnpm lint` clean
- 既存呼び出し側 (`scripts/newPost.ts` 内 12 ヶ所 + テスト) に変更不要で完全な後方互換
- 型ガードは値レベル export を持たず実行時ゼロコスト
- 将来 Resurface 等の新 Anchor layer (`kind: "resurface"` 等) が追加されても、`kind` を string literal として持っている限り破綻しない設計

Closes #556