### PR TITLE
chore: Anchor 系コンポーネントの表示文言テンプレートを定数化 (Closes #534)

### DIFF
--- a/src/components/common/Coordinate.tsx
+++ b/src/components/common/Coordinate.tsx
@@ -108,6 +108,13 @@ const separatorStyles = css({
   marginInline: "xs",
 });
 
+// Issue #534: 表示文言テンプレートを定数として外出し。将来の i18n 化や
+// 文言調整の影響範囲をファイル内 1 箇所に局所化する。
+// (i18n フレームワークは導入しない方針 — 単純な template リテラルに留める)
+const COORDINATE_LIST_ARIA_LABEL = "個人史座標";
+const COORDINATE_LABEL_TEMPLATE = (label: string, daysSince: number): string =>
+  `${label} から ${daysSince} 日目`;
+
 /**
  * 座標1件の表示文言を構築する純粋関数。
  *
@@ -115,7 +122,7 @@ const separatorStyles = css({
  * も同じ書式で表示する。
  */
 const buildCoordinateLabel = (coordinate: CoordinateData): string => {
-  return `${coordinate.label} から ${coordinate.daysSince} 日目`;
+  return COORDINATE_LABEL_TEMPLATE(coordinate.label, coordinate.daysSince);
 };
 
 /**
@@ -154,7 +161,7 @@ export const Coordinate = memo(
     return (
       <div className={containerStyles} data-token-color="fg.muted">
         {/* biome-ignore lint/a11y/noRedundantRoles: Safari/VoiceOver で list-style: none を当てた ul の list セマンティクスが剥奪される既知の WebKit バグへの防御として role="list" を明示する */}
