### PR TITLE
chore: Anchor 系コンポーネントの Pulse 思想禁則語彙テストを共通定数化

### DIFF
--- a/src/components/common/__tests__/Coordinate.test.tsx
+++ b/src/components/common/__tests__/Coordinate.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { describe, expect, it } from "vitest";
 import type { Milestone } from "../../../lib/anchors";
+import { buildPulseForbiddenVocabRegex } from "../../../test/forbiddenVocab";
 import { Coordinate } from "../Coordinate";
 
 /**
@@ -164,6 +165,27 @@ describe("Coordinate", () => {
       expect(group.textContent).toContain("333");
       // 区切り文字「・」が間に存在する
       expect(group.textContent).toMatch(/・/);
+    });
+  });
+
+  describe("過剰可視化の禁止 (Pulse 思想)", () => {
+    it("Pulse 思想禁則語彙 (投稿頻度 / 執筆ペース 等) が座標 UI に現れない", () => {
+      // 語彙の網羅は src/test/forbiddenVocab.ts に集約してあり、
+      // Resurface / AnchorPage / HomePage と共通の禁則語彙集を参照する
+      // (Issue #540)。Coordinate は「{label} から N 日目」の最小表現のみで
+      // 抽象指標語彙を一切吐かない構造を Tripwire で保証する。
+      const { container } = render(
+        <Coordinate
+          publishedAt="2025-12-31T00:00:00+09:00"
+          milestones={[
+            { date: "2025-01-01", label: "サイト開設", tone: "neutral" },
+            { date: "2025-02-01", label: "社会復帰", tone: "light" },
+          ]}
+        />,
+      );
+
+      const text = container.textContent ?? "";
+      expect(text).not.toMatch(buildPulseForbiddenVocabRegex());
     });
   });
 

--- a/src/components/common/__tests__/Resurface.test.tsx
+++ b/src/components/common/__tests__/Resurface.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import type { PostSummary } from "../../../lib/markdown";
 import type { ResurfacedEntry } from "../../../lib/resurface";
+import { buildPulseForbiddenVocabRegex } from "../../../test/forbiddenVocab";
 import { Resurface } from "../Resurface";
 
 const buildPost = (overrides: Partial<PostSummary> = {}): PostSummary => ({
@@ -242,6 +243,29 @@ describe("Resurface", () => {
       expect(screen.queryByText(/日経過/)).not.toBeInTheDocument();
       expect(screen.queryByText(/投稿間隔/)).not.toBeInTheDocument();
       expect(screen.queryByText(/頻度/)).not.toBeInTheDocument();
+    });
+
+    it("Pulse 思想禁則語彙 (投稿頻度 / 執筆ペース 等) が UI 上に現れない", () => {
+      // 語彙の網羅は src/test/forbiddenVocab.ts に集約してあり、
+      // Coordinate / AnchorPage / HomePage と共通の禁則語彙集を参照する
+      // (Issue #540)。Resurface は silence reason の数値ガードと併せて
+      // 抽象指標語彙でも防御する。
+      const { container } = render(
+        <MemoryRouter>
+          <Resurface
+            entry={buildEntry({
+              reason: {
+                kind: "silence",
+                lastPostDaysAgo: 60,
+                sub: "yearAgo",
+              },
+            })}
+          />
+        </MemoryRouter>,
+      );
+
+      const text = container.textContent ?? "";
+      expect(text).not.toMatch(buildPulseForbiddenVocabRegex());
     });
   });
 

--- a/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
+++ b/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
@@ -9,6 +9,7 @@ import {
   type Milestone,
 } from "../../../lib/anchors";
 import type { PostSummary } from "../../../lib/markdown";
+import { buildPulseForbiddenVocabRegex } from "../../../test/forbiddenVocab";
 import { AnchorPage } from "../AnchorPage";
 
 /**
@@ -144,5 +145,22 @@ describe("AnchorPage (実16記事での回帰テスト)", () => {
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it("16 記事 + 実 milestones の描画結果に Pulse 思想禁則語彙が現れない", () => {
+    // 語彙の網羅は src/test/forbiddenVocab.ts に集約してあり、
+    // Coordinate / Resurface / HomePage と共通の禁則語彙集を参照する
+    // (Issue #540)。AnchorPage.test.tsx は固定 fixture でガードしているのに
+    // 対し、本テストは実 datasources/milestones.json + 全 16 記事の組合せでも
+    // 抽象指標語彙が漏れていないことを Tripwire で防御する。
+    const posts = buildPostSummaries(postIds);
+    const { container } = render(
+      <MemoryRouter>
+        <AnchorPage posts={posts} milestones={milestones} />
+      </MemoryRouter>,
+    );
+
+    const text = container.textContent ?? "";
+    expect(text).not.toMatch(buildPulseForbiddenVocabRegex());
   });
 });

--- a/src/components/pages/__tests__/AnchorPage.test.tsx
+++ b/src/components/pages/__tests__/AnchorPage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import type { Milestone } from "../../../lib/anchors";
 import type { PostSummary } from "../../../lib/markdown";
+import { buildPulseForbiddenVocabRegex } from "../../../test/forbiddenVocab";
 import { AnchorPage } from "../AnchorPage";
 
 /**
@@ -370,9 +371,11 @@ describe("AnchorPage", () => {
       );
 
       // 「投稿頻度」「平均間隔」「ペース」など Pulse を切った思想に反する語彙
-      // が AnchorPage には現れない
+      // が AnchorPage には現れない。語彙の網羅は src/test/forbiddenVocab.ts に
+      // 集約してあり、Coordinate / Resurface / HomePage と共通の禁則語彙集を
+      // 参照する (Issue #540)。
       const text = container.textContent ?? "";
-      expect(text).not.toMatch(/投稿頻度|平均間隔|投稿ペース/);
+      expect(text).not.toMatch(buildPulseForbiddenVocabRegex());
     });
 
     it("グラフ要素 (canvas) を含まない", () => {

--- a/src/components/pages/__tests__/HomePage.test.tsx
+++ b/src/components/pages/__tests__/HomePage.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import type { Post, PostSummary } from "../../../lib/markdown";
 import type { ResurfacedEntry } from "../../../lib/resurface";
+import { buildPulseForbiddenVocabRegex } from "../../../test/forbiddenVocab";
 import { HomePage } from "../HomePage";
 
 const mockPosts: Post[] = [
@@ -447,6 +448,29 @@ describe("HomePage", () => {
       expect(
         screen.getByRole("region", { name: "過去の記事" }),
       ).toBeInTheDocument();
+    });
+
+    it("Resurface を含む HomePage 全体に Pulse 思想禁則語彙が現れない", () => {
+      // 語彙の網羅は src/test/forbiddenVocab.ts に集約してあり、
+      // Coordinate / Resurface / AnchorPage と共通の禁則語彙集を参照する
+      // (Issue #540)。HomePage は Resurface セクションを内包するため、
+      // ページ統合状態でも抽象指標語彙が漏れていないことを Tripwire で
+      // 防御する。
+      const posts = buildMockPosts(3);
+      const { container } = render(
+        <MemoryRouter>
+          <HomePage
+            posts={posts}
+            currentPage={1}
+            totalPages={1}
+            onPageChange={mockOnPageChange}
+            resurfaceEntry={buildEntry()}
+          />
+        </MemoryRouter>,
+      );
+
+      const text = container.textContent ?? "";
+      expect(text).not.toMatch(buildPulseForbiddenVocabRegex());
     });
   });
 });

--- a/src/test/__tests__/forbiddenVocab.test.ts
+++ b/src/test/__tests__/forbiddenVocab.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPulseForbiddenVocabRegex,
+  PULSE_FORBIDDEN_VOCAB,
+} from "../forbiddenVocab";
+
+/**
+ * Pulse 思想禁則語彙 (Issue #540) の共通定数自体のサニティテスト。
+ *
+ * 個別 Tripwire テスト (Coordinate / Resurface / AnchorPage / HomePage) は
+ * 「実描画テキストがこの語彙にマッチしないこと」を検査する。本テストはその
+ * 上流で「定数自体が壊れていないこと」(初期 8 語を含む / 重複がない / regex
+ * が想定通り構築される) を保証する。
+ */
+describe("forbiddenVocab (Pulse 思想禁則語彙)", () => {
+  it("Issue #540 の初期語彙 8 語を全て含む", () => {
+    const initial = [
+      "投稿頻度",
+      "平均間隔",
+      "投稿ペース",
+      "執筆ペース",
+      "投稿リズム",
+      "更新頻度",
+      "投稿量",
+      "執筆量",
+    ];
+
+    for (const term of initial) {
+      expect(PULSE_FORBIDDEN_VOCAB).toContain(term);
+    }
+  });
+
+  it("重複した語彙を含まない", () => {
+    const unique = new Set(PULSE_FORBIDDEN_VOCAB);
+    expect(unique.size).toBe(PULSE_FORBIDDEN_VOCAB.length);
+  });
+
+  it("生成された regex で禁則語彙の各語にマッチする", () => {
+    const regex = buildPulseForbiddenVocabRegex();
+    for (const term of PULSE_FORBIDDEN_VOCAB) {
+      expect(term).toMatch(regex);
+    }
+  });
+
+  it("生成された regex は中立な文字列にマッチしない", () => {
+    const regex = buildPulseForbiddenVocabRegex();
+    expect("こんにちは").not.toMatch(regex);
+    expect("社会復帰から 10 日目").not.toMatch(regex);
+    expect("過去の記事").not.toMatch(regex);
+  });
+
+  it("呼び出すたびに新しい RegExp インスタンスを返す (状態汚染を避けるため)", () => {
+    const r1 = buildPulseForbiddenVocabRegex();
+    const r2 = buildPulseForbiddenVocabRegex();
+    expect(r1).not.toBe(r2);
+    expect(r1.source).toBe(r2.source);
+  });
+});

