### PR TITLE
chore: pnpm type-check:test を CI に配線して tsconfig.test.json の breakage を検出可能にする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Type check
         run: pnpm exec tsc --noEmit
+
+      - name: Type check (test)
+        run: pnpm exec tsc -p tsconfig.test.json --noEmit


### PR DESCRIPTION
## 概要

Issue #559: `.github/workflows/ci.yml` は `pnpm exec tsc --noEmit` (tsconfig.json ベース) のみで、`tsconfig.test.json` ベースの型チェックが CI 未配線。テスト用 tsconfig (`vitest/globals` 等) で発生する型エラーが CI を素通りしていた。本 PR で `Type check (test)` step を追加して両方を CI 必須化する。

## 変更内容

- `.github/workflows/ci.yml`:
  - 既存 `Type check` step (`pnpm exec tsc --noEmit`) の直後に `Type check (test)` step (`pnpm exec tsc -p tsconfig.test.json --noEmit`) を追加 (+3 行)
  - 既存 inline スタイル (`pnpm exec tsc ...`) との一貫性を優先し、本 PR では script 呼び出しではなくインラインで記述

## 備考

- 検証: ローカルで `pnpm exec tsc -p tsconfig.test.json --noEmit` を実行し exit=0 (pass) 確認、yaml syntax 検証 OK
- 実行時間影響: type-check 本体 ~4.4s + type-check:test ~2.9s = ~7s (cold)。`pnpm install --frozen-lockfile` 等が支配的で実害軽微

## DA レビュー対応

- **script vs inline drift リスク (Moderate)**: 既存 `Type check` step も inline 採用のため、本 PR は inline 化を踏襲。将来 `pnpm type-check` / `pnpm type-check:test` 呼び出しに統一する変更は **follow-up Issue #579** として登録済み
- **incremental cache 検証 (AC 派生)**: 本 PR スコープでは incremental 未導入。現状 ~7s 程度で実害なく、リポジトリ拡大時に再評価する設計。**follow-up Issue #580** で `tsc --incremental` + `actions/cache` 配線を別途検討

Closes #559