### PR TITLE
chore: panda-hash-regression workflow の sed/grep 失敗時 diagnostic 強化 (Issue #572)

### DIFF
--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -60,6 +60,15 @@ jobs:
           fi
           if ! grep -qE '^\s*hash:\s*true,?\s*$' panda.config.ts; then
             echo "::error::panda.config.ts への hash:true 挿入に失敗しました。preflight 行の書式が想定 (^\\s*preflight: true,?$) と異なる可能性があります。確認ポイント: (1) preflight 行の末尾カンマ有無 (sed の置換失敗) / (2) preflight 行がコメントアウトされていないか / (3) 別記法 (例: preflight: { enabled: true } 等の object 表記) に変わっていないか / (4) 行頭に空白/タブ以外の文字 (YAML マーカー '-' / CR-LF の CR 混入など) が紛れていないか。"
+            # Issue #572: 失敗時に panda.config.ts の preflight 周辺行 (L15-30)
+            # を dump し、上記 (1)-(4) のどれが原因かを実機の現物で切り分け
+            # 可能にする。正常系では本ブロックには到達しない (exit 1 で job
+            # が止まる) ため、後段の "patched head" dump との二重出力には
+            # ならない。cat -A を使い、行末の CR (`^M`) や trailing space ($)
+            # を可視化して (4) の検出を補助する。
+            echo "--- panda.config.ts (preflight 周辺, L15-30) ---" >&2
+            sed -n '15,30p' panda.config.ts | cat -A >&2
+            echo "--- end of dump ---" >&2
             exit 1
           fi
           echo "--- panda.config.ts (patched head) ---"


### PR DESCRIPTION
## 概要

Issue #572 「chore: panda-hash-regression workflow の sed/grep 失敗時 diagnostic 強化 (Issue #527 follow-up)」の対応。

`.github/workflows/panda-hash-regression.yml` の hash:true 挿入ステップで、grep による検証失敗時 (exit 1 直前) に panda.config.ts の preflight 周辺行を dump する diagnostic ブロックを追加し、原因切り分けを容易にする。

Closes #572

## 変更内容

- `.github/workflows/panda-hash-regression.yml`: hash:true 挿入後の grep 検証 (`if ! grep ...; then`) で失敗した場合、`exit 1` の直前に `sed -n '15,30p' panda.config.ts | cat -A` で panda.config.ts の preflight 周辺行 (L15-30) を stderr に dump するブロックを追加。`cat -A` により行末の CR (`^M`) や trailing space (`$`) も可視化され、Issue #572 で列挙された 4 つの失敗原因 ((1) カンマ有無 / (2) コメントアウト / (3) 別記法 / (4) CR-LF 混入等) のどれが該当するかを実機の現物で切り分け可能にする。

## 受け入れ基準の充足

- [x] 失敗時 (exit 1 直前) に panda.config.ts の preflight 周辺行が出力される
- [x] 既存の正常系で出力が二重にならない (exit 1 で job が止まり、後段の "patched head" dump (L74-75) には到達しないため)
- [ ] workflow_dispatch で正常系の動作確認 → 本 workflow は master からのみ実行可能 (`on: workflow_dispatch` のみ、push トリガーなし) のため、merge 後に Actions UI から手動実行で検証する

## 備考

- `cat -A` は GNU coreutils の機能。本 workflow は `runs-on: ubuntu-latest` 固定のため動作担保される。
- 失敗系の diagnostic 出力は stderr に出すことで、正常系の stdout ログとの混在を防いだ。