### PR TITLE
chore: fg.muted × bg.* の WCAG 1.4.3 AA 4.5:1 を Tripwire 化 + Coordinate JSDoc を実測値に整合 (Closes #537)

### DIFF
--- a/src/components/common/Coordinate.tsx
+++ b/src/components/common/Coordinate.tsx
@@ -54,7 +54,10 @@ interface CoordinateProps {
  *   Safari/VoiceOver で list セマンティクスが剥奪される既知の WebKit バグへの防御
  * - `<ul>/<li>` のリスト構造で項目ナビゲーションを許容
  * - 色は `fg.muted` (補助情報) を採用。`bg.surface` 上に置かれる前提で
- *   1.4.3 / 1.4.6 の本文比 4.5:1 / 7:1 を満たす Editorial Citrus トークン
+ *   WCAG 1.4.3 AA (4.5:1) を満たす Editorial Citrus トークン
+ *   (実測値: light 6.17:1 / dark 7.91:1。light は AAA 7:1 未達のため
+ *    補助情報専用で本文転用は不可。検証は colorTokens.test.ts §"Issue #537"
+ *    で Tripwire 化済み)
  *
  * 撤退可能性:
  * - `show={false}` で個別に OFF にできる
@@ -74,7 +77,8 @@ const containerStyles = css({
   gap: "xs",
   marginTop: "sm",
   // 補助情報のため fg.muted を採用 (MetaInfo card variant と同じ語彙)。
-  // bg.surface 上の補助情報として WCAG 1.4.3 (4.5:1) / 1.4.6 (7:1) を満たす。
+  // bg.surface 上の補助情報として WCAG 1.4.3 AA (4.5:1) を満たす
+  // (実測 light 6.17:1 / dark 7.91:1、検証は colorTokens.test.ts §"Issue #537")。
   color: "fg.muted",
   fontSize: "xs",
   lineHeight: "snug",

--- a/src/lib/__tests__/colorTokens.test.ts
+++ b/src/lib/__tests__/colorTokens.test.ts
@@ -549,3 +549,86 @@ describe("マージン僅少警告ライン", () => {
     }
   });
 });
+
+describe("Issue #537: fg.muted 補助情報の WCAG 1.4.3 AA (4.5:1) 検証", () => {
+  // Issue #491 (Coordinate) / Issue #492 (Resurface) の DA レビュー軽微指摘
+  // (Issue #537) への対応。Coordinate は `fg.muted` を bg.surface 上に置く前提で
+  // 「WCAG 1.4.3 AA (4.5:1) を満たす」と JSDoc に書かれているが、数値検証が
+  // 未追加だった。本 describe で fg.muted を補助情報文字色として使うパターン
+  // (Coordinate / Resurface の見出し等) を全 bg 階層について Tripwire 化する。
+  //
+  // 留意点 (実測値の事実):
+  //   - light の fg.muted (sumi-600) は **AA pass / AAA 未達** (bg.surface 上 6.17:1)。
+  //     fg.muted は本文ではなく「補助情報のみ」用途に限定するルール (panda.config.ts
+  //     §accent ガイドライン参照)。本文として転用する場合は fg.secondary に振り直す。
+  //   - dark の fg.muted (bone-100) は全 bg 階層で AA 以上 (bg.surface 上 7.91:1 で AAA)。
+
+  it("fg.muted × bg.surface (light) が WCAG 1.4.3 AA 4.5:1 を満たす", () => {
+    // Coordinate / Resurface 見出しが想定する主要配置。
+    // 実測 6.17:1: AA pass / AAA (7.0:1) 未達。
+    const r = ratio(
+      semanticColorTokens.fgMuted.light,
+      semanticColorTokens.bgSurface.light,
+    );
+    expect(r).toBeGreaterThanOrEqual(contrastThresholds.largeText);
+  });
+
+  it("fg.muted × bg.surface (dark) が WCAG 1.4.3 AA 4.5:1 を満たす", () => {
+    // 実測 7.91:1: AAA pass。
+    const r = ratio(
+      semanticColorTokens.fgMuted.dark,
+      semanticColorTokens.bgSurface.dark,
+    );
+    expect(r).toBeGreaterThanOrEqual(contrastThresholds.largeText);
+  });
+
+  it("fg.muted × bg.canvas (light) が WCAG 1.4.3 AA 4.5:1 を満たす", () => {
+    // Coordinate を bg.canvas 直上に置くページ (記事詳細 MetaInfo 近傍など) の保険。
+    // 実測 6.54:1: AA pass / AAA 未達。
+    const r = ratio(
+      semanticColorTokens.fgMuted.light,
+      semanticColorTokens.bgCanvas.light,
+    );
+    expect(r).toBeGreaterThanOrEqual(contrastThresholds.largeText);
+  });
+
+  it("fg.muted × bg.canvas (dark) が WCAG 1.4.3 AA 4.5:1 を満たす", () => {
+    // 実測 14.84:1: AAA pass。
+    const r = ratio(
+      semanticColorTokens.fgMuted.dark,
+      semanticColorTokens.bgCanvas.dark,
+    );
+    expect(r).toBeGreaterThanOrEqual(contrastThresholds.largeText);
+  });
+
+  it("fg.muted × bg.muted (light) が WCAG 1.4.3 AA 4.5:1 を満たす", () => {
+    // 注釈ブロック内に fg.muted の補助情報を置く場合の保険 (Issue #409 で
+    // bg.muted を新設したため検証対象に加える)。実測 6.35:1: AA pass / AAA 未達。
+    const r = ratio(
+      semanticColorTokens.fgMuted.light,
+      semanticColorTokens.bgMuted.light,
+    );
+    expect(r).toBeGreaterThanOrEqual(contrastThresholds.largeText);
+  });
+
+  it("fg.muted × bg.muted (dark) が WCAG 1.4.3 AA 4.5:1 を満たす", () => {
+    // 実測 11.87:1: AAA pass。
+    const r = ratio(
+      semanticColorTokens.fgMuted.dark,
+      semanticColorTokens.bgMuted.dark,
+    );
+    expect(r).toBeGreaterThanOrEqual(contrastThresholds.largeText);
+  });
+
+  it("fg.muted (light) は本文 AAA 7.20:1 を満たさない (補助情報のみ運用 Tripwire)", () => {
+    // negative test: fg.muted は補助情報専用 token で、本文として転用すると AAA
+    // 未達。Coordinate JSDoc の「7:1 を満たす」記述は実態と乖離していたため、
+    // Issue #537 で実測ベースに修正済み (commit 1)。値が将来改善された場合は
+    // このテストが落ちて、本文転用解禁の意思決定をレビューで促す。
+    const r = ratio(
+      semanticColorTokens.fgMuted.light,
+      semanticColorTokens.bgSurface.light,
+    );
+    expect(r).toBeLessThan(contrastThresholds.bodyText);
+  });
+});

--- a/src/lib/__tests__/colorTokens.test.ts
+++ b/src/lib/__tests__/colorTokens.test.ts
@@ -620,15 +620,10 @@ describe("Issue #537: fg.muted 補助情報の WCAG 1.4.3 AA (4.5:1) 検証", ()
     expect(r).toBeGreaterThanOrEqual(contrastThresholds.largeText);
   });
 