--- a/src/test/forbiddenVocab.ts
+++ b/src/test/forbiddenVocab.ts
@@ -1,0 +1,50 @@
+/**
+ * Anchor 系コンポーネントの Tripwire テスト用の Pulse 思想禁則語彙集。
+ *
+ * 「Pulse (頻度可視化)」を切った思想を厳守するため、UI 上で投稿頻度・投稿間隔・
+ * 執筆量・更新頻度のような "抽象指標" を表示してはならない。本定数は
+ * Coordinate / Resurface / AnchorPage / HomePage の Tripwire テストから共通参照し、
+ * 「3 語のみで防御 → 類義語素通り」というガード網漏れを構造的に解消する。
+ *
+ * 出典: Issue #540 (Issue #493 PR の DA レビュー指摘の積み残し)
+ *
+ * 追加・削除の方針:
+ * - 「Pulse 思想に反する語彙」を本ファイルに集約する
+ * - 個別テスト側で独自に「投稿ペースに関する文言を含まない」のような同種の
+ *   regex を書き起こしたくなったら、本定数への追記を優先する
+ * - 既存記事 (datasources/*.md) の本文ヒットを避けたいケースは Tripwire ではなく
+ *   個別テスト側で個別 query を書くこと (本定数は **UI ラベル / 抽象指標** に限定)
+ */
+
+/**
+ * Pulse 思想で禁止する語彙の正規化済みリスト。
+ *
+ * - 「投稿頻度 / 平均間隔 / 投稿ペース」: Issue #493 PR DA レビューで指摘済み既存3語
+ * - 「執筆ペース / 投稿リズム / 更新頻度 / 投稿量 / 執筆量」: Issue #540 で追加する類義語
+ *
+ * 数値表現 (「N 日ぶり」「N 日経過」等) は語彙ではなく数値パターンであり、
+ * `Resurface.test.tsx` 側で個別の regex (`/日ぶり/` 等) で防御している。本定数の
+ * 対象は **完全一致語彙** のみとする。
+ */
+export const PULSE_FORBIDDEN_VOCAB = [
+  "投稿頻度",
+  "平均間隔",
+  "投稿ペース",
+  "執筆ペース",
+  "投稿リズム",
+  "更新頻度",
+  "投稿量",
+  "執筆量",
+] as const;
+
+export type PulseForbiddenTerm = (typeof PULSE_FORBIDDEN_VOCAB)[number];
+
+/**
+ * `PULSE_FORBIDDEN_VOCAB` を `|` で連結した RegExp を生成する。
+ *
+ * `expect(text).not.toMatch(buildPulseForbiddenVocabRegex())` の形で
+ * Tripwire テストから利用する。RegExp はテストごとに新規生成して
+ * `lastIndex` 等の状態汚染を避ける。
+ */
+export const buildPulseForbiddenVocabRegex = (): RegExp =>
+  new RegExp(PULSE_FORBIDDEN_VOCAB.join("|"));


