### PR TITLE
chore: precommit-guard-tests workflow の期待 SKIP count drift を修正 (12 → 11)

### DIFF
--- a/.github/workflows/precommit-guard-tests.yml
+++ b/.github/workflows/precommit-guard-tests.yml
@@ -90,7 +90,7 @@ jobs:
             echo "## pre-commit-guard test harness";
             echo "";
             if [ -n "$out_file" ] && [ -f "$out_file" ]; then
-              # TOTAL 行 (例: "TOTAL: 27  OK: 15  FAIL: 0  SKIP(known-limitation): 12")
+              # TOTAL 行 (例: "TOTAL: 27  OK: 16  FAIL: 0  SKIP(known-limitation): 11")
               # を抽出して目立つ位置に置く。grep が一致しない場合に備えて || true。
               total_line=$(grep -E '^TOTAL:' "$out_file" || true)
               if [ -n "$total_line" ]; then

--- a/.github/workflows/precommit-guard-tests.yml
+++ b/.github/workflows/precommit-guard-tests.yml
@@ -56,10 +56,12 @@ jobs:
         # literal 一致 grep で固定化する。
         #
         # harness の TOTAL 行例:
-        #   TOTAL: 27  OK: 15  FAIL: 0  SKIP(known-limitation): 12
+        #   TOTAL: 27  OK: 16  FAIL: 0  SKIP(known-limitation): 11
         #
-        # 期待値は現状 12 (Issue #550 の DA レビューで指摘された既存 bypass 11
-        # + R06 nested subshell 1)。新たに known-limitation が追加された
+        # 期待値は現状 11 (Issue #568 / PR #594 で R06 nested subshell を
+        # known-limitation から「block」期待値へ昇格させたことで、Issue #550
+        # の DA レビューで指摘された既存 bypass 11 件 = E01-E11 のみが
+        # known-limitation として残る)。新たに known-limitation が追加された
         # (= SKIP が増えた) regression を CI 上で検知し、harness 側と本
         # workflow 側を同 PR で更新する運用に倒す。
         run: |
@@ -69,8 +71,8 @@ jobs:
             echo "::error::harness output file not found: $out_file"
             exit 1
           fi
-          if ! grep -qE 'SKIP\(known-limitation\): 12$' "$out_file"; then
-            echo "::error::Expected 'SKIP(known-limitation): 12' but harness output diverged."
+          if ! grep -qE 'SKIP\(known-limitation\): 11$' "$out_file"; then
+            echo "::error::Expected 'SKIP(known-limitation): 11' but harness output diverged."
             echo "::error::Check harness output below and update either the harness or this workflow in the same PR."
             grep -E '^TOTAL:' "$out_file" || echo "(TOTAL line not found in harness output)"
             exit 1


### PR DESCRIPTION
## 概要

`precommit-guard-tests` workflow の assert ステップが `SKIP(known-limitation): 12` を期待しているが、harness 出力は `SKIP(known-limitation): 11` であり、master 起点で本 workflow が常時 fail している。後続 PR (#595-#599) が CI UNSTABLE 化しているため、緊急で期待値を 11 へ追従させる。

## 変更内容

- `.github/workflows/precommit-guard-tests.yml`: assert ステップの期待値 `SKIP\(known-limitation\): 12` → `SKIP\(known-limitation\): 11` へ更新。コメントも整合させ「R06 を block 期待値へ昇格させた結果、既存 bypass 11 件 = E01-E11 のみが known-limitation として残る」旨を明記。

## 判断根拠（harness 11 が正、workflow 12 が drift）

- PR #594 (`2ec3e34`, Issue #568 設計合意フェーズ) で R06 (`cd worktree && (git commit)` nested subshell) を `known-limitation` から「`block`」期待値へ意図的に昇格させた
  - 元コミットメッセージ: 「R06 期待値修正 (Issue #568 設計合意フェーズ)」
  - これにより SKIP 件数は 12 → 11 へ正当に減少
- harness 本体 (`.claude/hooks/__tests__/pre-commit-guard.test.sh`) のコメントも「Issue #568 (Counterpoint 32 採用) で本 hook の責務を絞った結果、E01-E11 (= 11 件) のみが known-limitation」と明示
- ローカル実機実行結果: `TOTAL: 27  OK: 16  FAIL: 0  SKIP(known-limitation): 11`
- workflow 側 assert だけが旧期待値 12 のまま取り残されていた drift

harness を 12 に戻す選択肢もあり得たが、PR #594 は Issue #568 の設計合意フェーズの正規修正であり戻すべきではない。workflow 側追従が正しい対応。

## 動作確認

ローカルで workflow assert ステップを再現:

```
TOTAL: 27  OK: 16  FAIL: 0  SKIP(known-limitation): 11
ASSERT PASS: SKIP(known-limitation): 11 matched
harness_exit=0
```

副作用チェック:

- `pnpm test:run`: 837 passed (50 files)
- `pnpm lint`: No fixes applied (118 files)
- `pnpm type-check`: OK

## 備考

Closes #600