### PR TITLE
fix: AnchorPage.allPosts.test.tsx の未定義 milestones 参照を解消する (Issue #618 案A)

### DIFF
--- a/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
+++ b/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
+import milestonesData from "../../../../datasources/milestones.json";
 import { inferPublishedAt, type Milestone } from "../../../lib/anchors";
 import type { PostSummary } from "../../../lib/markdown";
 import { buildPulseForbiddenVocabRegex } from "../../../test/forbiddenVocab";
@@ -247,14 +248,31 @@ const expectations: readonly PostCoordinatesExpectation[] = [
  * メリットがある一方で、「本番 milestone の label rename / tone 変更 /
  * 日付変更などの意味的変更が本テスト上で silent pass する」リスクを孕む。
  * 本番 milestones.json と本テスト fixture のずれは、本番 JSON を直接 import
- * している `anchors.test.ts` および開発者の意識的な fixture 更新 (上述「fixture
- * の更新ルール」) で担保する設計とする。
+ * している `anchors.test.ts`、本ファイル末尾の「Pulse 思想禁則語彙が現れない」
+ * Tripwire テスト (後述 `milestones` 定数を限定的に使用)、および開発者の
+ * 意識的な fixture 更新 (上述「fixture の更新ルール」) で担保する設計とする。
  */
 const testMilestones: readonly Milestone[] = [
   { date: "2025-08-05", label: "休職開始", tone: "heavy" },
   { date: "2025-08-26", label: "サイト開設", tone: "neutral" },
   { date: "2025-09-05", label: "社会復帰", tone: "light" },
 ];
+
+/**
+ * 本ファイル末尾の「Pulse 思想禁則語彙が現れない」Tripwire テスト専用に、
+ * 本番 `datasources/milestones.json` を**限定的に**直接 import した定数。
+ *
+ * fixture (expectations) と組ませる入力は意図的に `testMilestones` に切り離して
+ * いるが (本 JSDoc 上部の trade-off 参照)、Pulse 禁則語彙 Tripwire は
+ * 「実 milestones × 全 16 記事の組合せ」で抽象指標語彙の漏れを防ぐことが目的
+ * (Issue #540 / Issue #618 案A) のため、本 1 件のテストに限り本番 JSON を
+ * そのまま入力として渡す。
+ *
+ * narrowing キャストの意図は `anchors.test.ts` の milestonesJson キャスト
+ * (Issue #546) と同じ: resolveJsonModule で widen された `tone: string` を
+ * `Milestone["tone"]` の literal union に narrowing する。
+ */
+const milestones: readonly Milestone[] = milestonesData as readonly Milestone[];
 
 const postFilePaths = Object.keys(import.meta.glob("/datasources/*.md"));
 
@@ -404,6 +422,10 @@ describe("AnchorPage (実16記事での回帰テスト)", () => {
     // (Issue #540)。AnchorPage.test.tsx は固定 fixture でガードしているのに
     // 対し、本テストは実 datasources/milestones.json + 全 16 記事の組合せでも
     // 抽象指標語彙が漏れていないことを Tripwire で防御する。
+    //
+    // Issue #618 案A: 本テストは「Pulse 禁則語彙の組合せ Tripwire」が目的のため、
+    // fixture 化方針 (`testMilestones` ベース) を維持しつつ、本 1 件のみ
+    // 例外的に本番 `milestones` (datasources/milestones.json 由来) を入力に使う。
     const posts = buildPostSummaries(postIds);
     const { container } = render(
       <MemoryRouter>

--- a/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
+++ b/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
@@ -272,7 +272,10 @@ const testMilestones: readonly Milestone[] = [
  * (Issue #546) と同じ: resolveJsonModule で widen された `tone: string` を
  * `Milestone["tone"]` の literal union に narrowing する。
  * 設計判断の正本 (集約せず各 page で個別 import / 撤退方法 / 不正値時の挙動
- * など) は `src/pages/index.tsx` の MILESTONES JSDoc を参照 (Issue #546)。
+ * など) は `src/pages/anchor.tsx` の MILESTONES JSDoc を参照 (Issue #546)。
+ * AnchorPage ドメインにおける不正 `tone` / 不正 `date` 時の具体挙動
+ * (`data-tone` への素通し / 座標一覧から静かに落ちる) も同 JSDoc に記述あり
+ * (`anchors.test.ts` の同等キャストコメントも同じ参照先に揃えてある)。
  *
  * **副次効果 (Tripwire 強化)**: 本定数を導入することで、末尾の Pulse 禁則語彙
  * Tripwire テストが runtime で必ず実行されるようになる (Issue #618 案A)。

--- a/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
+++ b/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
@@ -271,6 +271,13 @@ const testMilestones: readonly Milestone[] = [
  * narrowing キャストの意図は `anchors.test.ts` の milestonesJson キャスト
  * (Issue #546) と同じ: resolveJsonModule で widen された `tone: string` を
  * `Milestone["tone"]` の literal union に narrowing する。
+ * 設計判断の正本 (集約せず各 page で個別 import / 撤退方法 / 不正値時の挙動
+ * など) は `src/pages/index.tsx` の MILESTONES JSDoc を参照 (Issue #546)。
+ *
+ * **副次効果 (Tripwire 強化)**: 本定数を導入することで、末尾の Pulse 禁則語彙
+ * Tripwire テストが runtime で必ず実行されるようになる (Issue #618 案A)。
+ * PR #611 / #612 のような「未定義 milestones 参照」交差バグが今後再発した場合も
+ * 本 Tripwire 経由で検知できるため、検知網が二重化される。
  */
 const milestones: readonly Milestone[] = milestonesData as readonly Milestone[];
 


### PR DESCRIPTION
## 概要

Issue #618 案A 対応。PR #611 (Pulse 禁則語彙 Tripwire テストで実 milestones を入力に使用) と PR #612 (fixture 化により本番 `datasources/milestones.json` の直接 import を撤去) のマージ順序が交差した結果、master HEAD の `AnchorPage.allPosts.test.tsx` 末尾で `milestones` 変数が未定義のまま参照され、`ReferenceError: milestones is not defined` でテストが失敗していた。

fixture 化方針 (`testMilestones` ベース) は維持しつつ、Pulse 禁則語彙 Tripwire テスト 1 件に限り本番 `datasources/milestones.json` を限定的に直接 import して `milestones` 定数を復活させることで未定義参照を解消する。

Closes #618

## 変更内容

- `src/components/pages/__tests__/AnchorPage.allPosts.test.tsx`:
  - 本番 `datasources/milestones.json` を `milestonesData` として import し、Pulse 禁則語彙 Tripwire テスト用に `milestones` (narrowing キャスト済み `readonly Milestone[]`) を再宣言。narrowing の意図は `anchors.test.ts` の milestonesJson キャスト (Issue #546) と同じ
  - `testMilestones` 上部 JSDoc の「本番 JSON と fixture のずれ担保先」注記を更新し、本ファイル末尾の Pulse 禁則語彙 Tripwire テスト (`milestones` 定数を限定的に使用) も担保先に含まれることを明示
  - 「16 記事 + 実 milestones の描画結果に Pulse 思想禁則語彙が現れない」テスト内コメントに Issue #618 案A の判断根拠 (fixture 化方針維持 + 本テスト 1 件のみ本番 JSON を例外的に入力に使う) を追記
  - `milestones` 定数 JSDoc に、設計判断 (集約せず各 page で個別 import / 撤退方法 / 不正値時の挙動など) の正本ポインタとして `src/pages/anchor.tsx` の MILESTONES JSDoc への参照を追記 (DA Should Consider S-1)
  - 同 JSDoc に Tripwire が runtime で必ず実行されることによる再発検知の二重化に関する副次効果を追記 (DA Should Consider S-2)

## 採用案 (案A) の判断根拠

- **fixture 化方針 (PR #612) を尊重しつつ未定義参照を最小修正で解消できる**: `testMilestones` ベースの fixture 化 (本番 milestones.json 改変で fixture が道連れ失敗するのを防ぐ目的) はそのまま維持する。本番 JSON を入力に使うのは Pulse 禁則語彙 Tripwire (PR #611 で導入) 1 件のみで、その 1 件は元々「実 milestones × 全 16 記事の組合せ」で抽象指標語彙の漏れを Tripwire 検知することが目的のため、本番 JSON 直接 import が**目的整合的**
- **narrowing キャスト方針も既存規範に合わせる**: `anchors.test.ts` で確立済みの milestonesJson キャスト規範 (Issue #546) と同じ書き方を踏襲し、規範のばらつきを避ける
- **修正範囲がテストファイル 1 つに閉じる**: プロダクションコード非改変で AC を満たせる

## 案B / 案C 棄却理由

- **案B (Tripwire テストも `testMilestones` に統一して本番 JSON 入力を完全撤去)**: Pulse 禁則語彙 Tripwire の元々の意図 (実 milestones で組合せ検知) と齟齬。`testMilestones` は 3 件しかなく、本番 JSON の更新で語彙が混入した際の検知能力が落ちる
- **案C (Tripwire テストを削除)**: PR #611 で導入された検知網を失うため不採用
- **将来検討項目 (案C相当: anchors.test.ts に本番 milestones label Tripwire 追加 + 本テストは `testMilestones` に統一)**: DA Could C-4 で言及されたが、本 PR では最小修正に絞るため対応範囲外。必要になった時点で別 Issue を切る

## 動作確認結果

- `pnpm test:run`: **871 件 pass / 51 ファイル** (実行時間 6.5s)。Issue #618 の再現失敗 (`ReferenceError: milestones is not defined`) が解消
- `pnpm exec tsc --noEmit`: clean (型エラー 0)
- `pnpm lint` (`biome lint ./src ./scripts`): clean (lint エラー 0)
- `pnpm exec biome check ./src ./scripts`: **既存 21 件**の fmt 系 diagnostics が出る。これは master HEAD でも同数再現する **本 PR 以前から存在する残債**で、本 PR スコープ外。別 Issue で対応する (DA Should Consider S-3)

## 副次効果

- 本修正により Pulse 禁則語彙 Tripwire テストが runtime で必ず実行されるようになるため、PR #611 / #612 のような「未定義 milestones 参照」交差バグが今後再発した場合も Tripwire 経由で検知される (= 検知網の二重化、DA Should Consider S-2)

## 備考

<details>
<summary>Anchor 型を扱う PR のみチェック (Issue #556)</summary>

本 PR はテストファイル内の `milestones` 定数の宣言形式 (`readonly Milestone[]`) を扱うのみで、`scripts/newPost.ts` の `IgnitionInput` などに `Coordinate` / `Elapsed` フィールドを新規追加・変更するものではないため、Issue #556 の構造的縮退ガード対象外。

</details>
