### PR TITLE
refactor: PostDetailPage の milestones / showCoordinate props を required 化

### DIFF
--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -25,14 +25,23 @@ interface PostDetailPageProps {
    * import して渡す。本コンポーネントは `inferPublishedAt(post.id)` で
    * publishedAt を逆算し、Coordinate に渡す純粋な中継を行う。
    *
-   * 既定 (省略) では空配列扱いで Coordinate は描画されない (= 既存テスト互換)。
+   * Issue #533 で required 化。「Post.tsx 以外の経路で PostDetailPage を呼んだ際、
+   * `milestones` を渡し忘れると無音で Coordinate が消える」という UX バグを
+   * 型エラーで検知するため optional から required に変更した。空配列を渡す
+   * ことで Coordinate を非表示にできる (Coordinate 内部で early return)。
    */
-  milestones?: readonly Milestone[];
+  milestones: readonly Milestone[];
   /**
    * Coordinate の表示 OFF フラグ (撤退可能性 / epic #487)。
    *
    * Anchor 企画は「いつでも黙らせられる」設計要件。Resurface と同じ命名
-   * (`show*` 親側変数 + 子側 `show` prop) で揃える。既定 true。
+   * (`show*` 親側変数 + 子側 `show` prop) で揃える。
+   *
+   * Issue #533: 本フラグは「明示的に OFF にしたいとき専用」のスイッチで、
+   * 既定 true (= 通常時は何も指定せず Coordinate を描画する) として扱う。
+   * required 化はせず optional のまま据え置く方針 (呼び出し側で都度 true を
+   * 書かせる負担を避けるため)。OFF にしたい呼び出し側だけ `showCoordinate={false}`
+   * を明示する。
    */
   showCoordinate?: boolean;
 }
