### PR TITLE
chore: anchors.test.ts の milestonesJson キャストに narrowing 理由コメント追加

### DIFF
--- a/src/lib/__tests__/anchors.test.ts
+++ b/src/lib/__tests__/anchors.test.ts
@@ -642,6 +642,12 @@ describe("型レベル: Coordinate / Elapsed の nominal 化 (Issue #497)", () =
 //   - 要素の daysSince が NaN
 describe("Issue #489 AC: 実データ統合 (milestones.json × 全記事)", () => {
   const datasourcesDir = join(__dirname, "..", "..", "..", "datasources");
+  // `as readonly Milestone[]` は resolveJsonModule:true で widen された JSON 型
+  // (`tone: string`) を `Milestone` (`tone: "neutral" | "light" | "heavy"`) に
+  // narrowing するキャスト。設計判断の正本 (集約せず各 page で個別 import / 撤退方法
+  // / 不正値時の挙動など) は pages/anchor.tsx の MILESTONES JSDoc を参照 (Issue #546)。
+  // 本テストは「本物の milestones.json を入力にする回帰テスト」のため、production と
+  // 同一の narrowing キャストをそのまま再現する。
   const milestones = milestonesJson as readonly Milestone[];
 
   const collectPostPublishedAts = (): readonly string[] => {


### PR DESCRIPTION
## 概要

PR #598 (Issue #583) で `AnchorPage.allPosts.test.tsx` に追加した narrowing 理由コメント (6 行) と同形式のコメントを、同パターンが残存していた `src/lib/__tests__/anchors.test.ts:645` のキャスト直前にも追加し、保守時の認知負荷を整合させる。

`Coordinate.allPosts.test.tsx` の JSDoc (L220-222) で「本番 JSON を直接 import している `AnchorPage.allPosts.test.tsx` / `anchors.test.ts` および開発者の意識的な fixture 更新で担保する設計」と既に言及されており、anchors.test.ts は narrowing キャスト戦略上重要な存在として認識済み。今回両者を揃えることで、片方だけ JSDoc が薄い違和感を解消する。

Closes #603

## 変更内容

- `src/lib/__tests__/anchors.test.ts`:
  本番 JSON (`datasources/milestones.json`) を直接 import している統合テスト内の `as readonly Milestone[]` キャスト直前に、PR #598 と同粒度・同形式の 6 行コメントを追加。
  - キャストが `resolveJsonModule:true` で widen された JSON 型 (`tone: string`) を `Milestone` (`tone: "neutral" | "light" | "heavy"`) に narrowing する目的であること
  - 設計判断の正本 (集約せず各 page で個別 import / 撤退方法 / 不正値時の挙動など) は `pages/anchor.tsx` の MILESTONES JSDoc (Issue #546) を参照すべきこと
  - 本テストは「本物の milestones.json を入力にする回帰テスト」のため、production と同一の narrowing キャストをそのまま再現する旨

## 備考

- 既存テストの振る舞いに変化なし (コメント追加のみ)。
- `pnpm test:run` (837 件 pass) / `pnpm lint` / `pnpm type-check` 全 pass を確認済み。
- PR #598 と粒度整合: 同じ 6 行構成 (キャストの目的 2 行 + 設計正本ポインタ 2 行 + 本テストの位置づけ 2 行) で文面を揃えた。