### PR TITLE
chore: pages/*.tsx の MILESTONES 定数 JSDoc 統一 (案B 採用)

### DIFF
--- a/src/pages/anchor.tsx
+++ b/src/pages/anchor.tsx
@@ -45,6 +45,27 @@ import {
  *   記載順が画面の表示順になる)。日付順などで並び替えたい場合は、JSON 自体
  *   を並び替えるか、本ファイルで sort を挟むこと。
  */
+
+/**
+ * 節目データ (`datasources/milestones.json`)。
+ *
+ * AnchorPage (個人史タイムライン) で「節目一覧 + 各記事の座標」を描画するために
+ * 使用する。Coordinate (Issue #491) / Resurface (Issue #492) と同じ JSON を
+ * 共有しているが、Issue #546 の判断で **集約せず各 page で個別 import** する
+ * 設計を採用している (撤退性 > DRY)。`src/lib/milestones.ts` のような集約点を
+ * 作ると 1 行修正が 3 page に同時影響し、page 単位での段階的撤退 (例: anchor
+ * だけ `[]` にして検証する等) が困難になるため。詳細は Issue #546 / docs/ANCHOR.md
+ * 「撤退性」節を参照。
+ *
+ * `as readonly Milestone[]` キャストは tsconfig.json の resolveJsonModule:true で
+ * 取得される widen された型 (例: `tone: string`) を `Milestone`
+ * (`tone: "neutral" | "light" | "heavy"`) に narrowing するため。
+ * JSON データの妥当性は datasources 側で人手担保しており (`docs/MILESTONES.md`)、
+ * `anchors.ts` 側にランタイム検証はない (将来 Issue #547 で Zod 等の導入を検討中)。
+ *
+ * 撤退方法: `datasources/milestones.json` の配列を `[]` にすれば AnchorPage の
+ * 節目一覧が空状態になる (AnchorPage 側で穏やかな 0 件文言を表示)。
+ */
 const MILESTONES: readonly Milestone[] = milestonesData as readonly Milestone[];
 
 const Anchor = () => {

--- a/src/pages/anchor.tsx
+++ b/src/pages/anchor.tsx
@@ -52,16 +52,31 @@ import {
  * AnchorPage (個人史タイムライン) で「節目一覧 + 各記事の座標」を描画するために
  * 使用する。Coordinate (Issue #491) / Resurface (Issue #492) と同じ JSON を
  * 共有しているが、Issue #546 の判断で **集約せず各 page で個別 import** する
- * 設計を採用している (撤退性 > DRY)。`src/lib/milestones.ts` のような集約点を
- * 作ると 1 行修正が 3 page に同時影響し、page 単位での段階的撤退 (例: anchor
- * だけ `[]` にして検証する等) が困難になるため。詳細は Issue #546 / docs/ANCHOR.md
- * 「撤退性」節を参照。
+ * 設計を採用している (認知負荷の局所化を優先)。`src/lib/milestones.ts` のような
+ * 集約点を作ると、各 page を読む際に「この MILESTONES はどこから来てどう加工
+ * されたものか」を別ファイルまで追いかける必要が出るため、3 page で import 経路と
+ * narrowing キャストを揃え、各 page の責務 (Coordinate / Resurface / AnchorPage
+ * のどれに渡すか) をその場で完結して読めるようにする。撤退の単位は
+ * docs/ANCHOR.md 「撤退可能性」節のとおり **コンポーネント (Coordinate /
+ * Resurface) ごとの `show` フラグ** が一次手段であり、JSON の `[]` 化は 3 経路
+ * まとめての停止 = 二次手段である。
  *
  * `as readonly Milestone[]` キャストは tsconfig.json の resolveJsonModule:true で
  * 取得される widen された型 (例: `tone: string`) を `Milestone`
  * (`tone: "neutral" | "light" | "heavy"`) に narrowing するため。
  * JSON データの妥当性は datasources 側で人手担保しており (`docs/MILESTONES.md`)、
  * `anchors.ts` 側にランタイム検証はない (将来 Issue #547 で Zod 等の導入を検討中)。
+ * 値域から外れた場合の実害は AnchorPage の責務範囲では以下に帰着する:
+ * - 不正 `tone` (`"neutral" | "light" | "heavy"` 以外の文字列): 節目一覧の
+ *   `<li data-tone="...">` および各記事の座標の `<span data-tone="...">` に
+ *   未知 string がそのまま `data-tone` として出る (描画は破綻しない)。色分けは
+ *   していないため (AnchorPage は「過剰可視化を避ける」設計で tone を色に
+ *   写像しない)、視覚的にも気付きにくいが破綻もしない
+ * - 不正 `date` (`YYYY-MM-DD` 形式違反): 節目一覧ではその不正文字列がそのまま
+ *   日付列に表示される (= 運用画面の透明性を優先し、フィルタしない) 一方、
+ *   各記事の座標計算では `anchors.ts` の `toMilestoneCalendarDate` が `null` を
+ *   返し、`computeCoordinates` が当該節目を `continue` でスキップするため、
+ *   座標一覧からは静かに落ちる
  *
  * 撤退方法: `datasources/milestones.json` の配列を `[]` にすれば AnchorPage の
  * 節目一覧が空状態になる (AnchorPage 側で穏やかな 0 件文言を表示)。

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,24 +14,28 @@ import {
 } from "../styles/transitions";
 
 /**
- * 現在の Resurface 用節目データ。
+ * 節目データ (`datasources/milestones.json`)。
  *
- * `datasources/milestones.json` から JSON import で読み込む (Issue #489)。
+ * Resurface (Issue #492 / N-5) で「節目記念日 (milestoneAnniversary)」の発火に
+ * 使用する。Coordinate (Issue #491) / AnchorPage (Issue #493) と同じ JSON を
+ * 共有しているが、Issue #546 の判断で **集約せず各 page で個別 import** する
+ * 設計を採用している (撤退性 > DRY)。`src/lib/milestones.ts` のような集約点を
+ * 作ると 1 行修正が 3 page に同時影響し、page 単位での段階的撤退 (例: index
+ * だけ `[]` にして Resurface だけ止める等) が困難になるため。詳細は Issue #546
+ * / docs/ANCHOR.md 「撤退性」節を参照。
  *
- * - 撤退方法: milestones.json の配列を `[]` にすれば座標は消える。沈黙トリガー
- *   と暦の節目は引き続き機能し、節目記念日 (milestoneAnniversary) だけが
- *   発火しなくなる。
- * - 編集方法: `docs/MILESTONES.md` を参照する。
+ * `as readonly Milestone[]` キャストは tsconfig.json の resolveJsonModule:true で
+ * 取得される widen された型 (例: `tone: string`) を `Milestone`
+ * (`tone: "neutral" | "light" | "heavy"`) に narrowing するため。
+ * JSON データの妥当性は datasources 側で人手担保しており (`docs/MILESTONES.md`)、
+ * `anchors.ts` 側にランタイム検証はない (将来 Issue #547 で Zod 等の導入を検討中)。
+ * 実値が値域から外れた場合の実害は、表示側で undefined になるか除外されるかに
+ * 帰着する。`date` の `YYYY-MM-DD` 形式違反は `anchors.ts` の
+ * `toMilestoneCalendarDate` が null 扱いで sub-coordinate を捨てる仕様で吸収される。
  *
- * 型は `Milestone[]` にキャストする。JSON import の型は構造的に Milestone を
- * 満たすが、`tone` フィールドが `string` として推論されるため明示的に narrow する。
- *
- * `MILESTONES as readonly Milestone[]` は型レベルで `MilestoneTone` を満たすと
- * 信頼するキャストであり、`anchors.ts` 側に tone のランタイム検証はない (型のみ)。
- * 実値が `"neutral" | "light" | "heavy"` の値域から外れた場合の挙動は型保証されず、
- * 実害は表示側で undefined になるか除外されるかに帰着する。
- * (date の `YYYY-MM-DD` 形式違反は `anchors.ts` の `toMilestoneCalendarDate` が
- *  null 扱いで sub-coordinate を捨てる仕様で吸収される)
+ * 撤退方法: `datasources/milestones.json` の配列を `[]` にすれば節目記念日が
+ * 発火しなくなる (沈黙トリガーと暦の節目は引き続き機能する)。編集方法は
+ * `docs/MILESTONES.md` を参照する。
  */
 const MILESTONES: readonly Milestone[] = milestonesData as readonly Milestone[];
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,10 +19,14 @@ import {
  * Resurface (Issue #492 / N-5) で「節目記念日 (milestoneAnniversary)」の発火に
  * 使用する。Coordinate (Issue #491) / AnchorPage (Issue #493) と同じ JSON を
  * 共有しているが、Issue #546 の判断で **集約せず各 page で個別 import** する
- * 設計を採用している (撤退性 > DRY)。`src/lib/milestones.ts` のような集約点を
- * 作ると 1 行修正が 3 page に同時影響し、page 単位での段階的撤退 (例: index
- * だけ `[]` にして Resurface だけ止める等) が困難になるため。詳細は Issue #546
- * / docs/ANCHOR.md 「撤退性」節を参照。
+ * 設計を採用している (認知負荷の局所化を優先)。`src/lib/milestones.ts` のような
+ * 集約点を作ると、各 page を読む際に「この MILESTONES はどこから来てどう加工
+ * されたものか」を別ファイルまで追いかける必要が出るため、3 page で import 経路と
+ * narrowing キャストを揃え、各 page の責務 (Coordinate / Resurface / AnchorPage
+ * のどれに渡すか) をその場で完結して読めるようにする。撤退の単位は
+ * docs/ANCHOR.md 「撤退可能性」節のとおり **コンポーネント (Coordinate /
+ * Resurface) ごとの `show` フラグ** が一次手段であり、JSON の `[]` 化は 3 経路
+ * まとめての停止 = 二次手段である。
  *
  * `as readonly Milestone[]` キャストは tsconfig.json の resolveJsonModule:true で
  * 取得される widen された型 (例: `tone: string`) を `Milestone`

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -17,15 +17,26 @@ import {
 } from "../../styles/transitions";
 
 /**
- * Coordinate (Issue #491) 用節目データ。
+ * 節目データ (`datasources/milestones.json`)。
  *
- * `datasources/milestones.json` を JSON import で読み込む (Resurface 側
- * `pages/index.tsx` と同じ参照経路で揃える)。撤退方法・編集方法も同様で、
- * milestones.json の配列を `[]` にすれば全記事の Coordinate が消える。
+ * Coordinate (Issue #491) で「記事ごとの個人史座標」を算出するために使用する。
+ * Resurface (Issue #492) / AnchorPage (Issue #493) と同じ JSON を共有しているが、
+ * Issue #546 の判断で **集約せず各 page で個別 import** する設計を採用している
+ * (撤退性 > DRY)。`src/lib/milestones.ts` のような集約点を作ると 1 行修正が
+ * 3 page に同時影響し、page 単位での段階的撤退 (例: Post だけ `[]` にして
+ * Coordinate だけ止める等) が困難になるため。詳細は Issue #546 / docs/ANCHOR.md
+ * 「撤退性」節を参照。
  *
- * 型は `as readonly Milestone[]` で narrow する。`anchors.ts` 側に tone の
- * ランタイム検証はなく、不正値はサイレントに無視される (`computeCoordinates`
- * が tone:heavy 以外を Coordinate にし、表示層で更に tone:heavy を除外する)。
+ * `as readonly Milestone[]` キャストは tsconfig.json の resolveJsonModule:true で
+ * 取得される widen された型 (例: `tone: string`) を `Milestone`
+ * (`tone: "neutral" | "light" | "heavy"`) に narrowing するため。
+ * JSON データの妥当性は datasources 側で人手担保しており (`docs/MILESTONES.md`)、
+ * `anchors.ts` 側にランタイム検証はない (将来 Issue #547 で Zod 等の導入を検討中)。
+ * 不正な tone はサイレントに無視される (`computeCoordinates` が tone:heavy 以外を
+ * Coordinate にし、表示層で更に tone:heavy を除外する)。
+ *
+ * 撤退方法: `datasources/milestones.json` の配列を `[]` にすれば全記事の
+ * Coordinate が消える。編集方法は `docs/MILESTONES.md` を参照する。
  */
 const MILESTONES: readonly Milestone[] = milestonesData as readonly Milestone[];
 

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -22,10 +22,14 @@ import {
  * Coordinate (Issue #491) で「記事ごとの個人史座標」を算出するために使用する。
  * Resurface (Issue #492) / AnchorPage (Issue #493) と同じ JSON を共有しているが、
  * Issue #546 の判断で **集約せず各 page で個別 import** する設計を採用している
- * (撤退性 > DRY)。`src/lib/milestones.ts` のような集約点を作ると 1 行修正が
- * 3 page に同時影響し、page 単位での段階的撤退 (例: Post だけ `[]` にして
- * Coordinate だけ止める等) が困難になるため。詳細は Issue #546 / docs/ANCHOR.md
- * 「撤退性」節を参照。
+ * (認知負荷の局所化を優先)。`src/lib/milestones.ts` のような集約点を作ると、
+ * 各 page を読む際に「この MILESTONES はどこから来てどう加工されたものか」を
+ * 別ファイルまで追いかける必要が出るため、3 page で import 経路と narrowing
+ * キャストを揃え、各 page の責務 (Coordinate / Resurface / AnchorPage のどれに
+ * 渡すか) をその場で完結して読めるようにする。撤退の単位は docs/ANCHOR.md
+ * 「撤退可能性」節のとおり **コンポーネント (Coordinate / Resurface) ごとの
+ * `show` フラグ** が一次手段であり、JSON の `[]` 化は 3 経路まとめての停止 =
+ * 二次手段である。
  *
  * `as readonly Milestone[]` キャストは tsconfig.json の resolveJsonModule:true で
  * 取得される widen された型 (例: `tone: string`) を `Milestone`


### PR DESCRIPTION
## 概要

Issue #546: `const MILESTONES: readonly Milestone[] = milestonesData as readonly Milestone[]` が 3 ファイル (`pages/anchor.tsx`, `pages/index.tsx`, `pages/posts/Post.tsx`) で重複し、JSDoc も不揃いだった点を、**案B (各 page で個別 import + JSDoc 統一)** で解消。

## 採用案の根拠

- 案A (`src/lib/milestones.ts` に集約) を採用すると、3 page が同じ MILESTONES を参照する DRY な構造になるが、Issue #547 (datasources/milestones.json のランタイムスキーマ検証 / Zod 等) との二重作業リスクと、当面の単純さを比較し案B で進める
- **判断の根拠は "認知負荷の局所化"**: 各 page で import 経路と narrowing キャスト (`as readonly Milestone[]`) をその場で完結して読める形を維持する。集約せず JSDoc だけ統一する

## 変更内容

### 初期実装 (d053122)

- 3 ファイル共通核の JSDoc を統一: データソース明示 / 判断根拠 / `as readonly Milestone[]` キャスト理由 / Issue #547 ランタイム検証言及
- 各 page 固有部: 用途 (Coordinate / Resurface / AnchorPage) と撤退時の挙動

### DA / Reviewer 指摘対応 fixup (915ae42)

- **必須**: JSDoc 共通核から「page 単位での段階的撤退」「撤退性 > DRY」の主張を削除し、「**認知負荷の局所化**」(3 page で import 経路と narrowing キャストを揃え、各 page の責務をその場で完結して読める形にする) に置換。撤退手段は ANCHOR.md「撤退可能性」節と整合させて「一次手段 = コンポーネントごとの `show` フラグ」「二次手段 = JSON `[]` 化 (3 経路まとめての停止)」と明示
- **必須**: 「撤退性」→「撤退可能性」に修正 (3 ファイル統一、ANCHOR.md 見出しに揃える)
- **推奨**: anchor.tsx に不正値挙動段落を追加 (実態に合わせ「節目一覧では文字列がそのまま表示 / 座標計算では `computeCoordinates` の continue でスキップ」)

## 備考

- 検証: `pnpm test:run` 50 files / 811 件 全 pass、`pnpm lint` clean
- 実行時影響なし (JSDoc 追加・書き換えのみ、import 経路に変更なし)

## DA Strong 反論対応

- DA Strong 2 (テストファイル 2 件 `Coordinate.allPosts.test.tsx` / `AnchorPage.allPosts.test.tsx` で同パターン残存) は本 Issue #546 のスコープ (pages/*.tsx) 外のため、**follow-up Issue #583** として登録済み

Closes #546