@@ -172,7 +181,7 @@ export const PostDetailPage = ({
               {publishedAt !== null && (
                 <Coordinate
                   publishedAt={publishedAt}
-                  milestones={milestones ?? []}
+                  milestones={milestones}
                   show={showCoordinate}
                 />
               )}

--- a/src/components/pages/__tests__/PostDetailPage.test.tsx
+++ b/src/components/pages/__tests__/PostDetailPage.test.tsx
@@ -24,7 +24,12 @@ describe("PostDetailPage", () => {
   it("記事タイトルを表示できる", () => {
     render(
       <MemoryRouter>
-        <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+        <PostDetailPage
+          post={mockPost}
+          olderPost={null}
+          newerPost={null}
+          milestones={[]}
+        />
       </MemoryRouter>,
     );
 
@@ -36,7 +41,12 @@ describe("PostDetailPage", () => {
   it("記事のメタ情報を表示できる", () => {
     render(
       <MemoryRouter>
-        <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+        <PostDetailPage
+          post={mockPost}
+          olderPost={null}
+          newerPost={null}
+          milestones={[]}
+        />
       </MemoryRouter>,
     );
 
@@ -47,7 +57,12 @@ describe("PostDetailPage", () => {
   it("記事コンテンツを表示できる", () => {
     render(
       <MemoryRouter>
-        <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+        <PostDetailPage
+          post={mockPost}
+          olderPost={null}
+          newerPost={null}
+          milestones={[]}
+        />
       </MemoryRouter>,
     );
 
@@ -61,7 +76,12 @@ describe("PostDetailPage", () => {
   it("トップページへのリンクを表示できる", () => {
     render(
       <MemoryRouter>
-        <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+        <PostDetailPage
+          post={mockPost}
+          olderPost={null}
+          newerPost={null}
+          milestones={[]}
+        />
       </MemoryRouter>,
     );
 
@@ -82,6 +102,7 @@ describe("PostDetailPage", () => {
           post={postWithoutTitle}
           olderPost={null}
           newerPost={null}
+          milestones={[]}
         />
       </MemoryRouter>,
     );
@@ -100,7 +121,12 @@ describe("PostDetailPage", () => {
 
     render(
       <MemoryRouter>
-        <PostDetailPage post={postWithHtml} olderPost={null} newerPost={null} />
+        <PostDetailPage
+          post={postWithHtml}
+          olderPost={null}
+          newerPost={null}
+          milestones={[]}
+        />
       </MemoryRouter>,
     );
 
@@ -143,7 +169,12 @@ describe("PostDetailPage", () => {
     it("本文コンテナが prose scope として宣言される", () => {
       render(
         <MemoryRouter>
-          <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
         </MemoryRouter>,
       );
 
@@ -160,7 +191,12 @@ describe("PostDetailPage", () => {
     it("段落が prose scope コンテナの内側に配置される", () => {
       render(
         <MemoryRouter>
-          <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
         </MemoryRouter>,
       );
 
@@ -174,7 +210,12 @@ describe("PostDetailPage", () => {
     it("見出し (h2) が prose scope コンテナの内側に配置される", () => {
       render(
         <MemoryRouter>
-          <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
         </MemoryRouter>,
       );
 
@@ -198,6 +239,7 @@ describe("PostDetailPage", () => {
             post={postWithTable}
             olderPost={null}
             newerPost={null}
+            milestones={[]}
           />
         </MemoryRouter>,
       );
@@ -221,6 +263,7 @@ describe("PostDetailPage", () => {
             post={postWithList}
             olderPost={null}
             newerPost={null}
+            milestones={[]}
           />
         </MemoryRouter>,
       );
@@ -236,7 +279,12 @@ describe("PostDetailPage", () => {
     it("TOC は本文コンテナの外側に配置される", () => {
       render(
         <MemoryRouter>
-          <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
         </MemoryRouter>,
       );
 
@@ -265,7 +313,12 @@ describe("PostDetailPage", () => {
     it("article は border.subtle 専用 token を border として宣言する", () => {
       const { container } = render(
         <MemoryRouter>
-          <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
         </MemoryRouter>,
       );
 
@@ -277,7 +330,12 @@ describe("PostDetailPage", () => {
     it("ページナビゲーションは border.subtle を border として宣言する", () => {
       const { container } = render(
         <MemoryRouter>
-          <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
         </MemoryRouter>,
       );
 
@@ -296,7 +354,12 @@ describe("PostDetailPage", () => {
     it("header と本文の間の divider が borderTop + border.subtle を宣言する", () => {
       const { container } = render(
         <MemoryRouter>
-          <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
         </MemoryRouter>,
       );
 
@@ -319,7 +382,12 @@ describe("PostDetailPage", () => {
     it("H1 に view-transition-name: post-{id} を付与する", () => {
       render(
         <MemoryRouter>
-          <PostDetailPage post={mockPost} olderPost={null} newerPost={null} />
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
         </MemoryRouter>,
       );
 
@@ -336,8 +404,9 @@ describe("PostDetailPage", () => {
   //
   // 記事詳細の MetaInfo 近傍に「{label} から N 日目」を静かに一行で並べる。
   // - post.id (YYYYMMDDhhmmss) から publishedAt を逆算する
-  // - milestones prop と showCoordinate prop は optional (既定で非表示)
-  // - 不正な id (タイムスタンプ形式でない) は publishedAt 推定不可で非表示
+  // - milestones prop は required (Issue #533)、showCoordinate prop は
+  //   optional で既定 true (撤退時の OFF フラグ専用)
+  // - 空配列 / showCoordinate=false / publishedAt 推定不可 のいずれかで非表示
   // ==========================================================================
   describe("Coordinate 表示", () => {
     /**
@@ -373,18 +442,20 @@ describe("PostDetailPage", () => {
       expect(screen.getByText(/サイト開設/)).toBeInTheDocument();
     });
 
-    it("milestones を渡さない (既定) と Coordinate を描画しない", () => {
+    it("milestones が空配列のとき Coordinate を描画しない", () => {
       render(
         <MemoryRouter>
           <PostDetailPage
             post={mockPostWithTimestamp}
             olderPost={null}
             newerPost={null}
+            milestones={[]}
           />
         </MemoryRouter>,
       );
 
-      // milestones 未指定 (= 空配列扱い) で Coordinate は出ない
+      // Issue #533: milestones を required 化したため「未指定」のケースは型的に
+      // 成立しない。撤退時の挙動 (空配列で Coordinate を描画しない) を担保する。
       expect(
         screen.queryByRole("list", { name: "個人史座標" }),
       ).not.toBeInTheDocument();


### PR DESCRIPTION
## 概要

Issue #533: `PostDetailPage` の `milestones?` / `showCoordinate?` が共に optional で、`milestones ?? []` のフォールバックがあった。本実装の「既存 16 テスト破壊回避」目的では合理的だったが、「Post.tsx 以外の経路で PostDetailPage を呼んだ際、`milestones` を渡し忘れると無音で Coordinate が消える」UX バグの温床になっていた。本 PR で型レベルガード化する。

## 採用案

- `milestones`: **required 化** → 渡し忘れを型エラーで検知
- `showCoordinate`: **案B (optional 据え置き + JSDoc で「OFF フラグ専用」明文化)**
  - 採用根拠: 既定 true (= 通常時は何も指定せず Coordinate を描画) が呼び出し側の負担を最小化し、Anchor 機能の「基本 ON 運用 / OFF は撤退時の例外操作」という運用実態と整合
  - 案A (showCoordinate も required) は網羅性で勝るが、毎回 `showCoordinate={true}` を書く摩擦が大きい

## 変更内容

- `src/components/pages/PostDetailPage.tsx`:
  - `milestones` を required 化、`milestones ?? []` フォールバック排除
  - `showCoordinate` の JSDoc に「OFF フラグ専用」「既定 true (= 通常時は何も指定せず Coordinate を描画)」「OFF にしたい呼び出し側だけ `showCoordinate={false}` を明示」の運用意図を明文化
- `src/components/pages/__tests__/PostDetailPage.test.tsx`:
  - 既存 16 件のテストに `milestones={[]}` を機械的追記 (mockPost.id="test-post" は `inferPublishedAt` が null → Coordinate 非表示で互換)
  - 「milestones を渡さない (既定) と Coordinate を描画しない」テストを「milestones が空配列のとき Coordinate を描画しない」に書き換え (required 化で「未指定」が型的に成立しないため)

## 備考

- 検証: `pnpm test:run` 50 files / 811 件 全 pass、`pnpm tsc --noEmit` pass、`pnpm lint` clean
- 型エラー検知の実機検証: Post.tsx の `<PostDetailPage>` 呼び出しから `milestones={MILESTONES}` を一時削除 → `pnpm tsc --noEmit` が `error TS2741: Property 'milestones' is missing` で正しく検知することを Reviewer により確認済み
- `inferPublishedAt("test-post") === null` を実機検証 (DA レビュー) で確認、既存テスト互換性 OK
- 呼び出し側 `src/pages/posts/Post.tsx` は既に `milestones={MILESTONES}` を渡しているため、本 PR で破壊変更なし
- Reviewer: APPROVE (致命/重要/軽微すべてなし) / DA: YES (Strong 反論なし)

Closes #533