-        <ul aria-label="個人史座標" role="list">
+        <ul aria-label={COORDINATE_LIST_ARIA_LABEL} role="list">
           {displayable.map((coordinate, index) => (
             // milestones.json に同じ label が誤って 2 行入っても React の
             // duplicate key warning を起こさないよう、label と daysSince を

--- a/src/components/common/Coordinate.tsx
+++ b/src/components/common/Coordinate.tsx
@@ -111,7 +111,7 @@ const separatorStyles = css({
 // Issue #534: 表示文言テンプレートを定数として外出し。将来の i18n 化や
 // 文言調整の影響範囲をファイル内 1 箇所に局所化する。
 // (i18n フレームワークは導入しない方針 — 単純な template リテラルに留める)
-const COORDINATE_LIST_ARIA_LABEL = "個人史座標";
+const COORDINATE_LIST_ARIA_LABEL = "個人史座標" as const;
 const COORDINATE_LABEL_TEMPLATE = (label: string, daysSince: number): string =>
   `${label} から ${daysSince} 日目`;
 

--- a/src/components/common/Resurface.tsx
+++ b/src/components/common/Resurface.tsx
@@ -177,11 +177,11 @@ const stretchedLinkStyles = css({
 // Issue #534: 表示文言テンプレート / 固定文言を定数として外出し。将来の i18n
 // 化や文言調整の影響範囲をファイル内 1 箇所に局所化する。
 // (i18n フレームワークは導入しない方針 — 単純な template リテラル / 文字列定数)
-const RESURFACE_SECTION_HEADING = "過去の記事";
-const RESURFACE_SECTION_ARIA_LABEL = "過去の記事";
-const RESURFACE_UNTITLED_POST = "無題の記事";
-const RESURFACE_REASON_LABEL_SILENCE_YEAR_AGO = "1 年前のあなたの声";
-const RESURFACE_REASON_LABEL_SILENCE_OLDEST = "もう一度";
+const RESURFACE_SECTION_HEADING = "過去の記事" as const;
+const RESURFACE_SECTION_ARIA_LABEL = "過去の記事" as const;
+const RESURFACE_UNTITLED_POST = "無題の記事" as const;
+const RESURFACE_REASON_LABEL_SILENCE_YEAR_AGO = "1 年前のあなたの声" as const;
+const RESURFACE_REASON_LABEL_SILENCE_OLDEST = "もう一度" as const;
 const RESURFACE_REASON_LABEL_CALENDAR_TEMPLATE = (yearsAgo: number): string =>
   `${yearsAgo} 年前の今日`;
 const RESURFACE_REASON_LABEL_MILESTONE_ANNIVERSARY_TEMPLATE = (

--- a/src/components/common/Resurface.tsx
+++ b/src/components/common/Resurface.tsx
@@ -174,6 +174,21 @@ const stretchedLinkStyles = css({
   },
 });
 
+// Issue #534: 表示文言テンプレート / 固定文言を定数として外出し。将来の i18n
+// 化や文言調整の影響範囲をファイル内 1 箇所に局所化する。
+// (i18n フレームワークは導入しない方針 — 単純な template リテラル / 文字列定数)
+const RESURFACE_SECTION_HEADING = "過去の記事";
+const RESURFACE_SECTION_ARIA_LABEL = "過去の記事";
+const RESURFACE_UNTITLED_POST = "無題の記事";
+const RESURFACE_REASON_LABEL_SILENCE_YEAR_AGO = "1 年前のあなたの声";
+const RESURFACE_REASON_LABEL_SILENCE_OLDEST = "もう一度";
+const RESURFACE_REASON_LABEL_CALENDAR_TEMPLATE = (yearsAgo: number): string =>
+  `${yearsAgo} 年前の今日`;
+const RESURFACE_REASON_LABEL_MILESTONE_ANNIVERSARY_TEMPLATE = (
+  label: string,
+  yearsSinceMilestone: number,
+): string => `${label}から ${yearsSinceMilestone} 年経った日`;
+
 /**
  * reason に応じた文脈ラベル文字列を返す純粋関数。
  *
@@ -186,11 +201,16 @@ const stretchedLinkStyles = css({
 const buildReasonLabel = (reason: ResurfaceReason): string => {
   switch (reason.kind) {
     case "silence":
-      return reason.sub === "yearAgo" ? "1 年前のあなたの声" : "もう一度";
+      return reason.sub === "yearAgo"
+        ? RESURFACE_REASON_LABEL_SILENCE_YEAR_AGO
+        : RESURFACE_REASON_LABEL_SILENCE_OLDEST;
     case "calendar":
-      return `${reason.yearsAgo} 年前の今日`;
+      return RESURFACE_REASON_LABEL_CALENDAR_TEMPLATE(reason.yearsAgo);
     case "milestoneAnniversary":
-      return `${reason.label}から ${reason.yearsSinceMilestone} 年経った日`;
+      return RESURFACE_REASON_LABEL_MILESTONE_ANNIVERSARY_TEMPLATE(
+        reason.label,
+        reason.yearsSinceMilestone,
+      );
   }
 };
 
@@ -230,10 +250,10 @@ export const Resurface = memo(({ entry, show = true }: ResurfaceProps) => {
     <section
       className={sectionStyles}
       aria-labelledby="resurface-section-heading"
-      aria-label="過去の記事"
+      aria-label={RESURFACE_SECTION_ARIA_LABEL}
     >
       <h3 id="resurface-section-heading" className={headingStyles}>
-        過去の記事
+        {RESURFACE_SECTION_HEADING}
       </h3>
       <article
         className={cardStyles}
@@ -248,7 +268,7 @@ export const Resurface = memo(({ entry, show = true }: ResurfaceProps) => {
             className={stretchedLinkStyles}
             viewTransition
           >
-            {post.title || "無題の記事"}
+            {post.title || RESURFACE_UNTITLED_POST}
           </Link>
         </h3>
         {post.excerpt && <p className={excerptStyles}>{post.excerpt}</p>}

--- a/src/components/pages/AnchorPage.tsx
+++ b/src/components/pages/AnchorPage.tsx
@@ -242,16 +242,16 @@ const skippedNoteStyles = css({
 // 二重定義する (= Coordinate と AnchorPage は表示ポリシーが異なるため共通化
 // しない / CLAUDE.md の「過度に抽象化しない」方針)。書式変更時は両ファイルを
 // 同時更新する運用責任は Tripwire テスト (出力文字列の正規表現マッチ) が担う。
-const ANCHOR_PAGE_HEADING = "Anchor";
+const ANCHOR_PAGE_HEADING = "Anchor" as const;
 const ANCHOR_PAGE_DESCRIPTION =
-  "登録された節目と、各記事の座標を一覧表示します。";
-const ANCHOR_MILESTONES_SECTION_HEADING = "節目一覧";
-const ANCHOR_MILESTONES_LIST_ARIA_LABEL = "節目一覧";
-const ANCHOR_POSTS_SECTION_HEADING = "各記事の座標";
-const ANCHOR_EMPTY_MILESTONES_MESSAGE = "まだ節目が記録されていません。";
-const ANCHOR_EMPTY_POSTS_MESSAGE = "まだ記事がありません。";
-const ANCHOR_EMPTY_COORDINATES_MESSAGE = "まだ通過した節目はありません";
-const ANCHOR_UNTITLED_POST = "無題の記事";
+  "登録された節目と、各記事の座標を一覧表示します。" as const;
+const ANCHOR_MILESTONES_SECTION_HEADING = "節目一覧" as const;
+const ANCHOR_MILESTONES_LIST_ARIA_LABEL = "節目一覧" as const;
+const ANCHOR_POSTS_SECTION_HEADING = "各記事の座標" as const;
+const ANCHOR_EMPTY_MILESTONES_MESSAGE = "まだ節目が記録されていません。" as const;
+const ANCHOR_EMPTY_POSTS_MESSAGE = "まだ記事がありません。" as const;
+const ANCHOR_EMPTY_COORDINATES_MESSAGE = "まだ通過した節目はありません" as const;
+const ANCHOR_UNTITLED_POST = "無題の記事" as const;
 const ANCHOR_SKIPPED_NOTE_TEMPLATE = (skippedCount: number): string =>
   `publishedAt 推定不可でスキップした記事: ${skippedCount} 件`;
 const ANCHOR_ALL_SKIPPED_FALLBACK_TEMPLATE = (skippedCount: number): string =>

--- a/src/components/pages/AnchorPage.tsx
+++ b/src/components/pages/AnchorPage.tsx
@@ -234,6 +234,33 @@ const skippedNoteStyles = css({
   fontVariantNumeric: "tabular-nums",
 });
 
+// Issue #534: 表示文言テンプレート / 固定文言を定数として外出し。将来の i18n
+// 化や文言調整の影響範囲をファイル内 1 箇所に局所化する。
+// (i18n フレームワークは導入しない方針 — 単純な template リテラル / 文字列定数)
+//
+// Coordinate.tsx 側の COORDINATE_LABEL_TEMPLATE と書式が一致する事実は意図的に
+// 二重定義する (= Coordinate と AnchorPage は表示ポリシーが異なるため共通化
+// しない / CLAUDE.md の「過度に抽象化しない」方針)。書式変更時は両ファイルを
+// 同時更新する運用責任は Tripwire テスト (出力文字列の正規表現マッチ) が担う。
+const ANCHOR_PAGE_HEADING = "Anchor";
+const ANCHOR_PAGE_DESCRIPTION =
+  "登録された節目と、各記事の座標を一覧表示します。";
+const ANCHOR_MILESTONES_SECTION_HEADING = "節目一覧";
+const ANCHOR_MILESTONES_LIST_ARIA_LABEL = "節目一覧";
+const ANCHOR_POSTS_SECTION_HEADING = "各記事の座標";
+const ANCHOR_EMPTY_MILESTONES_MESSAGE = "まだ節目が記録されていません。";
+const ANCHOR_EMPTY_POSTS_MESSAGE = "まだ記事がありません。";
+const ANCHOR_EMPTY_COORDINATES_MESSAGE = "まだ通過した節目はありません";
+const ANCHOR_UNTITLED_POST = "無題の記事";
+const ANCHOR_SKIPPED_NOTE_TEMPLATE = (skippedCount: number): string =>
+  `publishedAt 推定不可でスキップした記事: ${skippedCount} 件`;
+const ANCHOR_ALL_SKIPPED_FALLBACK_TEMPLATE = (skippedCount: number): string =>
+  `全記事が publishedAt 推定不可のためスキップしました (${skippedCount} 件)`;
+const ANCHOR_COORDINATE_LABEL_TEMPLATE = (
+  label: string,
+  daysSince: number,
+): string => `${label} から ${daysSince} 日目`;
+
 /**
  * 座標 1 件の表示文言を構築する純粋関数。
  *
@@ -242,7 +269,10 @@ const skippedNoteStyles = css({
  * しない (= 隠さない)。
  */
 const buildCoordinateLabel = (coordinate: Coordinate): string => {
-  return `${coordinate.label} から ${coordinate.daysSince} 日目`;
+  return ANCHOR_COORDINATE_LABEL_TEMPLATE(
+    coordinate.label,
+    coordinate.daysSince,
+  );
 };
 
 /**
@@ -300,10 +330,8 @@ export const AnchorPage = memo(({ posts, milestones }: AnchorPageProps) => {
     <div className={containerStyles}>
       <div className={sectionGapStyles}>
         <div>
-          <h1 className={pageHeadingStyles}>Anchor</h1>
-          <p className={pageDescriptionStyles}>
-            登録された節目と、各記事の座標を一覧表示します。
-          </p>
+          <h1 className={pageHeadingStyles}>{ANCHOR_PAGE_HEADING}</h1>
+          <p className={pageDescriptionStyles}>{ANCHOR_PAGE_DESCRIPTION}</p>
         </div>
 
         {/* 節目一覧 (heavy を含む全件)
@@ -316,13 +344,15 @@ export const AnchorPage = memo(({ posts, milestones }: AnchorPageProps) => {
           data-token-border="border.subtle"
         >
           <h2 id="anchor-milestones-heading" className={sectionHeadingStyles}>
-            節目一覧
+            {ANCHOR_MILESTONES_SECTION_HEADING}
           </h2>
           {milestones.length === 0 ? (
-            <p className={emptyStateStyles}>まだ節目が記録されていません。</p>
+            <p className={emptyStateStyles}>
+              {ANCHOR_EMPTY_MILESTONES_MESSAGE}
+            </p>
           ) : (
             <ul
-              aria-label="節目一覧"
+              aria-label={ANCHOR_MILESTONES_LIST_ARIA_LABEL}
               className={milestoneListStyles}
               // biome-ignore lint/a11y/noRedundantRoles: Safari/VoiceOver で list-style: none を当てた ul の list セマンティクスが剥奪される既知の WebKit バグへの防御として role="list" を明示する
               role="list"
@@ -356,7 +386,7 @@ export const AnchorPage = memo(({ posts, milestones }: AnchorPageProps) => {
             (= テスト用 id) は素直にスキップする。 */}
         {posts.length === 0 ? (
           <div className={sectionBlockStyles} data-token-border="border.subtle">
-            <p className={emptyStateStyles}>まだ記事がありません。</p>
+            <p className={emptyStateStyles}>{ANCHOR_EMPTY_POSTS_MESSAGE}</p>
           </div>
         ) : (
           <section
@@ -365,15 +395,14 @@ export const AnchorPage = memo(({ posts, milestones }: AnchorPageProps) => {
             data-token-border="border.subtle"
           >
             <h2 id="anchor-posts-heading" className={sectionHeadingStyles}>
-              各記事の座標
+              {ANCHOR_POSTS_SECTION_HEADING}
             </h2>
             {postEntries.length === 0 ? (
               // 全記事が publishedAt 推定不可だった場合のフォールバック (Issue #544)。
               // 空 `<ul>` を出すと「各記事の座標」見出し + 空 list + 注記という
               // 不自然な画面になるため、穏やかな空状態テキストにまとめる。
-              // i18n: Issue #534 で定数化候補
               <p className={emptyStateStyles} role="note">
-                {`全記事が publishedAt 推定不可のためスキップしました (${skippedCount} 件)`}
+                {ANCHOR_ALL_SKIPPED_FALLBACK_TEMPLATE(skippedCount)}
               </p>
             ) : (
               <>
@@ -386,11 +415,11 @@ export const AnchorPage = memo(({ posts, milestones }: AnchorPageProps) => {
                       data-token-border="border.subtle"
                     >
                       <span className={postTitleStyles}>
-                        {entry.post.title || "無題の記事"}
+                        {entry.post.title || ANCHOR_UNTITLED_POST}
                       </span>
                       {entry.coordinates.length === 0 ? (
                         <span className={emptyStateStyles}>
-                          まだ通過した節目はありません
+                          {ANCHOR_EMPTY_COORDINATES_MESSAGE}
                         </span>
                       ) : (
                         <div className={postCoordinatesStyles}>
@@ -410,11 +439,10 @@ export const AnchorPage = memo(({ posts, milestones }: AnchorPageProps) => {
                 {/* publishedAt 推定不可な記事のスキップ件数注記 (Issue #544)
                     運用画面として「壊れた id がある事実」を画面に出すための添え書き。
                     0 件のときは注記そのものを出さない (= ノイズ削減 + 運用画面の
-                    控えめなトーンを維持)。
-                    i18n: Issue #534 で定数化候補 */}
+                    控えめなトーンを維持)。 */}
                 {skippedCount > 0 ? (
                   <p className={skippedNoteStyles} role="note">
-                    publishedAt 推定不可でスキップした記事: {skippedCount} 件
+                    {ANCHOR_SKIPPED_NOTE_TEMPLATE(skippedCount)}
                   </p>
                 ) : null}
               </>


### PR DESCRIPTION
## 概要

Issue #534 (i18n 足場) への対応。Anchor 系コンポーネント (Coordinate / Resurface / AnchorPage) の表示文言テンプレートを各ファイル内のトップレベル定数として外出しし、将来の i18n 影響範囲を局所化する。i18n フレームワークの導入はしない (CLAUDE.md「外部ライブラリの追加は原則しない」方針)。

Closes #534

## 変更内容

- `src/components/common/Coordinate.tsx`: 2 定数追加 (`COORDINATE_LIST_ARIA_LABEL`, `COORDINATE_LABEL_TEMPLATE`)
- `src/components/common/Resurface.tsx`: 7 定数追加 (`RESURFACE_SECTION_HEADING` / `RESURFACE_SECTION_ARIA_LABEL` / `RESURFACE_UNTITLED_POST` / `RESURFACE_REASON_LABEL_SILENCE_YEAR_AGO` / `RESURFACE_REASON_LABEL_SILENCE_OLDEST` / `RESURFACE_REASON_LABEL_CALENDAR_TEMPLATE` / `RESURFACE_REASON_LABEL_MILESTONE_ANNIVERSARY_TEMPLATE`)
- `src/components/pages/AnchorPage.tsx`: 11 定数追加 (heading / description / empty メッセージ / skipped_note / coordinate_label 等)
- 全リテラル定数に `as const` を付与してリテラル型を温存 (DA レビュー S-2 反映、将来 i18n キー型解決のための足場)
- 命名規約: リテラル = UPPER_SNAKE_CASE, テンプレート関数 = `*_TEMPLATE` suffix で統一

## 設計上の判断

- **Coordinate と AnchorPage で `coordinate_label` を意図的に二重定義**: heavy 除外ポリシー (Coordinate = 除外あり / AnchorPage = 全 tone 透明性) が将来分岐した際に逆流防止するため。AnchorPage.tsx 内コメントで意図を明文化済み
- **共通モジュール化 (`src/lib/i18n/anchorMessages.ts` 等) は避けた**: 過剰抽象化を避け、各コンポーネントの直近上部にローカル定数として配置 (CLAUDE.md「過度に抽象化しない」方針)
- **既存テストは無修正**: 出力文字列が不変なため Tripwire 873 件全 pass

## 既知の制約 (follow-up 候補)

- `"無題の記事"` は Anchor 系外 (IndexRow / BentoCard / FeaturedCard / PostDetailPage) でも 4 箇所重複しており、横断共通化は別 Issue で追跡 (DA M-1)
- Anchor 系外コンポーネントの定数化ロードマップは別 Issue で管理 (DA M-2)

## ローカルレビュー結果

- DA レビュー: マージ可 (S-2 = `as const` 付与を取り込み済み)
- /review: 承認、ブロッキング指摘なし
- /security-review: 脆弱性なし (純粋な内部リファクタ、観測可能な振る舞い不変)

## 検証

- [x] `pnpm lint` pass (Checked 120 files, no fixes applied)
- [x] `pnpm test:run` pass (51 files / 873 tests)
- [x] `pnpm build` pass (panda → tsc → vite build 全工程通過)