### PR TITLE
chore: milestones.json の意味的スナップショットテストを追加 (Closes #615)

### DIFF
--- a/src/components/common/__tests__/Coordinate.allPosts.test.tsx
+++ b/src/components/common/__tests__/Coordinate.allPosts.test.tsx
@@ -217,10 +217,13 @@ const postIds = postFilePaths
  * メリットがある一方で、「本番 milestone の label rename / tone 変更 /
  * 日付変更などの意味的変更が本テスト上で silent pass する」リスクを孕む。
  * 本番 milestones.json と本テスト fixture のずれは、本番 JSON を直接 import
- * している `anchors.test.ts` および開発者の意識的な fixture 更新
+ * している `anchors.test.ts` および `milestones.semantic.test.ts` (Issue #615
+ * で追加した意味的スナップショット: 本番 JSON の date / label / tone 全件を
+ * 固定 fixture と toEqual 比較し rename / 日付変更 / tone 変更 / 追加 / 削除 /
+ * 並び替えを失敗として検知)、および開発者の意識的な fixture 更新
  * (上述「fixture の更新ルール」) で担保する設計とする。
  * (PR #612 で `AnchorPage.allPosts.test.tsx` も本テストと同様 fixture 化されたため、
- * 本番 JSON 直接 import は `anchors.test.ts` のみとなった)
+ * 本番 JSON 直接 import は `anchors.test.ts` と `milestones.semantic.test.ts` のみとなった)
  */
 const testMilestones: readonly Milestone[] = [
   { date: "2025-08-05", label: "休職開始", tone: "heavy" },

--- a/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
+++ b/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
@@ -248,7 +248,10 @@ const expectations: readonly PostCoordinatesExpectation[] = [
  * メリットがある一方で、「本番 milestone の label rename / tone 変更 /
  * 日付変更などの意味的変更が本テスト上で silent pass する」リスクを孕む。
  * 本番 milestones.json と本テスト fixture のずれは、本番 JSON を直接 import
- * している `anchors.test.ts`、本ファイル末尾の「Pulse 思想禁則語彙が現れない」
+ * している `anchors.test.ts` および `milestones.semantic.test.ts` (Issue #615
+ * で追加した意味的スナップショット: 本番 JSON の date / label / tone 全件を
+ * 固定 fixture と toEqual 比較し rename / 日付変更 / tone 変更 / 追加 / 削除 /
+ * 並び替えを失敗として検知)、本ファイル末尾の「Pulse 思想禁則語彙が現れない」
  * Tripwire テスト (後述 `milestones` 定数を限定的に使用)、および開発者の
  * 意識的な fixture 更新 (上述「fixture の更新ルール」) で担保する設計とする。
  */

--- a/src/lib/__tests__/milestones.semantic.test.ts
+++ b/src/lib/__tests__/milestones.semantic.test.ts
@@ -1,0 +1,63 @@
+/**
+ * datasources/milestones.json の意味的スナップショットテスト (Issue #615)
+ *
+ * 背景:
+ * 既存の `anchors.test.ts` (Issue #489 AC 群) は本番 `milestones.json` を
+ * 入力にした統合テストを持つが、検証範囲は「型 / 値域 / NaN / 例外なし」
+ * までで、label 名や date の意味的整合は誰も検証していなかった。
+ * その結果、例えば `"サイト開設"` を `"blog 開設"` にリネームしても
+ * 全テストが silent pass してしまう状態だった (PR #612 独立 DA レビュー
+ * Moderate 反論より)。
+ *
+ * 本ファイルは本番 `milestones.json` の **全 milestone** を
+ * `{ date, label, tone }` の期待値 fixture として固定し、rename / 日付変更
+ * を明示的にテスト failure として検知することを目的とする。
+ *
+ * 更新ルール:
+ * 本番 `datasources/milestones.json` を意図的に更新した場合は、本ファイルの
+ * `EXPECTED_MILESTONES` も同時に書き直すこと。`toEqual` は順序も比較するため、
+ * 配列順は本番 JSON と完全に一致させる。
+ *
+ * 非スコープ:
+ * - Zod 等の schema 検証による型レベル担保は Issue #547 で別途対応する
+ */
+
+import { describe, expect, it } from "vitest";
+import milestonesJson from "../../../datasources/milestones.json";
+import type { Milestone } from "../anchors";
+
+const EXPECTED_MILESTONES: readonly Milestone[] = [
+  {
+    date: "2025-08-05",
+    label: "休職開始",
+    tone: "heavy",
+  },
+  {
+    date: "2025-08-26",
+    label: "サイト開設",
+    tone: "neutral",
+  },
+  {
+    date: "2025-09-05",
+    label: "社会復帰",
+    tone: "light",
+  },
+];
+
+describe("datasources/milestones.json 意味的スナップショット (Issue #615)", () => {
+  const actualMilestones = milestonesJson as readonly Milestone[];
+
+  it("milestones.json の全件が固定された期待値と完全一致する (rename / 日付変更 / tone 変更を検知できる)", () => {
+    expect(actualMilestones).toEqual(EXPECTED_MILESTONES);
+  });
+
+  it("milestones.json の件数が固定された期待値と一致する (追加 / 削除を検知できる)", () => {
+    expect(actualMilestones.length).toBe(EXPECTED_MILESTONES.length);
+  });
+
+  it("milestones.json の配列順序が固定された期待値と一致する (並び替えを検知できる)", () => {
+    const actualDates = actualMilestones.map((m) => m.date);
+    const expectedDates = EXPECTED_MILESTONES.map((m) => m.date);
+    expect(actualDates).toEqual(expectedDates);
+  });
+});

--- a/src/lib/__tests__/milestones.semantic.test.ts
+++ b/src/lib/__tests__/milestones.semantic.test.ts
@@ -44,6 +44,14 @@ const EXPECTED_MILESTONES: readonly Milestone[] = [
   },
 ];
 
+/**
+ * 3 ケース構成の意図 (DA レビュー M-1 への応答):
+ * 全件 `toEqual` が pass すれば件数 / 順序ケースは構造的に必ず pass するため、
+ * 形式的には冗長な従属関係にある。しかし fail 時の **局所診断性** を優先して
+ * 意図的に分離している。全件 `toEqual` の diff は配列全体を吐くため
+ * 「件数だけずれた」「順序だけずれた」を一目で切り分けにくいが、
+ * 件数 / 順序ケースが独立に fail すれば原因種別が即特定できる。
+ */
 describe("datasources/milestones.json 意味的スナップショット (Issue #615)", () => {
   const actualMilestones = milestonesJson as readonly Milestone[];
 


### PR DESCRIPTION
## 概要

Issue #615 (PR #612 follow-up) への対応。本番 `datasources/milestones.json` の意味的整合 (label / date / tone) を `toEqual` 固定 fixture で検証するスナップショットテストを追加し、rename / 日付変更 / tone 変更を silent pass させない失敗検知レイヤを構築する。

Closes #615

## 背景

PR #612 で AnchorPage.allPosts.test.tsx を fixture 化し本番 milestones.json 直接 import を廃止した結果、「本テストの fixture と本番 milestones.json のずれは `anchors.test.ts` が担保する」設計とした。しかし DA レビューで `anchors.test.ts` の Issue #489 AC 群は型範囲 / NaN / 例外なしまでしか検証しておらず、**意味的整合 (label 名・日付の正当性) を誰も検証していない silent pass 問題** が判明。

## 変更内容

- `src/lib/__tests__/milestones.semantic.test.ts` (新規, 3 ケース):
  1. 全件 `toEqual` で完全一致検証 (rename / date / tone 変更を検知)
  2. 件数チェック (追加 / 削除を検知)
  3. 配列順序チェック (並び替えを検知)
- `src/components/common/__tests__/Coordinate.allPosts.test.tsx`: JSDoc を `milestones.semantic.test.ts` 経由の意味的整合担保に更新
- `src/components/pages/__tests__/AnchorPage.allPosts.test.tsx`: 同上
- 3 ケース構成の意図 (fail 時の局所診断性) を JSDoc で明示 (DA M-1 反映)

## 設計上の判断

- **Zod schema 検証 (Issue #547) は本 PR スコープ外**: Issue 説明で明示的に分離されている
- **テストファイル配置**: `src/lib/__tests__/milestones.semantic.test.ts` で既存規約 (`anchors.test.ts` と同階層) と一致
- **fixture 重複**: 本 PR 完了後、`milestones.json` と同一の `{ date, label, tone }` 配列は 4 箇所に重複するが、共通化すると silent pass リスクが復活するため inline 採用

## fail 検知の実機確認

`datasources/milestones.json` の `"サイト開設"` を `"blog 開設"` に一時的に変更 → `pnpm test:run` で当該テストが意図通り fail (toEqual で diff を出力) → 元に戻して原状復帰を確認済み。

## 既知の制約 (follow-up 候補)

- milestone 件数が 5 件を超えた際の fixture 共通化判断閾値を JSDoc に追記する余地 (DA M-2)

## ローカルレビュー結果

- DA レビュー: マージ可 (M-1 = 3 ケース構成意図の JSDoc 明示を取り込み済み)
- /review: 承認、ブロッキング指摘なし
- /security-review: 脆弱性なし (テストコードのみで攻撃面追加なし)

## 検証

- [x] `pnpm lint` pass (Checked 121 files, no fixes applied)
- [x] `pnpm test:run` pass (52 files / 876 tests, 新規 3 件含む)
- [x] `pnpm build` pass (panda → tsc → vite build 完了)
- [x] fail 検知の実機確認 OK