### PR TITLE
chore: AnchorPage.allPosts.test.tsx の milestonesData キャストに narrowing 理由コメント追加 (Issue #546 follow-up)

### DIFF
--- a/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
+++ b/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
@@ -26,6 +26,12 @@ import { AnchorPage } from "../AnchorPage";
  * することで記事の追加・削除に追従できるテストにする。
  */
 
+// `as readonly Milestone[]` は resolveJsonModule:true で widen された JSON 型
+// (`tone: string`) を `Milestone` (`tone: "neutral" | "light" | "heavy"`) に
+// narrowing するキャスト。設計判断の正本 (集約せず各 page で個別 import / 撤退方法
+// / 不正値時の挙動など) は pages/anchor.tsx の MILESTONES JSDoc を参照 (Issue #546)。
+// 本テストは「本物の milestones.json を入力にする回帰テスト」のため、production と
+// 同一の narrowing キャストをそのまま再現する。
 const milestones: readonly Milestone[] = milestonesData as readonly Milestone[];
 
 const postFilePaths = Object.keys(import.meta.glob("/datasources/*.md"));


### PR DESCRIPTION
## 概要

Issue #583 (Issue #546 follow-up) の対応。`AnchorPage.allPosts.test.tsx` に残っていた `milestonesData as readonly Milestone[]` キャストに、narrowing の存在理由と pages/anchor.tsx の MILESTONES JSDoc (Issue #546 の設計判断正本) へのポインタを示す軽量コメントを追加する。

判断: **案 1 (1 〜数行の補足コメント追加)** を採用。

## 変更内容

- `src/components/pages/__tests__/AnchorPage.allPosts.test.tsx`:
  - `milestonesData as readonly Milestone[]` キャストの直前に 6 行コメントを追加
  - キャストの存在理由 (`resolveJsonModule:true` で widen された `tone: string` を `Milestone` の union 型に narrowing する目的) を明示
  - 設計判断の正本 (集約せず各 page で個別 import / 撤退方法 / 不正値時の挙動など) は `pages/anchor.tsx` の MILESTONES JSDoc (Issue #546) を参照する旨を併記
  - テストファイル側はコメントを最小限に留め、pages/*.tsx 側との粒度差を意図的に保つ

## 判断根拠 (3 案の比較)

| 案 | 評価 | 採否理由 |
|----|------|----------|
| 案 1: 補足コメント追加 | **採用** | narrowing キャストの存在理由を明示しつつ、設計正本は pages 側にポインタで委譲することで二重管理を避ける。コメント粒度を pages 側より薄く保つことで「過剰コメント化リスク」も回避 |
| 案 2: テスト用ヘルパー化 | 不採用 | Issue 本文の対象 2 件のうち `Coordinate.allPosts.test.tsx` は既に `testMilestones` で内製ハードコード化済み (本物の `milestones.json` を import していない)。実質対象は本ファイル 1 箇所のみで、薄いヘルパー化の抽象化コストが narrowing キャスト 1 行より重い |
| 案 3: 何もしない | 不採用 | Issue が起票されており、最小コストで可読性を上げられるなら案 1 を優先 |

## Issue 本文と実態の差分メモ

Issue #583 の対象として `Coordinate.allPosts.test.tsx:28` も挙げられていたが、実装の現状は `import milestonesData from "../../../../datasources/milestones.json"` を**行っておらず**、`testMilestones` という不変スナップショットを 3 件ハードコードしている (fixture 検算との一対関係を保つ意図、当該ファイル冒頭の JSDoc 参照)。したがって narrowing キャスト統一の対象は実態として **AnchorPage.allPosts.test.tsx 1 件のみ**。

## 別 Issue 化推奨

- `src/lib/__tests__/anchors.test.ts:645` の `milestonesJson as readonly Milestone[]` も同パターンだが、Issue #583 の明示スコープ外のため本 PR では触らない。気になる場合は別 Issue で整合させると良い。

## 備考

- 既存テスト 837 件 pass
- `pnpm lint` / `pnpm type-check` clean
- production コード経路への影響なし (テストファイルへのコメント追加のみ)

Closes #583