### PR TITLE
refactor: anchors.ts の computeCoordinates に heavy 除外オプションを追加し責務を集約

### DIFF
--- a/src/components/common/Coordinate.tsx
+++ b/src/components/common/Coordinate.tsx
@@ -132,15 +132,19 @@ export const Coordinate = memo(
       return null;
     }
 
-    // 過去の節目に絞った座標 (computeCoordinates が未来は除外する)
-    const coordinates = computeCoordinates(publishedAt, milestones);
-    // `heavy` を除外して表示候補に絞る。
-    // `Coordinate` は現状単型のため `kind` 判定は型レベルで tautology だが、
-    // 将来 `Coordinate | Elapsed` mixed union に拡張された際の narrowing 防御として
-    // 型ガード形式を採用する (Issue #497 の discriminator 設計意図に対応)。
-    const displayable = coordinates.filter(
-      (c): c is CoordinateData =>
-        c.kind === "coordinate" && c.tone !== "heavy",
+    // 過去かつ heavy 以外の節目に絞った座標。
+    // - 「publishedAt 以降の節目は除外」と「heavy 除外」はいずれも
+    //   `computeCoordinates` の責務に集約済み (Issue #532 / 案A)。
+    //   表示層で `c.tone !== "heavy"` の filter を書くと、別の表示層
+    //   (e.g. /anchor ページ = #493) で語彙が分散するリスクがあるため、
+    //   表示ポリシーをエンジン引数 (`excludeHeavy`) で表現する設計を採る。
+    // - 戻り値は `readonly Coordinate[]` (現状単型) のため、`kind` の narrowing は
+    //   ここでは不要。将来 `Coordinate | Elapsed` mixed union に拡張された場合は
+    //   再度 narrowing を入れる (Issue #497 の discriminator 設計意図に対応)。
+    const displayable: readonly CoordinateData[] = computeCoordinates(
+      publishedAt,
+      milestones,
+      { excludeHeavy: true },
     );
 
     if (displayable.length === 0) {

--- a/src/components/common/__tests__/Coordinate.allPosts.test.tsx
+++ b/src/components/common/__tests__/Coordinate.allPosts.test.tsx
@@ -66,8 +66,7 @@ interface CoordinateExpectation {
  *   import milestones from "../datasources/milestones.json";
  *   const id = "20260307120000"; // 追加した post.id
  *   const publishedAt = inferPublishedAt(id);
- *   const rows = computeCoordinates(publishedAt!, milestones as never)
- *     .filter((c) => c.tone !== "heavy")
+ *   const rows = computeCoordinates(publishedAt!, milestones as never, { excludeHeavy: true })
  *     .map((c) => ({ label: c.label, daysSince: c.daysSince }));
  *   console.log(JSON.stringify({ postId: id, publishedAt, expectedRows: rows }, null, 2));
  *

--- a/src/lib/__tests__/anchors.test.ts
+++ b/src/lib/__tests__/anchors.test.ts
@@ -227,6 +227,115 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
     });
   });
 