### PR DESCRIPTION
## 概要

Issue #493 PR の DA レビューで指摘された改善事項に対応する。`AnchorPage.test.tsx` で正規表現 `/投稿頻度|平均間隔|投稿ペース/` を排除しているが、Pulse 思想に反する語彙を 3 語のみで防御する設計は将来の類義語 (「執筆ペース」「投稿リズム」「執筆量推移」「N 日ぶり投稿」等) を素通りさせる。

語彙集を `src/test/forbiddenVocab.ts` に共通定数として集約し、Coordinate / Resurface / AnchorPage / HomePage の各 Tripwire テストから同じ集合を参照するように刷新した。

## 変更内容

- `src/test/forbiddenVocab.ts`: Pulse 思想禁則語彙 (`PULSE_FORBIDDEN_VOCAB`, 初期 8 語) と `buildPulseForbiddenVocabRegex()` ヘルパを新設
- `src/test/__tests__/forbiddenVocab.test.ts`: 定数自体のサニティテスト (初期 8 語の網羅 / 重複なし / regex 生成の正しさ)
- `src/components/pages/__tests__/AnchorPage.test.tsx`: 既存ハードコード regex を共通定数呼び出しに置換
- `src/components/common/__tests__/Coordinate.test.tsx`: 「過剰可視化の禁止 (Pulse 思想)」describe を新設し共通定数で防御
- `src/components/common/__tests__/Resurface.test.tsx`: 既存 Pulse 思想 describe に共通定数による語彙ガードを追加
- `src/components/pages/__tests__/AnchorPage.allPosts.test.tsx`: 実 `datasources/milestones.json` + 全 16 記事の組合せでも禁則語彙が現れないことを Tripwire で防御
- `src/components/pages/__tests__/HomePage.test.tsx`: Resurface 連携 describe に HomePage 全体での Pulse 禁則語彙ガードを追加