-  it("fg.muted (light) は本文 AAA 7.20:1 を満たさない (補助情報のみ運用 Tripwire)", () => {
-    // negative test: fg.muted は補助情報専用 token で、本文として転用すると AAA
-    // 未達。Coordinate JSDoc の「7:1 を満たす」記述は実態と乖離していたため、
-    // Issue #537 で実測ベースに修正済み (commit 1)。値が将来改善された場合は
-    // このテストが落ちて、本文転用解禁の意思決定をレビューで促す。
-    const r = ratio(
-      semanticColorTokens.fgMuted.light,
-      semanticColorTokens.bgSurface.light,
-    );
-    expect(r).toBeLessThan(contrastThresholds.bodyText);
-  });
+  // 補助情報専用 (AAA 未達 token の意図的選択) の運用意図は、
+  // panda.config.ts §"fg.muted は本文として運用しない (補助情報のみ)" と
+  // Coordinate.tsx の JSDoc (色は fg.muted / 補助情報専用で本文転用は不可) で
+  // ドキュメント化している。値が将来改善されて AAA を満たした場合でも、それは
+  // 純粋な改善変更であり Tripwire でブロックすべきではないため、本 describe では
+  // 「AAA を満たさない」ことを assert する negative test は持たない。
 });


### PR DESCRIPTION
## 概要