+  /**
+   * Issue #532: 表示ポリシーをエンジン引数で表現する案 (案A) を採用したことで、
+   * `excludeHeavy` オプションの挙動を仕様としてここで固定する。
+   *
+   * 表示層 (`Coordinate.tsx`) で `c.tone !== "heavy"` を filter で書くと、
+   * 別の表示層 (`/anchor` ページ = #493) で語彙が分散するリスクがあるため、
+   * 「どの tone を除外するか」の責務は anchors モジュールに集約する。
+   *
+   * 既存呼び出し (AnchorPage.tsx / 既存テスト) は options 未指定で
+   * 「heavy を含めて返す」既定挙動が維持されること (= 後方互換) を
+   * 「options 未指定」「options.excludeHeavy: false」テストで固定する。
+   */
+  describe("options.excludeHeavy: heavy 除外オプション (Issue #532)", () => {
+    it("options 未指定のとき heavy も含めて返す (既存挙動 = 後方互換)", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-01", label: "中立", tone: "neutral" },
+        { date: "2025-01-02", label: "軽め", tone: "light" },
+        { date: "2025-01-03", label: "重い", tone: "heavy" },
+      ];
+      const result = computeCoordinates(
+        "2025-02-01T12:00:00+09:00",
+        milestones,
+      );
+
+      expect(result).toHaveLength(3);
+      expect(result.map((c) => c.label)).toEqual(["中立", "軽め", "重い"]);
+    });
+
+    it("options.excludeHeavy が false のとき heavy も含めて返す (明示指定)", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-01", label: "中立", tone: "neutral" },
+        { date: "2025-01-02", label: "軽め", tone: "light" },
+        { date: "2025-01-03", label: "重い", tone: "heavy" },
+      ];
+      const result = computeCoordinates(
+        "2025-02-01T12:00:00+09:00",
+        milestones,
+        { excludeHeavy: false },
+      );
+
+      expect(result).toHaveLength(3);
+      expect(result.map((c) => c.label)).toEqual(["中立", "軽め", "重い"]);
+    });
+
+    it("options.excludeHeavy が true のとき tone === 'heavy' を除外して返す", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-01", label: "中立", tone: "neutral" },
+        { date: "2025-01-02", label: "軽め", tone: "light" },
+        { date: "2025-01-03", label: "重い", tone: "heavy" },
+      ];
+      const result = computeCoordinates(
+        "2025-02-01T12:00:00+09:00",
+        milestones,
+        { excludeHeavy: true },
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result.map((c) => c.label)).toEqual(["中立", "軽め"]);
+      expect(result.every((c) => c.tone !== "heavy")).toBe(true);
+    });
+
+    it("excludeHeavy: true で全 milestone が heavy のときは空配列を返す", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-01", label: "重い1", tone: "heavy" },
+        { date: "2025-01-02", label: "重い2", tone: "heavy" },
+      ];
+      const result = computeCoordinates(
+        "2025-02-01T12:00:00+09:00",
+        milestones,
+        { excludeHeavy: true },
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("excludeHeavy: true でも heavy 以外の入力順は保持される", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-05", label: "B", tone: "light" },
+        { date: "2025-01-04", label: "X", tone: "heavy" },
+        { date: "2025-01-01", label: "A", tone: "neutral" },
+        { date: "2025-01-03", label: "C", tone: "light" },
+      ];
+      const result = computeCoordinates(
+        "2025-02-01T12:00:00+09:00",
+        milestones,
+        { excludeHeavy: true },
+      );
+
+      expect(result.map((c) => c.label)).toEqual(["B", "A", "C"]);
+    });
+
+    it("excludeHeavy: true と未来除外は両立する (heavy かつ未来 / heavy かつ過去 / 未来 light / 過去 light)", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-01", label: "過去-light", tone: "light" },
+        { date: "2025-01-02", label: "過去-heavy", tone: "heavy" },
+        { date: "2025-12-31", label: "未来-light", tone: "light" },
+        { date: "2025-12-30", label: "未来-heavy", tone: "heavy" },
+      ];
+      const result = computeCoordinates(
+        "2025-02-01T12:00:00+09:00",
+        milestones,
+        { excludeHeavy: true },
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].label).toBe("過去-light");
+    });
+  });
+
   describe("日数計算の精度", () => {
     it("月をまたぐ場合も暦日数で計算される (2025-01-31 → 2025-02-01 は 1 日)", () => {
       const milestones: readonly Milestone[] = [

--- a/src/lib/anchors.ts
+++ b/src/lib/anchors.ts
@@ -194,6 +194,34 @@ const diffInDays = (origin: Date, target: Date): number => {
 };
 
 /**
+ * `computeCoordinates` の動作オプション
+ *
+ * - `excludeHeavy`: true のとき、tone === "heavy" の節目を結果から **除外** する。
+ *   未指定または false のときは heavy を含めて全 tone を返す (既存挙動)
+ *
+ * 設計判断 (Issue #532):
+ * - 「表示ポリシーをエンジン引数で表現する」案A を採用
+ * - 採用理由:
+ *   1. **表示層ごとの再実装リスクを排除する**: heavy 除外を `Coordinate.tsx`
+ *      側 (`c.tone !== "heavy"` の filter) で行うと、`/anchor` ページ (#493) など
+ *      別の表示層で「heavy も含めて出したい」「heavy だけ除外したい」を分岐したい
+ *      ときに `tone !== "heavy"` の語彙を表示層ごとに書き直すリスクがある
+ *   2. **責務集約**: 「どの tone を除外するか」は表示ポリシーだが、`MilestoneTone`
+ *      を知るのは anchors モジュールであり、表示層に enum 比較を漏らしたくない
+ *   3. **API 互換性維持**: options は省略可能で、既存呼び出し
+ *      (`AnchorPage.tsx` の heavy 含む呼び出し / 全テストケース) は無変更で動作する
+ * - 案B (ラッパー関数 `computeCoordinatesForDisplay` 追加) との比較: 同じ
+ *   モジュールに似た名前の関数を2つ並べると「どちらを呼ぶべきか」の意思決定コストが
+ *   表示層側に残る。options による単一関数化の方が API 表面が小さい
+ * - 案C (現状維持) との比較: ドキュメントだけでは「呼び出し忘れ」「filter の語彙
+ *   揺れ」を防げない (受け入れ基準は「いずれかを選択し判断根拠を明文化」なので
+ *   案C も選択肢だが、構造的に再発防止できる案A を採用する)
+ */
+export interface ComputeCoordinatesOptions {
+  readonly excludeHeavy?: boolean;
+}
+
+/**
  * 層1=座標: publishedAt と登録節目の差分日数を計算する
  *
  * - publishedAt より後 (未来) の節目は結果から **除外 (filter)** する
@@ -205,19 +233,29 @@ const diffInDays = (origin: Date, target: Date): number => {
  * - 空配列が渡されたら空配列を返す
  * - Milestone.date の値範囲は検証せず、`Date.UTC` のロールオーバーを許容する
  *   (`toMilestoneCalendarDate` の JSDoc / テスト「Milestone.date 不正値の仕様」参照)
+ * - `options.excludeHeavy` が true のとき、tone === "heavy" の節目を結果から
+ *   除外する。未指定または false のときは heavy を含めて返す (Issue #532)
  *
  * @param publishedAt - 記事の公開日時 (ISO 8601 文字列)
  * @param milestones - 登録された節目の配列
- * @returns 各節目に対応する Coordinate の配列 (publishedAt より後の節目は除外)
+ * @param options - 表示ポリシーオプション (省略可能。詳細は
+ *   `ComputeCoordinatesOptions` の JSDoc を参照)
+ * @returns 各節目に対応する Coordinate の配列 (publishedAt より後の節目は除外。
+ *   `excludeHeavy: true` 指定時はさらに heavy も除外)
  */
 export const computeCoordinates = (
   publishedAt: string,
   milestones: readonly Milestone[],
+  options?: ComputeCoordinatesOptions,
 ): readonly Coordinate[] => {
   const publishedDate = toJstCalendarDate(publishedAt);
+  const excludeHeavy = options?.excludeHeavy ?? false;
 
   const coordinates: Coordinate[] = [];
   for (const milestone of milestones) {
+    if (excludeHeavy && milestone.tone === "heavy") {
+      continue;
+    }
     const milestoneDate = toMilestoneCalendarDate(milestone.date);
     if (milestoneDate === null) {
       continue;


### PR DESCRIPTION
## 概要

Closes #532

`anchors.ts` の `computeCoordinates` に `options?: { excludeHeavy?: boolean }` を追加し、heavy 除外責務を表示層 (`Coordinate.tsx`) から engine 側に集約する refactor。Issue #491 PR の DA レビュー指摘「heavy 除外が `Coordinate.tsx` 側に閉じており、`/anchor` ページ (#493) 等で表示層ごとに `c.tone !== \"heavy\"` を書き直すリスクがある」への構造的対応。

採用案: **案A (オプション引数による表示ポリシー集約)**。判断根拠:

- 表示層ごとの再実装リスクを排除する (filter 語彙が分散しない)
- `MilestoneTone` 値の比較を anchors モジュールに閉じ込め、表示層から enum 比較を漏らさない
- options は省略可能で、既存呼び出し (AnchorPage.tsx / 既存テスト全件) は無変更で動作する (= API 互換性維持)
- 案B (ラッパー関数 `computeCoordinatesForDisplay` 追加) は同名前空間に似た関数2つが並び意思決定コストが増えるため不採用
- 案C (現状維持) は構造的に再発防止できないため不採用

## 変更内容

- `src/lib/anchors.ts`: `computeCoordinates` の第3引数に `options?: ComputeCoordinatesOptions` を追加。`excludeHeavy: true` のとき tone === 'heavy' を除外。options 未指定時は heavy も含めて返す既存挙動を維持
- `src/components/common/Coordinate.tsx`: 自前の `c.tone !== 'heavy'` filter を削除し、`computeCoordinates(..., { excludeHeavy: true })` 経由で heavy 除外を要求する形に変更。表示層から enum 比較を排除
- `src/lib/__tests__/anchors.test.ts`: `excludeHeavy` オプションの挙動を 6 ケースで仕様固定 (後方互換 / 明示 false / true 除外 / 全 heavy で空 / 入力順保持 / 未来除外との両立)
- `AnchorPage.tsx` は options 未指定 = heavy 含む挙動を継続使用 (無変更)

## 受け入れ基準

- [x] 案A〜Cいずれかを選択し判断根拠を明文化 (案A 採用、`ComputeCoordinatesOptions` JSDoc に明文化)
- [x] 採用案を実装 (`computeCoordinates` に options 追加 / `Coordinate.tsx` を新 API へ移行)
- [x] 既存テストが全 pass (845 件 pass)

## 備考

<details>
<summary>Anchor 型を扱う PR のみチェック (Issue #556)</summary>

- [x] `import type` で `Coordinate` を `anchors.ts` から参照しているか → `Coordinate.tsx` は `import { type Coordinate as CoordinateData, computeCoordinates, ... } from "../../lib/anchors"` 既存維持
- [x] 構造的リテラル `{ label, tone, daysSince }[]` のハンドメイド型宣言を追加していないか → なし
- [x] `scripts/__tests__/newPost.test.ts` の型レベルガード対象フィールドを追加・変更していないか → なし (本 PR は `IgnitionInput` 系のフィールド追加なし)

</details>

## テスト結果

- `pnpm test:run`: 50 files / 845 tests pass
- `pnpm lint`: pass (Biome 118 files checked, no fixes)
- `pnpm type-check`: pass (`tsc --noEmit` clean)
- `pnpm build`: pass (Vite production build 成功)