### 配置先の判断根拠

`src/lib/anchors/__tests__/forbidden-vocab.ts` ではなく `src/test/forbiddenVocab.ts` に配置した。理由は以下:

- 既に `src/lib/anchors.ts` 単一ファイルが存在し、`src/lib/anchors/` ディレクトリを新設するとモジュール構造が分裂する
- 既存の共通テストセットアップが `src/test/setup.ts` に置かれており、テスト専用ヘルパの集約先として一貫性がある
- プロジェクトの命名規約 (camelCase) に合わせ `forbiddenVocab.ts` とした

## 備考

機能影響なし、テスト品質向上。Closes #540

### 受け入れ基準

- [x] 共通定数 (`src/test/forbiddenVocab.ts`) に Pulse 思想禁則語彙を集約
- [x] 初期語彙例: `["投稿頻度", "平均間隔", "投稿ペース", "執筆ペース", "投稿リズム", "更新頻度", "投稿量", "執筆量"]` を全て含む
- [x] Coordinate / Resurface / AnchorPage / HomePage の各 Tripwire テストでこの定数を import して検査
- [ ] PR レビューチェックリストに「Pulse 語彙が追加されていないか」を明文化（任意項目のため本 PR では対応せず）

### 動作確認

- [x] `pnpm test:run`: 51 ファイル / 853 テスト 全 pass (本 PR で +5 件追加)
- [x] `pnpm lint`: No fixes applied
- [x] `pnpm type-check`: pass
- [x] `pnpm type-check:test`: pass