### PR TITLE
chore: CI で tsc --incremental + actions/cache を有効化し type-check を高速化 (Closes #580)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,16 @@ jobs:
 
       # Issue #580: tsc --incremental の .tsbuildinfo を cache し、
       # type-check / type-check:test の cold ビルドを高速化する。
-      # メインキー: lockfile + tsconfig*.json + src/scripts の hash が完全一致した場合のみ hit
+      # メインキー: lockfile + tsconfig.json / tsconfig.test.json + src/scripts の hash が完全一致した場合のみ hit
       # restoreKeys: lockfile + tsconfig が一致なら部分的に再利用 (src 差分のみ再計算)
-      - name: Cache tsc incremental build info
+      # tsconfig.build.json は本 cache のスコープ外 (build 側 / vite build 前 tsc) のため除外 (DA M-3)
+      - name: Cache tsc incremental build info (Issue #580)
         uses: actions/cache@v5
         with:
           path: .tsbuildinfo
-          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig*.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts') }}
+          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts') }}
           restore-keys: |
-            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig*.json') }}-
+            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json') }}-
             tsc-${{ runner.os }}-
 
       - name: Type check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,19 @@ jobs:
       - name: Lint design tokens (R-5 / Issue #393)
         run: pnpm lint:tokens
 
+      # Issue #580: tsc --incremental の .tsbuildinfo を cache し、
+      # type-check / type-check:test の cold ビルドを高速化する。
+      # メインキー: lockfile + tsconfig*.json + src/scripts の hash が完全一致した場合のみ hit
+      # restoreKeys: lockfile + tsconfig が一致なら部分的に再利用 (src 差分のみ再計算)
+      - name: Cache tsc incremental build info
+        uses: actions/cache@v5
+        with:
+          path: .tsbuildinfo
+          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig*.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts') }}
+          restore-keys: |
+            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig*.json') }}-
+            tsc-${{ runner.os }}-
+
       - name: Type check
         run: pnpm type-check
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ styled-system-studio
 playwright-report
 test-results
 /playwright/.cache
+
+## TypeScript incremental build (Issue #580)
+.tsbuildinfo
+*.tsbuildinfo

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,11 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
+    /* Incremental build (Issue #580): CI の type-check を高速化するため
+       .tsbuildinfo を出力し、actions/cache で再利用する。 */
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuildinfo/tsconfig.tsbuildinfo",
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -8,6 +8,10 @@
     "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client"],
     // テストでは setup 用の helper 変数等で意図的に未使用なものを許容する
     "noUnusedLocals": false,
-    "noUnusedParameters": false
+    "noUnusedParameters": false,
+    // Incremental build (Issue #580): tsconfig.json と独立した .tsbuildinfo を出力。
+    // 本体と test で include は同じだが、設定差分により別ビルド状態を持つため
+    // ファイルを分離する。
+    "tsBuildInfoFile": "./.tsbuildinfo/tsconfig.test.tsbuildinfo"
   }
 }


### PR DESCRIPTION
## 概要

Issue #580 (Issue #559 follow-up) への対応。CI の `tsc --noEmit` を `tsc --incremental` + `actions/cache@v5` で高速化する。現状 cold で本体 4.4s + test 2.9s = 計 ~7s を、cache hit で大幅に短縮。

Closes #580

## 変更内容

- `tsconfig.json`: `compilerOptions` に `incremental: true` + `tsBuildInfoFile: \"./.tsbuildinfo/tsconfig.tsbuildinfo\"` 追加
- `tsconfig.test.json`: `tsBuildInfoFile: \"./.tsbuildinfo/tsconfig.test.tsbuildinfo\"` 追加 (`incremental` は `extends` で継承)
- `.gitignore`: `.tsbuildinfo` (ディレクトリ) + `*.tsbuildinfo` (将来配置の保険) を追加
- `.github/workflows/ci.yml`: `actions/cache@v5` step を `Type check` の前に追加。cache key は `tsc-${os}-${hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json')}-${hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts')}`、restoreKeys 2 段

## 設計上の判断

### `tsBuildInfoFile` のディレクトリ分離
- 本体 `tsconfig.json` と test 用 `tsconfig.test.json` は `noUnusedLocals` 等の `compilerOptions` が異なるため buildinfo ファイル名を分離
- 同一ディレクトリ (`./.tsbuildinfo/`) に置き、`actions/cache` の `path: .tsbuildinfo` で 1 つの cache entry として管理

### cache key 設計
- `tsconfig*.json` glob ではなく `tsconfig.json` / `tsconfig.test.json` を明示列挙 (`tsconfig.build.json` は本 cache のスコープ外、DA M-3 反映)
- メインキー: lockfile + tsconfig + src/scripts の hash 完全一致時のみ完全 hit
- restoreKeys 第1段: lockfile + tsconfig 一致なら src 差分のみ再計算 (incremental の旨味)
- restoreKeys 第2段: OS のみ一致 (lockfile 変更直後の保険、TypeScript が古い buildinfo を自己 invalidate するので安全)

### `actions/cache@v5` の採用
- 既存 `playwright.yml` で v5 を採用しており、リポジトリ全体の version 整合性に従う

## ローカル実機計測

| 対象 | cold | warm (cache hit 相当) | 改善 |
|---|---|---|---|
| `tsc -p tsconfig.json` | 3.549s | 1.514s | 約 2.3〜2.5x |
| `tsc -p tsconfig.test.json` | 2.924s | 1.214s | 約 2.1〜2.4x |
| 合計 | ~6.5s | ~2.7s | 約 3.8s 短縮 |

**注**: CI 実機での cold / cache hit 計測は push 後の GitHub Actions ログから別途確認・追記予定 (DA M-2 反映)。`actions/cache` の restore overhead で warm 効果が縮む可能性あり。

## 既知の制約 (follow-up 候補)

- 本体と test で cache entry を分離して部分 invalidate を効かせる (DA S-1)
- `tsconfig.build.json` 側の incremental 化 (vite build 前 tsc) (DA M-1)
- restoreKeys 第 2 段の効果検証 (DA N-3)
- cache key hash glob に `scripts/**/*.tsx` を加える (将来 scripts 配下に tsx を置いた場合の保険) (レビュワー M1)
- `tsconfig.test.json` のコメントを「include は本体を継承」と書き換える微修正 (レビュワー N2)

## ローカルレビュー結果

- DA レビュー: 要修正 → M-3 (cache key 明示列挙) 取り込み済み、マージ可
- /review: 承認、ブロッキング指摘なし
- /security-review: 該当所見なし (CI workflow / tsconfig / .gitignore 変更のみ、untrusted input 経路なし)

## 検証

- [x] `pnpm lint` pass (120 files)
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` pass (`.tsbuildinfo/tsconfig.tsbuildinfo` 生成確認)
- [x] `pnpm exec tsc --noEmit -p tsconfig.test.json` pass (`.tsbuildinfo/tsconfig.test.tsbuildinfo` 生成確認)
- [x] `pnpm test:run` pass (51 files / 873 tests)
- [x] `pnpm build` pass
- [x] YAML 構文 valid (`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))\"`)
- [x] 2 回目 tsc 実行で warm 動作 (cache hit 相当の高速化) を実機確認