Issue #537 (Issue #491 PR の DA Round 1 軽微指摘12) への対応。Coordinate は `fg.muted` を bg.surface 上に置く前提で「WCAG 1.4.3 (4.5:1) / 1.4.6 (7:1) を満たす」と JSDoc に書かれていたが、数値検証 Tripwire と JSDoc の事実整合性が欠けていた。

Closes #537

## 変更内容

### Tripwire 追加 (`src/lib/__tests__/colorTokens.test.ts`)
- `describe(\"Issue #537: fg.muted 補助情報の WCAG 1.4.3 AA (4.5:1) 検証\")` ブロックを追加
- 6 ケース (light × 3 + dark × 3):
  - `fg.muted × bg.surface (light)` / `(dark)`
  - `fg.muted × bg.canvas (light)` / `(dark)`
  - `fg.muted × bg.muted (light)` / `(dark)`
- `expect(ratio).toBeGreaterThanOrEqual(contrastThresholds.largeText)` で AA 閾値割れを検知

### Coordinate JSDoc 修正 (副次発見)
- 既存 JSDoc が「1.4.6 (7:1) を満たす」と書いていたが、実測 light 6.17:1 で **AAA 未達**
- 実測値ベース (light 6.17:1 / dark 7.91:1) に修正、AAA 表記を削除
- Tripwire 参照 (`colorTokens.test.ts §\"Issue #537\"`) を JSDoc 内に追記

## 実測値 (culori `wcagContrast`)

| モード | ペア | fg | bg | ratio | 判定 |
|---|---|---|---|---|---|
| light | fg.muted × bg.surface | sumi.600 | cream.100 | **6.17:1** | AA / AAA fail |
| light | fg.muted × bg.canvas | sumi.600 | cream.50 | 6.54:1 | AA / AAA fail |
| light | fg.muted × bg.muted | sumi.600 | cream.75 | 6.35:1 | AA / AAA fail |
| dark | fg.muted × bg.surface | bone.100 | sumi.700 | 7.91:1 | AAA |
| dark | fg.muted × bg.canvas | bone.100 | sumi.950 | 14.84:1 | AAA |
| dark | fg.muted × bg.muted | bone.100 | sumi.650 | 11.87:1 | AAA |

## 設計上の判断

### negative test (AAA 未達 assert) を採用しない (DA S2 反映)
- 初版で `it(\"fg.muted (light) は本文 AAA 7.20:1 を満たさない (補助情報のみ運用 Tripwire)\")` を追加していたが、DA レビューで「将来 token が改善されて AAA 達成 → 改善変更が test に阻まれる副作用」が指摘
- 削除し、運用意図 (「補助情報専用、本文転用不可」) は `Coordinate.tsx` JSDoc + `panda.config.ts` token 定義コメントに集約

### 共通ヘルパ切り出しは YAGNI (見送り)
- AC「他の Anchor 系コンポーネントにも展開可能な共通ヘルパに切り出すか検討」に対し、現状 `colorTokens.test.ts` 1 ファイルに全コントラスト Tripwire が集約されている設計を維持
- Anchor 系コンポーネントは `semantic token` (`fg.muted × bg.*`) で検証可能で、コンポーネント単位のテストに分散させる必要なし

## 既知の制約 (follow-up 候補)

- `fg.muted` を使う他コンポーネント (Resurface / MetaInfo / Footer / AnchorPage / IndexRow / HomePage) の JSDoc 整合 (DA S1)
- dark mode で AAA 超過の上限ガード設計判断 (DA M2)

## ローカルレビュー結果

- DA レビュー: 要修正 → S2 (negative test 削除) 取り込み済み、マージ可
- /review: 承認、ブロッキング指摘なし、任意改善なし
- /security-review: No findings (テストコード + JSDoc 修正のみで攻撃面追加なし)

## 検証

- [x] `pnpm lint` pass (120 files)
- [x] `pnpm test:run` pass (51 files / 879 tests, 追加 6 件)
- [x] `pnpm build` pass
- [x] 実測値 (light 6.17:1 等) と JSDoc 記述の事実整合