### PR TITLE
chore: Coordinate separator の color 重複宣言を撤去し Tripwire 網漏れを構造的に解消

### DIFF
--- a/src/components/common/Coordinate.tsx
+++ b/src/components/common/Coordinate.tsx
@@ -98,9 +98,14 @@ const containerStyles = css({
 
 // 区切り文字「・」のスタイル。aria-hidden で SR からは隠す
 // (項目区切りは ul/li 構造で SR に伝わるため、視覚装飾のみ)。
+//
+// Issue #536: 色は wrapper (containerStyles) の `color: "fg.muted"` を CSS の
+// 継承で受け取り、ここでは独自宣言しない。separator に同じ token を重複宣言
+// すると Tripwire 網漏れ (wrapper だけ検証されるため separator の color を
+// 別 token に差し替えても気付けない) を構造的に生むため、宣言自体を撤去して
+// 「色は wrapper 1 箇所」に統一する (案 B: 構造的解決)。
 const separatorStyles = css({
   marginInline: "xs",
-  color: "fg.muted",
 });
 
 /**

--- a/src/components/common/__tests__/Coordinate.test.tsx
+++ b/src/components/common/__tests__/Coordinate.test.tsx
@@ -234,6 +234,59 @@ describe("Coordinate", () => {
       // ul の親要素であることを確認 (Coordinate の wrapper は ul を内包する)
       expect(wrapper?.querySelector("ul")).not.toBeNull();
     });
+
+    // Issue #536 (案 B): separator span は独自の color 宣言を持たず、wrapper の
+    // `color: "fg.muted"` を CSS の継承で受け取る構造に統一する。重複宣言を
+    // 撤去することで「wrapper だけ Tripwire 検証されて separator の color 差し替えに
+    // 気付けない」網漏れを**構造的に**解消する (案 A の二重 data-token-color 化より
+    // CSS が 1 行減り、宣言箇所が 1 箇所に集約される)。
+    //
+    // 本テストは separator が独自 `data-token-color` を吐かないこと (= 色は wrapper の
+    // 1 箇所のみで宣言される) を Tripwire 属性レベルで保証する。
+    it("separator span は独自の data-token-color を吐かず wrapper の色を継承する (Issue #536 案 B)", () => {
+      // 座標 2 件以上で separator span が描画される (index > 0 のときのみ描画)
+      const { container } = render(
+        <Coordinate
+          publishedAt="2025-12-31T00:00:00+09:00"
+          milestones={[
+            { date: "2025-01-01", label: "サイト開設", tone: "neutral" },
+            { date: "2025-02-01", label: "社会復帰", tone: "light" },
+          ]}
+        />,
+      );
+
+      // separator span (aria-hidden="true" を持つ span) を取得
+      const separators = container.querySelectorAll('span[aria-hidden="true"]');
+      // 2 件の座標があるので separator は 1 件描画される (index === 0 のときは出ない)
+      expect(separators).toHaveLength(1);
+
+      const separator = separators[0];
+      // 独自の data-token-color 属性を持たない (色は wrapper から継承)
+      expect(separator).not.toHaveAttribute("data-token-color");
+      // 表示文字は中点「・」
+      expect(separator?.textContent).toBe("・");
+    });
+
+    // Issue #536: 色の宣言箇所が wrapper の 1 箇所のみであることを Tripwire 網
+    // 全体で保証する (= ドキュメント全体に `data-token-color="fg.muted"` を持つ
+    // 要素は wrapper の 1 件しか存在しない)。separator や個別 li に同じ token
+    // を重複宣言したくなった場合のレビュー観点として機能する。
+    it("Coordinate 全体で data-token-color='fg.muted' を吐く要素は wrapper の 1 件のみ", () => {
+      const { container } = render(
+        <Coordinate
+          publishedAt="2025-12-31T00:00:00+09:00"
+          milestones={[
+            { date: "2025-01-01", label: "サイト開設", tone: "neutral" },
+            { date: "2025-02-01", label: "社会復帰", tone: "light" },
+          ]}
+        />,
+      );
+
+      const tokenColorNodes = container.querySelectorAll(
+        '[data-token-color="fg.muted"]',
+      );
+      expect(tokenColorNodes).toHaveLength(1);
+    });
   });
 
   // ==========================================================================


### PR DESCRIPTION
## 概要

Closes #536

`Coordinate.tsx` の separator (`<span className={separatorStyles}>`) が `color: \"fg.muted\"` を独立宣言しており、Tripwire テストは wrapper の `data-token-color` だけを検証していたため、separator の color を別 token に書き換えても気付けない網漏れがあった。Issue #536 の 3 案 (A: separator にも data-token-color 付与 / B: separator の color 撤去 → wrapper から継承 / C: 現状維持) から **案 B** を採用し、構造的解決を行う。

### 採用案 (B) の判断根拠

- separator の `color: \"fg.muted\"` は wrapper (`containerStyles`) と**まったく同じ token を重複宣言**しているだけで、視覚階層上の意図的な差別化はない (JSDoc / 既存コメントにも独自色を持たせる理由は書かれていない)。
- 案 A は属性を増やすが、wrapper と separator の `data-token-color` が常に同一であることをテストで保証することに過ぎず、本質的な変更検知力は上がらない。むしろ separator の色を独立に変えたい意図がある誤読を招く。
- 案 B は CSS が 1 行減り、color 宣言箇所が wrapper の 1 箇所に集約される。Tripwire 網漏れは「重複宣言が存在しないこと」によって**構造的に**解消される。
- メモリの方針 (\"過剰抽象化を避ける\" / \"最小実装\" / \"外部ライブラリ追加禁止\") とも整合。
- 案 C は Issue 起票済みで放置する理由が弱い。

## 変更内容

- `src/components/common/Coordinate.tsx`: `separatorStyles` の `color: \"fg.muted\"` を撤去 (wrapper の `color: \"fg.muted\"` を CSS の継承で受け取る構造に統一)。判断意図を JSDoc コメントで明文化。
- `src/components/common/__tests__/Coordinate.test.tsx`: Tripwire テストに 2 件追加。(1) separator span (aria-hidden=\"true\") が独自 `data-token-color` を吐かないこと、(2) Coordinate ドキュメント全体で `data-token-color=\"fg.muted\"` を持つ要素が wrapper の 1 件のみであること、を検証する (今後 separator や個別 li に同じ token を重複宣言した場合のレビュー観点として機能する)。

## 備考

- `pnpm test:run`: 839 件全 pass (Coordinate.test.tsx は 15 件 → 17 件に拡張)
- `pnpm lint`: クリーン
- `pnpm type-check`: クリーン