### PR TITLE
chore: tsconfig.json 本体に scripts/ を追加 (import.meta.dirname 型解決を含む)

### DIFF
--- a/scripts/calculateContrast.ts
+++ b/scripts/calculateContrast.ts
@@ -333,25 +333,15 @@ const getContrastPairs = (): readonly ContrastPair[] => {
 // =============================================================================
 
 /**
- * OKLCH 文字列から sRGB の WCAG 相対輝度を取得する。
- *
- * culori の `wcagLuminance` が内部で sRGB → linear (gamma 補正) →
- * 0.2126 R + 0.7152 G + 0.0722 B を行う WCAG 2.x 規定の実装。
- * これは Lighthouse の値ではなく WCAG 仕様を直接実装したもの。
- */
-const luminance = (oklchString: string): number => {
-  const color = parse(oklchString);
-  if (!color) {
-    throw new Error(`Failed to parse OKLCH: ${oklchString}`);
-  }
-  return wcagLuminance(color);
-};
-
-/**
  * 単一ペアのコントラスト比を WCAG 2.x 仕様で計算する。
  *
  * 実体は culori の `wcagContrast` で、(L1 + 0.05) / (L2 + 0.05)
  * (L1, L2 は明度の高い方・低い方の sRGB 相対輝度)。
+ *
+ * 内部で利用する `wcagLuminance` は culori が提供する WCAG 2.x 規定の
+ * 相対輝度計算 (sRGB → linear (gamma 補正) →
+ * 0.2126 R + 0.7152 G + 0.0722 B)。Lighthouse の値ではなく WCAG 仕様
+ * を直接実装したもの。
  */
 const computeContrast = (pair: ContrastPair): ContrastResult => {
   const fgColor = parse(pair.fg);

--- a/scripts/scripts-env.d.ts
+++ b/scripts/scripts-env.d.ts
@@ -1,0 +1,36 @@
+/**
+ * scripts/ 配下の Node ランタイム向け型拡張。
+ *
+ * 目的:
+ *   `import.meta.dirname` の型解決を tsconfig.json 本体経由の型チェックで
+ *   担保する。これは Node 20.11 / 21.2 以降で標準化された API であり、
+ *   ランタイムには存在するが、`vite/client` / `@types/node` (古いバージョン)
+ *   の型定義には含まれないことがあるため、ローカルで `ImportMeta` を
+ *   ambient で拡張する。
+ *
+ * 配置理由:
+ *   - `src/vite-env.d.ts` ではなく `scripts/` 配下に置くことで、
+ *     「Node 専用スクリプトのための型補強」という責務を明確にする。
+ *   - tsconfig.json の `include` が `["src", "scripts"]` を含むことで
+ *     本ファイルは ambient 宣言としてプロジェクト全体に反映される。
+ *
+ * 注意:
+ *   - `import.meta.filename` は scripts 配下で未使用のため宣言しない。
+ *     将来必要になったら追加する。
+ *   - `@types/node` を devDependencies に追加せず、追加依存ゼロで
+ *     型解決を担保するための最小宣言。
+ *
+ * 関連 Issue:
+ *   - #522: tsconfig.json 本体に scripts/ を追加 (`import.meta.dirname`
+ *     型解決が前提)
+ *   - PR #501: scripts/__tests__ を tsconfig.test.json でカバーした際に
+ *     残された「tsconfig.json 本体への scripts 追加は別 Issue」の負債を解消。
+ */
+
+interface ImportMeta {
+  /**
+   * 現在のモジュールが存在するディレクトリの絶対パス (Node 標準)。
+   * Node 20.11 / 21.2 以降で利用可能。
+   */
+  readonly dirname: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": ["src", "scripts"],
   "types": ["vitest/globals", "@testing-library/jest-dom"],
   "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,14 +1,13 @@
 {
+  // tsconfig.json (本体) を継承し、テスト実行時のみ必要な型と緩和設定を上書きする。
+  // include は本体の ["src", "scripts"] を継承するため (Issue #522)、
+  // src 配下 / scripts 配下の __tests__ も自動的にカバーされる。
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // vite/client は src 配下のテストが import.meta.env 等を参照するため必要
     "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client"],
+    // テストでは setup 用の helper 変数等で意図的に未使用なものを許容する
     "noUnusedLocals": false,
     "noUnusedParameters": false
-  },
-  "include": [
-    "src/**/*",
-    "src/**/__tests__/**/*",
-    "scripts/**/__tests__/**/*"
-  ],
-  "exclude": []
+  }
 }


### PR DESCRIPTION
## 概要

Issue #522: PR #501 の「既存負債」セクションで「tsconfig.json 本体への scripts 追加は別 Issue (`import.meta.dirname` 型解決が前提)」と明記されたが未着手だった点を解消。

採用案: **案A (`tsconfig.json` の include に `"scripts"` 追加 + `ImportMeta.dirname` ambient 拡張 + `tsconfig.test.json` の include 削減)**

## 変更内容

### 本体実装 (be7c244)

- `tsconfig.json`: `include` に `"scripts"` を追加 (scripts/ を本体型検査対象に含める)
- `scripts/scripts-env.d.ts` (新規): `interface ImportMeta { readonly dirname: string }` の ambient 宣言 (Node 20.11 / 21.2+ の標準 API、`@types/node` を追加せず Node 標準 API として宣言)
- `scripts/calculateContrast.ts`: 未使用関数 `luminance` を削除 (noUnusedLocals: true 適合のための必要対応、JSDoc は `computeContrast` 側に統合)

### 副次 (2172b50)

- `tsconfig.test.json`: `include` / `exclude` を削除し、本体の `["src", "scripts"]` を `extends` 経由で継承する形に集約。`scripts/__tests__` の二重指定 (本体 `scripts` カバー vs test の `scripts/**/__tests__/**/*`) を解消

## 備考

- 検証: `pnpm type-check` / `pnpm type-check:test` / `pnpm test:run` (50 files / 811 tests) / `pnpm contrast:check` / `pnpm lint:tokens` / `pnpm lint` (118 files) すべて pass
- 実機確認: `scripts/__tests__/newPost.test.ts` に故意の型エラーを注入 → `pnpm type-check:test` が exit code 2 で fail (test config の include 削減後も scripts/__tests__ が確実にカバーされる)
- `@types/node` 追加回避: メモリ「外部ライブラリ追加禁止」と整合させ、Node 標準 API の最小宣言で完結

## DA レビュー Moderate 反論への対応

- **`readonly dirname` の将来 @types/node upgrade 時 modifier conflict リスク**: 現状 `@types/node@17.0.45` では dirname 未宣言で問題顕在化なし。**follow-up Issue #589** で別途対応
- **tsconfig.json の `"types"` フィールド位置が compilerOptions の外側 (master 由来既存バグ)**: 本 PR で `include` に scripts を追加したため影響範囲が広がる懸念あり、**follow-up Issue #590** で別途対応

## 補助 tsconfig の扱い

- `tsconfig.test.json`: include/exclude 削減で本体継承化 (✅ 削減)
- `tsconfig.build.json`: `composite: true` の vite.config / panda.config 専用で責務が異なるため温存 (本 Issue スコープ外)

Closes #522