### PR TITLE
chore: ci.yml の Type check 系 step を pnpm script 呼び出しに統一

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: pnpm lint:tokens
 
       - name: Type check
-        run: pnpm exec tsc --noEmit
+        run: pnpm type-check
 
       - name: Type check (test)
-        run: pnpm exec tsc -p tsconfig.test.json --noEmit
+        run: pnpm type-check:test


### PR DESCRIPTION
## 概要

Issue #579 対応。`ci.yml` の Type check 系 step を inline の `pnpm exec tsc ...` から `package.json` の `scripts` (`type-check` / `type-check:test`) 呼び出しに統一し、CI と script 間の drift リスクを解消する。

Closes #579

## 変更内容

- `.github/workflows/ci.yml`: Type check 系 step 2 つを script 呼び出しに統一
  - `pnpm exec tsc --noEmit` → `pnpm type-check`
  - `pnpm exec tsc -p tsconfig.test.json --noEmit` → `pnpm type-check:test`
  - `package.json` の script 内容を変更した際、CI 側が自動追従するようになる

### inline 版と script 版の差分（drift 確認結果）

| step | CI 旧 inline | package.json script | 差分 |
| ---- | ------------ | ------------------- | ---- |
| Type check | `pnpm exec tsc --noEmit` | `tsc --noEmit` | なし（完全一致） |
| Type check (test) | `pnpm exec tsc -p tsconfig.test.json --noEmit` | `tsc --noEmit --project tsconfig.test.json` | フラグ表記のみ差異あり (`-p` ⇔ `--project`、引数順) |

`-p` は `--project` の短縮形のため**意味的には等価**で、tsc の挙動・終了コードは同一。よって既存ジョブの動作変化はなし。本 PR 統一によって以降の drift は自動的に解消される。

## 備考

ローカル検証:

- `pnpm type-check` ... pass
- `pnpm type-check:test` ... pass
- `pnpm test:run` ... 837 tests pass
- `pnpm lint` ... pass
- `actionlint .github/workflows/ci.yml` ... pass (出力なし)