### PR TITLE
chore: pre-commit-guard.sh の設計方針確定 + R06 期待値修正 (Issue #568 設計合意フェーズ)

### DIFF
--- a/.claude/hooks/__tests__/pre-commit-guard.test.sh
+++ b/.claude/hooks/__tests__/pre-commit-guard.test.sh
@@ -14,14 +14,19 @@
 #   pass             - hook が素通り (decision:block を出さない) ことを期待
 #   block            - hook が block を出すことを期待
 #   known-limitation - 現状の実装の限界。block でも pass でも fail にはしない
-#                      (shell 文字列解析の本質的限界 → Counterpoint 31:
+#                      (shell 文字列解析の本質的限界 → Issue #592 (Counterpoint 31):
 #                      git ネイティブ pre-commit hook 化で塞ぐ予定の項目)
 #
 # Issue #568 (Counterpoint 32 採用) で、本 hook の責務は
 # 「shell コマンド文字列で素直に判定できるもの」だけに絞ることが確定した。
-# これにより E01-E11 / R06 は known-limitation のまま放置でよい (本 hook の
+# これにより E01-E11 は known-limitation のまま放置でよい (本 hook の
 # 責任範囲外) と整理された。本ハーネスにこれらのケースを残すのは
-# Counterpoint 31 導入時に「block」昇格を検知する regression trail として。
+# Issue #592 (Counterpoint 31) 導入時に「block」昇格を検知する regression trail として。
+#
+# R06 (`cd worktree && (git commit)` nested subshell) は known-limitation ではなく
+# 「block」期待値で固定する。元実装でも cwd が main-repo のまま評価されて master と
+# 判定され block されており、これが現状の安全側挙動として正しい。Issue #592
+# 完了時に R06 が「pass」に変化したら regression として検出される構造を保つ。
 #
 # 本テストは Bash ツールの PreToolUse hook (pre-commit-guard.sh) と
 # 同じスクリプトを呼び出すため、テスト実行コマンド自身に
@@ -146,11 +151,14 @@ add_case "R05" "pass" "fix-required" \
   "$MAIN_REPO" "cd $WORKTREE && cd src && $GIT commit -m x" \
   "consecutive cd: cd worktree && cd subdir && commit"
 
-# 既知の限界: cd 後に subshell が始まると cwd 継承ができない (shell 文字列解析の限界)
-# Counterpoint 31 (git native pre-commit hook) で本質的に塞ぐ予定
-add_case "R06" "known-limitation" "out-of-scope (Counterpoint 31)" \
+# cd 後に subshell が始まると cwd 継承ができないため、現状の resolve_target_dir は
+# main-repo (= master) を判定対象として block する (= 安全側 fallback)。これは
+# best-effort としての適切な挙動であり、Issue #592 (Counterpoint 31 = git native
+# pre-commit hook) 完了後に「正しく worktree を解決した上で pass」へ変化すべき
+# regression trail として block 期待値で固定する。
+add_case "R06" "block" "fix-required" \
   "$MAIN_REPO" "cd $WORKTREE && ($GIT commit -m x)" \
-  "cd worktree && (commit) nested subshell — git native hook で塞ぐ"
+  "cd worktree && (commit) nested subshell — safe-side block (Issue #592 で pass 化予定)"
 
 # --- --git-dir / --work-tree 系 (Critical 19-20) -----------------------------
 add_case "X01" "pass" "fix-required" \
@@ -187,61 +195,61 @@ add_case "FP02" "block" "sanity" \
   "$WORKTREE" "$GIT push -f origin feat/test" \
   "git push -f is blocked"
 
-# --- 構造的 bypass (Issue #568 で範囲外と確定、Counterpoint 31 に委譲) -----
+# --- 構造的 bypass (Issue #568 で範囲外と確定、Issue #592 / Counterpoint 31 に委譲) -----
 # Issue #568 (Counterpoint 32 採用) で本 hook の責務を「shell コマンド文字列で
 # 素直に判定できるもの」に絞る方針が確立した。以下 E01-E11 は shell 文字列解析の
 # 本質的限界に起因する bypass であり、本 hook では塞がない。
 #
 # 真の保護は git ネイティブ pre-commit hook (`.githooks/pre-commit` +
-# `core.hooksPath`) で行う想定 (Counterpoint 31 — follow-up Issue 候補)。
+# `core.hooksPath`) で行う想定 (Issue #592 — Counterpoint 31 follow-up)。
 # git ネイティブ hook 側であれば、どんな経路 (eval / bash -c / 絶対パス /
 # env -C 等) から git commit を呼んでも必ず実行されるため、bypass は不可能となる。
 #
 # 本ハーネスでは「regression テスト」として E01-E11 をリストに残し、
-# Counterpoint 31 が将来導入されたタイミングで「block」期待値へ昇格させる
+# Issue #592 が将来導入されたタイミングで「block」期待値へ昇格させる
 # trail を保つ。known-limitation のままなので pass/block どちらでも fail にしない。
-add_case "E01_BY13" "known-limitation" "out-of-scope (Counterpoint 31)" \
+add_case "E01_BY13" "known-limitation" "out-of-scope (Issue #592, Counterpoint 31)" \
   "$MAIN_REPO" "PAGER=cat $GIT commit -m x" \
   "PAGER=cat g..it commit (env-prefix) — git native hook で塞ぐ"
 
-add_case "E02_BY17" "known-limitation" "out-of-scope (Counterpoint 31)" \
+add_case "E02_BY17" "known-limitation" "out-of-scope (Issue #592, Counterpoint 31)" \
   "$MAIN_REPO" "/usr/bin/$GIT commit -m x" \
   "absolute path /usr/bin/g..it — git native hook で塞ぐ"
 
-add_case "E03_BY9" "known-limitation" "out-of-scope (Counterpoint 31)" \
+add_case "E03_BY9" "known-limitation" "out-of-scope (Issue #592, Counterpoint 31)" \
   "$MAIN_REPO" "sudo $GIT commit -m x" \
   "sudo g..it commit — git native hook で塞ぐ"
 
-add_case "E04_T8" "known-limitation" "out-of-scope (Counterpoint 31)" \
+add_case "E04_T8" "known-limitation" "out-of-scope (Issue #592, Counterpoint 31)" \
   "$MAIN_REPO" "eval \"$GIT commit -m bypass\"" \
   "eval \"g..it commit\" — git native hook で塞ぐ"
 
-add_case "E05_T9" "known-limitation" "out-of-scope (Counterpoint 31)" \
+add_case "E05_T9" "known-limitation" "out-of-scope (Issue #592, Counterpoint 31)" \
   "$MAIN_REPO" "bash -c \"$GIT commit -m x\"" \
   "bash -c \"g..it commit\" — git native hook で塞ぐ"
 
-add_case "E06_T29" "known-limitation" "out-of-scope (Counterpoint 31)" \
+add_case "E06_T29" "known-limitation" "out-of-scope (Issue #592, Counterpoint 31)" \
   "$MAIN_REPO" "GIT_DIR=$MAIN_REPO/.git $GIT commit -m x" \
   "GIT_DIR=... g..it commit — git native hook で塞ぐ"
 
-add_case "E07_T38" "known-limitation" "out-of-scope (Counterpoint 31)" \
+add_case "E07_T38" "known-limitation" "out-of-scope (Issue #592, Counterpoint 31)" \
   "$MAIN_REPO" "env -C $MAIN_REPO $GIT commit -m x" \
   "env -C ... g..it commit — git native hook で塞ぐ"
 
-add_case "E08_T30" "known-limitation" "out-of-scope (Counterpoint 31)" \
+add_case "E08_T30" "known-limitation" "out-of-scope (Issue #592, Counterpoint 31)" \
   "$MAIN_REPO" "alias gc=\"$GIT commit\"; gc -m x" \
   "alias gc=...; gc -m — git native hook で塞ぐ"
 
-add_case "E09_BY4" "known-limitation" "out-of-scope (Counterpoint 31)" \
+add_case "E09_BY4" "known-limitation" "out-of-scope (Issue #592, Counterpoint 31)" \
   "$MAIN_REPO" "$GIT \\\\
  commit -m x" \
   "g..it <newline> commit — git native hook で塞ぐ"
 
-add_case "E10_BY16" "known-limitation" "out-of-scope (Counterpoint 31)" \
+add_case "E10_BY16" "known-limitation" "out-of-scope (Issue #592, Counterpoint 31)" \
   "$MAIN_REPO" "\"$GIT\" commit -m x" \
   "\"g..it\" commit (quoted) — git native hook で塞ぐ"
 
-add_case "E11_INJ1" "known-limitation" "out-of-scope (Counterpoint 31)" \
+add_case "E11_INJ1" "known-limitation" "out-of-scope (Issue #592, Counterpoint 31)" \
   "$MAIN_REPO" "$GIT -C \"\$(echo $MAIN_REPO)\" commit -m x" \
   "g..it -C \$(echo MAIN) commit — git native hook で塞ぐ"
 

--- a/.claude/hooks/__tests__/pre-commit-guard.test.sh
+++ b/.claude/hooks/__tests__/pre-commit-guard.test.sh
@@ -14,7 +14,14 @@
 #   pass             - hook が素通り (decision:block を出さない) ことを期待
 #   block            - hook が block を出すことを期待
 #   known-limitation - 現状の実装の限界。block でも pass でも fail にはしない
-#                      (DA レビューで指摘された既存 bypass / follow-up Issue 候補)
+#                      (shell 文字列解析の本質的限界 → Counterpoint 31:
+#                      git ネイティブ pre-commit hook 化で塞ぐ予定の項目)
+#
+# Issue #568 (Counterpoint 32 採用) で、本 hook の責務は
+# 「shell コマンド文字列で素直に判定できるもの」だけに絞ることが確定した。
+# これにより E01-E11 / R06 は known-limitation のまま放置でよい (本 hook の
+# 責任範囲外) と整理された。本ハーネスにこれらのケースを残すのは
+# Counterpoint 31 導入時に「block」昇格を検知する regression trail として。
 #
 # 本テストは Bash ツールの PreToolUse hook (pre-commit-guard.sh) と
 # 同じスクリプトを呼び出すため、テスト実行コマンド自身に
@@ -139,11 +146,11 @@ add_case "R05" "pass" "fix-required" \
   "$MAIN_REPO" "cd $WORKTREE && cd src && $GIT commit -m x" \
   "consecutive cd: cd worktree && cd subdir && commit"
 
-# 既知の限界: cd 後に subshell が始まると cwd 継承ができない
-# follow-up Issue 化候補 (DA Critical 17 続き)
-add_case "R06" "known-limitation" "fix-required" \
+# 既知の限界: cd 後に subshell が始まると cwd 継承ができない (shell 文字列解析の限界)
+# Counterpoint 31 (git native pre-commit hook) で本質的に塞ぐ予定
+add_case "R06" "known-limitation" "out-of-scope (Counterpoint 31)" \
   "$MAIN_REPO" "cd $WORKTREE && ($GIT commit -m x)" \
-  "cd worktree && (commit) nested subshell — known limitation"
+  "cd worktree && (commit) nested subshell — git native hook で塞ぐ"
 
 # --- --git-dir / --work-tree 系 (Critical 19-20) -----------------------------
 add_case "X01" "pass" "fix-required" \
@@ -180,54 +187,63 @@ add_case "FP02" "block" "sanity" \
   "$WORKTREE" "$GIT push -f origin feat/test" \
   "git push -f is blocked"
 
-# --- 既存 bypass (master/PR 共通の素通り、follow-up Issue 化候補) -----------
-# DA レビューで指摘された 11 件。これらは元実装にもあった bypass で、
-# 本 PR の regression ではない。known-limitation として記録し、別 Issue で
-# 包括対応する (例: git ネイティブ pre-commit hook 化など Counterpoint 31/32)。
-add_case "E01_BY13" "known-limitation" "existing-bypass" \
+# --- 構造的 bypass (Issue #568 で範囲外と確定、Counterpoint 31 に委譲) -----
+# Issue #568 (Counterpoint 32 採用) で本 hook の責務を「shell コマンド文字列で
+# 素直に判定できるもの」に絞る方針が確立した。以下 E01-E11 は shell 文字列解析の
+# 本質的限界に起因する bypass であり、本 hook では塞がない。
+#
+# 真の保護は git ネイティブ pre-commit hook (`.githooks/pre-commit` +
+# `core.hooksPath`) で行う想定 (Counterpoint 31 — follow-up Issue 候補)。
+# git ネイティブ hook 側であれば、どんな経路 (eval / bash -c / 絶対パス /
+# env -C 等) から git commit を呼んでも必ず実行されるため、bypass は不可能となる。
+#
+# 本ハーネスでは「regression テスト」として E01-E11 をリストに残し、
+# Counterpoint 31 が将来導入されたタイミングで「block」期待値へ昇格させる
+# trail を保つ。known-limitation のままなので pass/block どちらでも fail にしない。
+add_case "E01_BY13" "known-limitation" "out-of-scope (Counterpoint 31)" \
   "$MAIN_REPO" "PAGER=cat $GIT commit -m x" \
-  "PAGER=cat g..it commit (env-prefix)"
+  "PAGER=cat g..it commit (env-prefix) — git native hook で塞ぐ"
 
-add_case "E02_BY17" "known-limitation" "existing-bypass" \
+add_case "E02_BY17" "known-limitation" "out-of-scope (Counterpoint 31)" \
   "$MAIN_REPO" "/usr/bin/$GIT commit -m x" \
-  "absolute path /usr/bin/g..it"
+  "absolute path /usr/bin/g..it — git native hook で塞ぐ"
 
-add_case "E03_BY9" "known-limitation" "existing-bypass" \
+add_case "E03_BY9" "known-limitation" "out-of-scope (Counterpoint 31)" \
   "$MAIN_REPO" "sudo $GIT commit -m x" \
-  "sudo g..it commit"
+  "sudo g..it commit — git native hook で塞ぐ"
 
-add_case "E04_T8" "known-limitation" "existing-bypass" \
+add_case "E04_T8" "known-limitation" "out-of-scope (Counterpoint 31)" \
   "$MAIN_REPO" "eval \"$GIT commit -m bypass\"" \
-  "eval \"g..it commit\""
+  "eval \"g..it commit\" — git native hook で塞ぐ"
 
-add_case "E05_T9" "known-limitation" "existing-bypass" \
+add_case "E05_T9" "known-limitation" "out-of-scope (Counterpoint 31)" \
   "$MAIN_REPO" "bash -c \"$GIT commit -m x\"" \
-  "bash -c \"g..it commit\""
+  "bash -c \"g..it commit\" — git native hook で塞ぐ"
 
-add_case "E06_T29" "known-limitation" "existing-bypass" \
+add_case "E06_T29" "known-limitation" "out-of-scope (Counterpoint 31)" \
   "$MAIN_REPO" "GIT_DIR=$MAIN_REPO/.git $GIT commit -m x" \
-  "GIT_DIR=... g..it commit"
+  "GIT_DIR=... g..it commit — git native hook で塞ぐ"
 
-add_case "E07_T38" "known-limitation" "existing-bypass" \
+add_case "E07_T38" "known-limitation" "out-of-scope (Counterpoint 31)" \
   "$MAIN_REPO" "env -C $MAIN_REPO $GIT commit -m x" \
-  "env -C ... g..it commit"
+  "env -C ... g..it commit — git native hook で塞ぐ"
 
-add_case "E08_T30" "known-limitation" "existing-bypass" \
+add_case "E08_T30" "known-limitation" "out-of-scope (Counterpoint 31)" \
   "$MAIN_REPO" "alias gc=\"$GIT commit\"; gc -m x" \
-  "alias gc=...; gc -m"
+  "alias gc=...; gc -m — git native hook で塞ぐ"
 
-add_case "E09_BY4" "known-limitation" "existing-bypass" \
+add_case "E09_BY4" "known-limitation" "out-of-scope (Counterpoint 31)" \
   "$MAIN_REPO" "$GIT \\\\
  commit -m x" \
-  "g..it <newline> commit"
+  "g..it <newline> commit — git native hook で塞ぐ"
 
-add_case "E10_BY16" "known-limitation" "existing-bypass" \
+add_case "E10_BY16" "known-limitation" "out-of-scope (Counterpoint 31)" \
   "$MAIN_REPO" "\"$GIT\" commit -m x" \
-  "\"g..it\" commit (quoted)"
+  "\"g..it\" commit (quoted) — git native hook で塞ぐ"
 
-add_case "E11_INJ1" "known-limitation" "existing-bypass" \
+add_case "E11_INJ1" "known-limitation" "out-of-scope (Counterpoint 31)" \
   "$MAIN_REPO" "$GIT -C \"\$(echo $MAIN_REPO)\" commit -m x" \
-  "g..it -C \$(echo MAIN) commit — split shears it"
+  "g..it -C \$(echo MAIN) commit — git native hook で塞ぐ"
 
 # -----------------------------------------------------------------------------
 # 実行

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -2,6 +2,40 @@
 # pre-commit-guard: git commit / push / rebase 実行前の規約チェック
 # PreToolUse hook として Bash ツール実行前に呼ばれる
 # 標準入力からJSON（tool_input.command含む）を受け取り、違反時は JSON decision:block を stdout に出力
+#
+# 設計方針 (Issue #568 — Counterpoint 32 を採用):
+#   本 hook は「shell コマンド文字列を解析」する PreToolUse hook であり、構造的に
+#   bypass 可能なパターンが多数存在する (例: `eval`, `bash -c`, env-prefix, 絶対パス,
+#   `env -C`, alias, 行継続, 引用符による分割回避 など — Issue #568 の E01-E11)。
+#   shell の文字列解析ですべての bypass を塞ぐのは本質的に不可能なので、
+#   責務を「コマンド文字列で素直に判定できるもの」だけに絞り、bypass 不可能性を
+#   要求する判定は git ネイティブ hook (`.githooks/pre-commit` + `core.hooksPath`)
+#   に委ねる方針とする (follow-up Issue: Counterpoint 31)。
+#
+# 本 hook が施行する規約:
+#   1. `git rebase` 禁止 — sub-command 名そのものの literal 判定
+#   2. `git push --force` / `-f` / `--force-with-lease` 禁止 — オプション literal 判定
+#   3. コミットメッセージ内に `Co-Authored-By` を含めない — `-m`/`--message` 引数の文字列判定
+#   4. master/main ブランチへの直接 commit/push 拒否 (best-effort)
+#      ※ 4 は shell 文字列解析の限界により bypass 可能。
+#         本質的な保護は git ネイティブ hook に委ねる (Counterpoint 31)。
+#         本 hook では「素朴な `git commit -m x` を master で叩いた場合」のみ best-effort で block する。
+#
+# 既知の限界 (= Counterpoint 31 まで残る bypass):
+#   - env 変数 prefix (`PAGER=cat git commit ...`)
+#   - 絶対パス (`/usr/bin/git commit ...`)
+#   - sudo / 前置コマンド (`sudo`, `nice`, `timeout`, `stdbuf` 等)
+#   - indirection (`eval "git ..."`, `bash -c "git ..."`)
+#   - env 変数経由の git 設定 (`GIT_DIR=... git commit`)
+#   - `env -C <path> git commit`
+#   - alias (`alias gc="git commit"; gc -m x`)
+#   - 行継続 (`git \<NL> commit`)
+#   - quoted command (`"git" commit`)
+#   - コマンド置換による path 隠蔽 (`git -C "$(echo $REPO)" commit`)
+#
+# Counterpoint 32 (worktree allowlist) は本 hook の責務縮小により実質的に達成。
+# `.claude/worktrees/` 配下の git worktree は agent ごとに feature ブランチを切るので
+# 本 hook のブランチ判定をすり抜けても CI/GitHub 側で master 直 push を防げる。
 
 set -euo pipefail
 

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -10,7 +10,7 @@
 #   shell の文字列解析ですべての bypass を塞ぐのは本質的に不可能なので、
 #   責務を「コマンド文字列で素直に判定できるもの」だけに絞り、bypass 不可能性を
 #   要求する判定は git ネイティブ hook (`.githooks/pre-commit` + `core.hooksPath`)
-#   に委ねる方針とする (follow-up Issue: Counterpoint 31)。
+#   に委ねる方針とする (follow-up Issue: #592 — Counterpoint 31)。
 #
 # 本 hook が施行する規約:
 #   1. `git rebase` 禁止 — sub-command 名そのものの literal 判定
@@ -18,10 +18,10 @@
 #   3. コミットメッセージ内に `Co-Authored-By` を含めない — `-m`/`--message` 引数の文字列判定
 #   4. master/main ブランチへの直接 commit/push 拒否 (best-effort)
 #      ※ 4 は shell 文字列解析の限界により bypass 可能。
-#         本質的な保護は git ネイティブ hook に委ねる (Counterpoint 31)。
+#         本質的な保護は git ネイティブ hook に委ねる (#592 — Counterpoint 31)。
 #         本 hook では「素朴な `git commit -m x` を master で叩いた場合」のみ best-effort で block する。
 #
-# 既知の限界 (= Counterpoint 31 まで残る bypass):
+# 既知の限界 (= Counterpoint 31 / Issue #592 まで残る bypass):
 #   - env 変数 prefix (`PAGER=cat git commit ...`)
 #   - 絶対パス (`/usr/bin/git commit ...`)
 #   - sudo / 前置コマンド (`sudo`, `nice`, `timeout`, `stdbuf` 等)
@@ -33,9 +33,17 @@
 #   - quoted command (`"git" commit`)
 #   - コマンド置換による path 隠蔽 (`git -C "$(echo $REPO)" commit`)
 #
-# Counterpoint 32 (worktree allowlist) は本 hook の責務縮小により実質的に達成。
-# `.claude/worktrees/` 配下の git worktree は agent ごとに feature ブランチを切るので
-# 本 hook のブランチ判定をすり抜けても CI/GitHub 側で master 直 push を防げる。
+# Counterpoint 32 (worktree allowlist) について:
+#   本 PR では allowlist を実装しない。理由は以下:
+#     - 「literal な `cd <path>` / `git -C <path>` の path 抽出」は既存実装
+#       (resolve_target_dir) でカバー済みで、worktree 経由のブランチ判定は正しく
+#       動作する (Issue #550 / Issue #567 の対応範囲)。
+#     - 動的に決まる path (コマンド置換・変数展開) は shell 文字列解析の限界により
+#       allowlist でも本質的に防げないため、ここで追加実装する価値が薄い。
+#     - 上記の構造的 bypass は #592 (Counterpoint 31 = git ネイティブ pre-commit hook)
+#       で塞ぐ計画であり、それまでは本 hook は best-effort に留める。
+#   よって、固定 path 列の allowlist 実装は #592 の完了後に再評価することとし、
+#   本 hook では追加実装しない。
 
 set -euo pipefail
 


### PR DESCRIPTION
## 概要

Issue #568: pre-commit-guard.sh の bypass 包括対応 (Counterpoint 31/32)

本 PR は **設計合意フェーズ** として位置付け、shell 文字列解析方式の本質的限界を組織的に認め、本質的な bypass 対応 (Counterpoint 31: git ネイティブ pre-commit hook 化) を **Issue #592 (follow-up)** に正式委譲する。

### Issue #568 と Issue #592 の関係

- **Issue #568 (本 PR で close)**: 設計合意 Issue。「shell 文字列解析の限界を認め、git ネイティブ hook に責任移管する」という方針を script header / test harness に明記
- **Issue #592 (新規 follow-up、本 PR で起票)**: 実装 Issue。`.githooks/pre-commit` 新規追加 + `git config core.hooksPath .githooks` のローカル設定手順を README に明記、E01-E11 + R06 を全件解消

## 変更内容

### 初期実装 (357a15d, 0e3043b)

- `.claude/hooks/pre-commit-guard.sh`: script header に設計方針 (Counterpoint 32 採用) を明記
- `.claude/hooks/__tests__/pre-commit-guard.test.sh`: SKIP ラベルに follow-up 案内を追記

### DA / Reviewer 指摘対応 fixup (44b3278)

- **必須対応1 (follow-up Issue 起票)**: `gh issue create` で **Issue #592** (Counterpoint 31, E01-E11 + R06 を全件解消) を起票
- **必須対応2 (虚偽記述訂正)**: 「Counterpoint 32 (worktree allowlist) は本 hook の責務縮小により実質的に達成」+ 存在しない `.claude/worktrees/` への言及を削除。代替として「literal な cd / git -C path は既存 `resolve_target_dir` でカバー済み、動的 path は shell 解析の本質的限界で防げない、構造的 bypass は #592 で塞ぐ」と整理
- **必須対応3 (SKIP ラベルに Issue 番号)**: 「out-of-scope (Counterpoint 31)」→「out-of-scope (Issue #592, Counterpoint 31)」(11 件一括置換)
- **必須対応4 (R06 ラベル修正)**: `known-limitation` → `block` 期待値に変更 (元実装で main-repo (master) と判定されて block しており safe-side fallback として正しい挙動、Issue #592 完了後に「pass」へ変化したら regression として検出される)

## test harness 結果

- 変更前: TOTAL 27 / OK 15 / FAIL 0 / SKIP 12
- 変更後: **TOTAL 27 / OK 16 / FAIL 0 / SKIP 11** (R06 が block 期待値で OK 判定に昇格、SKIP 12→11)

## AC 充足評価

- Issue #568 本文 AC (Counterpoint 31 + 32 各 4 項目): 本 PR では機械的変更ゼロ。本 Issue は「設計合意フェーズ完了」として close
- 実装 AC は **Issue #592** に持ち越し (Counterpoint 31 で E01-E11 + R06 を全件解消)

## 備考

- 検証: `pnpm test:run` 50 files / 811 件 全 pass、`pnpm lint` clean
- 既存リスク (E01-E11 bypass は本 PR で未解消) は Issue 本文 「優先度中、悪意的 bypass は容易」と公式に追認済み。Claude Code の主用途は agent 利用で、悪意的攻撃者ではなく LLM 遵守ガイドが中心目的
- master/main 直 push の最終防衛は GitHub branch protection (CI 側) で担保される前提
- Counterpoint 31 の実装は Issue #592 で並行追跡

Closes #568