### PR TITLE
chore: markdownParser splitLines JSDoc と RFC editorial-citrus の補足追記

### DIFF
--- a/docs/rfc/editorial-citrus/README.md
+++ b/docs/rfc/editorial-citrus/README.md
@@ -40,4 +40,5 @@ v1 RFC (`01-concept-and-personas.md` 〜 `09-glossary-and-decisions.md`) は本 
   - **2026-05-16 時点: 未実装 (Issue #520 / PR #557 で `src/lib/meta.ts` を削除済)**
   - 当初 `## メタ` セクションで `status` / `published_at` / `updated_at` / `tags` を任意拡張する設計が `src/lib/meta.ts` に実装されていたが、実利用されないまま死蔵していたため Issue #520 / PR #557 で削除した
   - 再導入する場合は、削除直前の実装 (`git show 6014792^:src/lib/meta.ts`) およびテスト境界値拡充の参考 (`git show 15523ad`) を起点に、本 RFC の互換性の約束 (既存記事無改変) を守る形で書き直すこと
+  - 参考 SHA に関する注記 (Issue #582): Issue #558 本文の受け入れ基準では `15523ad` と `cd05b6c` の両 SHA 参照が要請されていたが、`cd05b6c` はリポジトリに存在しない誤参照である (`git rev-parse cd05b6c` → unknown revision)。実在するのは `15523ad` (テスト拡充時点) と `6014792^` (削除直前) のみであり、本 RFC および PR #594 の `splitLines` バックポート実装ではこの 2 つを参照している
 - 既存 Gruvbox カラーはコードハイライト用途で温存

--- a/docs/rfc/editorial-citrus/README.md
+++ b/docs/rfc/editorial-citrus/README.md
@@ -40,5 +40,5 @@ v1 RFC (`01-concept-and-personas.md` 〜 `09-glossary-and-decisions.md`) は本 
   - **2026-05-16 時点: 未実装 (Issue #520 / PR #557 で `src/lib/meta.ts` を削除済)**
   - 当初 `## メタ` セクションで `status` / `published_at` / `updated_at` / `tags` を任意拡張する設計が `src/lib/meta.ts` に実装されていたが、実利用されないまま死蔵していたため Issue #520 / PR #557 で削除した
   - 再導入する場合は、削除直前の実装 (`git show 6014792^:src/lib/meta.ts`) およびテスト境界値拡充の参考 (`git show 15523ad`) を起点に、本 RFC の互換性の約束 (既存記事無改変) を守る形で書き直すこと
-  - 参考 SHA に関する注記 (Issue #582): Issue #558 本文の受け入れ基準では `15523ad` と `cd05b6c` の両 SHA 参照が要請されていたが、`cd05b6c` はリポジトリに存在しない誤参照である (`git rev-parse cd05b6c` → unknown revision)。実在するのは `15523ad` (テスト拡充時点) と `6014792^` (削除直前) のみであり、本 RFC および PR #594 の `splitLines` バックポート実装ではこの 2 つを参照している
+  - 参考 SHA に関する注記 (Issue #582): Issue #558 本文の受け入れ基準では `15523ad` と `cd05b6c` の両 SHA 参照が要請されていたが、`cd05b6c` はリポジトリに存在しない誤参照である (`git rev-parse cd05b6c` → unknown revision)。実在するのは `15523ad` (テスト拡充時点) と `6014792^` (削除直前) のみであり、本 RFC および PR #584 の `splitLines` バックポート実装ではこの 2 つを参照している
 - 既存 Gruvbox カラーはコードハイライト用途で温存

--- a/src/lib/markdownParser.ts
+++ b/src/lib/markdownParser.ts
@@ -6,7 +6,14 @@
  * Markdown 全文を行配列に変換する
  *
  * - 文字列冒頭の UTF-8 BOM (U+FEFF) を 1 文字除去する
- * - 改行コードは CRLF (`\r\n`) / LF (`\n`) / CR (`\r`) の 3 種を許容する
+ *   (ファイルとしての BOM は仕様上ファイル先頭にしか存在しえないため、
+ *   冒頭 1 文字のみ除去すれば十分。文字列途中に現れる U+FEFF は本来の
+ *   ゼロ幅ノーブレークスペースとして意図的に挿入された可能性があるので
+ *   保持する)
+ * - 改行コードは CRLF (`\r\n`) / LF (`\n`) / CR (`\r`) の ASCII 3 種を許容する
+ *   (Unicode 改行 LINE SEPARATOR `U+2028` / PARAGRAPH SEPARATOR `U+2029`
+ *   は Markdown ソースとして流入することがほぼ無いため非対応。
+ *   必要になった時点で対応範囲を拡張する)
  *
  * 旧 `src/lib/meta.ts` の `splitLines` (Issue #520 で削除) が持っていた
  * BOM 除去 + CRLF/LF/CR 三対応のノウハウを `markdownParser.ts` 側に


### PR DESCRIPTION
## 概要

PR #594 (Issue #558) の DA レビュー Moderate 反論 2 件の follow-up。
PR 自体は merge YES だったが保守性向上目的で別 Issue (#582) として登録されたものへの対応。

splitLines 実装の設計判断と、Issue #558 本文の SHA 誤参照という 2 つの「未文書化の前提」を、それぞれ JSDoc / RFC に最小限の追補で残し、将来の保守時にコードベースだけで意図を読み取れる状態にする。

Closes #582

## 変更内容

- `src/lib/markdownParser.ts`: `splitLines` の JSDoc に PR #594 の設計判断の理由付けを追記
  - 「冒頭 1 文字のみ BOM 除去する理由」(ファイル BOM は仕様上ファイル先頭にしか存在しえない / 途中の U+FEFF は ZWNBSP として意図的に挿入された可能性があるため保持)
  - 「ASCII 改行 3 種のみサポートする理由」(Unicode 改行 `U+2028` / `U+2029` は Markdown ソースとして流入することがほぼ無いため非対応。必要になった時点で拡張)
- `docs/rfc/editorial-citrus/README.md`: `src/lib/meta.ts` 削除注記の再導入手順に、SHA 参照に関する 1 行注記を追加
  - Issue #558 本文の受け入れ基準は `15523ad` と `cd05b6c` の両 SHA 参照を要請していたが、`cd05b6c` はリポジトリに存在しない誤参照 (`git rev-parse cd05b6c` → unknown revision)
  - 実在するのは `15523ad` (テスト拡充時点) と `6014792^` (削除直前) のみ
  - PR #594 ではこの 2 つの実在 SHA で代替済

## 備考

- 事前確認: `git rev-parse cd05b6c` で誤参照を実機確認 / `git rev-parse 15523ad 6014792` で実在を実機確認
- RFC は既に実装と整合 (削除済み事実を反映済) のため、追記での対応が適切と判断 (削除や方針変更は不要)
- `pnpm test:run`: 837 tests passed (50 files)
- `pnpm lint`: No fixes applied (118 files)
- Anchor 型を扱う変更ではないため Anchor チェックブロックは対象外