### PR TITLE
chore: tsconfig.json の types フィールド位置を compilerOptions 内に正規化

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,9 +18,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    /* Types */
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src", "scripts"],
-  "types": ["vitest/globals", "@testing-library/jest-dom"],
   "references": [{ "path": "./tsconfig.build.json" }]
 }


### PR DESCRIPTION
## 概要

`tsconfig.json` の `"types"` フィールドが `compilerOptions` の外側に書かれており、TypeScript コンパイラに無視されていた既存バグを是正する (Issue #590)。

- 修正前: `tsc --showConfig` 出力に `types` が含まれず、`vitest/globals` / `@testing-library/jest-dom` の型は **暗黙取込** (types 未指定時のデフォルト挙動 = `node_modules/@types/*` を全部取り込む) に依存して解決されていた
- 修正後: `types` が `compilerOptions.types` として正しく適用され、`vitest/globals` と `@testing-library/jest-dom` の 2 つに限定される

PR #591 (Issue #522) で `tsconfig.json` の `include` に `scripts/` を追加した結果、この既存バグの影響範囲が広がるため対応。

## 変更内容

- `tsconfig.json`: 25 行目にあった `"types"` フィールドを `compilerOptions` 内へ移動。既存の `/* Bundler mode */` `/* Linting */` セクション分割と整合させ `/* Types */` セクションコメントを追加

## 受け入れ基準

- [x] `tsconfig.json` の `"types"` フィールドが `compilerOptions` 内に正しく配置
- [x] `tsc --showConfig` 出力に `types` が反映されることを実機確認
- [x] `pnpm type-check` / `pnpm type-check:test` 全 pass

## 実機検証結果

- `npx tsc --showConfig` の `compilerOptions.types` に `["vitest/globals", "@testing-library/jest-dom"]` が反映されることを確認
- `npx tsc --showConfig --project tsconfig.test.json` の `compilerOptions.types` は extends 経由で継承された後、tsconfig.test.json 側の自前 `types` (`["vitest/globals", "@testing-library/jest-dom", "vite/client"]`) で正しく上書きされていることを確認
- `pnpm type-check` pass
- `pnpm type-check:test` pass
- `pnpm test:run` 837 件全 pass
- `pnpm lint` pass

## 補足 (別 Issue 化推奨)

本変更により `types` が 2 つに限定された結果、TypeScript の `typeRoots` (`node_modules/@types`) からの暗黙取込は抑止される。ただし `scripts/` 配下では `process.argv` 等の Node API を使用しており、現状は `@types/node@17.0.45` が pnpm の transitive dependency として `node_modules/.pnpm/@types+node@17.0.45/` に存在し、`import { ... } from "node:fs"` 等の経由で ambient module として型解決されている。

この「`@types/node` を devDependencies に明示せず transitive 依存に頼っている」という構造は本 PR とは独立した既存課題であり、依存ツリーの変化で消える可能性がある。別 Issue として切り出して検討することを推奨する。

Closes #590

## 備考

<details>
<summary>Anchor 型を扱う PR のみチェック (Issue #556)</summary>

本 PR は tsconfig.json の修正のみで Anchor 型に関わる変更は含まないため、本ブロックは対象外。

</details>