### PR TITLE
chore: scripts/calculateContrast.ts の予防的リファクタ + ヘルパー単体テスト追加 (Closes #623)

### DIFF
--- a/scripts/__tests__/calculateContrast.test.ts
+++ b/scripts/__tests__/calculateContrast.test.ts
@@ -1,0 +1,185 @@
+/**
+ * scripts/calculateContrast.ts のヘルパー単体テスト (Issue #623 / S-2 対応)
+ *
+ * 検証対象:
+ *   - buildCsvRow: valid OKLCH ペアで CSV 行を組み立て、invalid 入力で undefined を返す
+ *   - emitGithubActionsWarnings: 環境変数 GITHUB_ACTIONS の状態で出力分岐する
+ *
+ * 方針:
+ *   - 振る舞い単位で 1 ケースずつ書く (TDD)
+ *   - 環境変数判定は dead code 化を防ぐため true / false 両ケース検証
+ *   - console.log は vi.spyOn で捕獲する
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildCsvRow,
+  type ContrastPair,
+  type ContrastResult,
+  emitGithubActionsWarnings,
+  type NamedColor,
+} from "../calculateContrast.ts";
+
+// =============================================================================
+// buildCsvRow
+// =============================================================================
+
+describe("buildCsvRow", () => {
+  it("valid OKLCH ペアで CSV 行を組み立てられる", () => {
+    const surface: NamedColor = {
+      label: "cream-50",
+      value: "oklch(98% 0.02 90)",
+      role: "surface",
+    };
+    const fg: NamedColor = {
+      label: "ink-900",
+      value: "oklch(20% 0.02 90)",
+      role: "fg",
+    };
+
+    const row = buildCsvRow(surface, fg);
+
+    expect(row).toBeDefined();
+    // CSV カラム順は CSV_HEADER と同期している:
+    //   surface,fg,surface_oklch,fg_oklch,ratio,verdict,aaa,aa
+    const columns = (row as string).split(",");
+    expect(columns).toHaveLength(8);
+    expect(columns[0]).toBe("cream-50");
+    expect(columns[1]).toBe("ink-900");
+    expect(columns[2]).toBe('"oklch(98% 0.02 90)"');
+    expect(columns[3]).toBe('"oklch(20% 0.02 90)"');
+    // ratio は数値文字列 (小数 2 桁)。実際の値ではなく形式のみ検証する
+    // (culori の wcagContrast 戻り値の精度に振り回されないため)。
+    expect(columns[4]).toMatch(/^\d+\.\d{2}$/);
+    // verdict は AAA / AA / AA-large / FAIL のいずれか
+    expect(["AAA", "AA", "AA-large", "FAIL"]).toContain(columns[5]);
+    expect(["yes", "no"]).toContain(columns[6]);
+    expect(["yes", "no"]).toContain(columns[7]);
+  });
+
+  it("parse 不能な fg 文字列で undefined を返す", () => {
+    const surface: NamedColor = {
+      label: "cream-50",
+      value: "oklch(98% 0.02 90)",
+      role: "surface",
+    };
+    const fg: NamedColor = {
+      label: "invalid",
+      value: "not-a-color",
+      role: "fg",
+    };
+
+    const row = buildCsvRow(surface, fg);
+
+    expect(row).toBeUndefined();
+  });
+
+  it("parse 不能な surface 文字列で undefined を返す", () => {
+    const surface: NamedColor = {
+      label: "invalid",
+      value: "totally-invalid-color-string",
+      role: "surface",
+    };
+    const fg: NamedColor = {
+      label: "ink-900",
+      value: "oklch(20% 0.02 90)",
+      role: "fg",
+    };
+
+    const row = buildCsvRow(surface, fg);
+
+    expect(row).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// emitGithubActionsWarnings
+// =============================================================================
+
+describe("emitGithubActionsWarnings", () => {
+  const buildResult = (
+    name: string,
+    ratio: number,
+    marginal: boolean,
+  ): ContrastResult => {
+    const pair: ContrastPair = {
+      name,
+      fg: "oklch(20% 0.02 90)",
+      bg: "oklch(98% 0.02 90)",
+      minRatio: 4.5,
+      category: "body",
+    };
+    return {
+      pair,
+      ratio,
+      fgLuminance: 0.1,
+      bgLuminance: 0.9,
+      aaa: ratio >= 7,
+      aa: ratio >= 4.5,
+      passed: ratio >= pair.minRatio,
+      marginal,
+    };
+  };
+
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  const originalEnv = process.env.GITHUB_ACTIONS;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    if (originalEnv === undefined) {
+      delete process.env.GITHUB_ACTIONS;
+    } else {
+      process.env.GITHUB_ACTIONS = originalEnv;
+    }
+  });
+
+  it("GITHUB_ACTIONS=true でマージン僅少ペアごとに ::warning:: を出力できる", () => {
+    process.env.GITHUB_ACTIONS = "true";
+    const marginal = [
+      buildResult("pair-a", 7.05, true),
+      buildResult("pair-b", 4.6, true),
+    ];
+
+    emitGithubActionsWarnings(marginal);
+
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy).toHaveBeenNthCalledWith(
+      1,
+      "::warning::マージン僅少 ratio=7.05 pair-a",
+    );
+    expect(logSpy).toHaveBeenNthCalledWith(
+      2,
+      "::warning::マージン僅少 ratio=4.60 pair-b",
+    );
+  });
+
+  it("GITHUB_ACTIONS 未設定では何も出力しない", () => {
+    delete process.env.GITHUB_ACTIONS;
+    const marginal = [buildResult("pair-a", 7.05, true)];
+
+    emitGithubActionsWarnings(marginal);
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("GITHUB_ACTIONS=false (true 以外の値) では何も出力しない", () => {
+    process.env.GITHUB_ACTIONS = "false";
+    const marginal = [buildResult("pair-a", 7.05, true)];
+
+    emitGithubActionsWarnings(marginal);
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("GITHUB_ACTIONS=true でもマージン僅少が空配列なら何も出力しない", () => {
+    process.env.GITHUB_ACTIONS = "true";
+
+    emitGithubActionsWarnings([]);
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/calculateContrast.ts
+++ b/scripts/calculateContrast.ts
@@ -477,7 +477,8 @@ const verdict = (ratio: number): string => {
   return "FAIL";
 };
 
-const CSV_HEADER = "surface,fg,surface_oklch,fg_oklch,ratio,verdict,aaa,aa";
+const CSV_HEADER =
+  "surface,fg,surface_oklch,fg_oklch,ratio,verdict,aaa,aa" as const;
 
 const formatCsvRow = (
   surface: NamedColor,

--- a/scripts/calculateContrast.ts
+++ b/scripts/calculateContrast.ts
@@ -23,6 +23,7 @@
  *     # マージン僅少 (1.05 倍以内) も fail にする
  */
 
+import { basename } from "node:path";
 import { parse, wcagContrast, wcagLuminance } from "culori";
 import {
   contrastThresholds,
@@ -34,7 +35,7 @@ import {
 // 型定義
 // =============================================================================
 
-interface ContrastPair {
+export interface ContrastPair {
   readonly name: string;
   readonly fg: string;
   readonly bg: string;
@@ -44,7 +45,7 @@ interface ContrastPair {
   readonly category: ContrastCategory;
 }
 
-type ContrastCategory =
+export type ContrastCategory =
   | "body"
   | "ui-large"
   | "link"
@@ -52,7 +53,7 @@ type ContrastCategory =
   | "status"
   | "decorative";
 
-interface ContrastResult {
+export interface ContrastResult {
   readonly pair: ContrastPair;
   readonly ratio: number;
   readonly fgLuminance: number;
@@ -369,7 +370,7 @@ const computeContrast = (pair: ContrastPair): ContrastResult => {
 // CSV (surface × fg 全組合せ)
 // =============================================================================
 
-interface NamedColor {
+export interface NamedColor {
   readonly label: string;
   readonly value: string;
   readonly role: "surface" | "fg";
@@ -483,7 +484,15 @@ const formatCsvRow = (
   ].join(",");
 };
 
-const buildCsvRow = (
+/**
+ * 単一の surface × fg ペアから CSV 1 行を組み立てる。
+ *
+ * culori `parse()` が `undefined` を返すケース (= 不正な OKLCH 文字列等)
+ * では sentinel として `undefined` を返し、行をスキップさせる。
+ *
+ * テストから import するため export する (S-2 / Issue #623)。
+ */
+export const buildCsvRow = (
   surface: NamedColor,
   fg: NamedColor,
 ): string | undefined => {
@@ -685,7 +694,18 @@ const printReport = (
   }
 };
 
-const emitGithubActionsWarnings = (
+/**
+ * `GITHUB_ACTIONS=true` 環境下でのみ、マージン僅少ペアを
+ * GitHub Actions の `::warning::` 形式で出力する。
+ *
+ * - `GITHUB_ACTIONS` 未設定 / `"true"` 以外: 何も出力しない (= ローカル実行で副作用なし)
+ * - `marginal.length === 0`: 早期 return (出力すべき行がない)
+ *
+ * テストから import するため export する (S-2 / Issue #623)。
+ * 環境変数で挙動分岐するため、両ケース (true / false) を単体テストで担保し
+ * 環境変数判定の dead code 化を防ぐ。
+ */
+export const emitGithubActionsWarnings = (
   marginal: readonly ContrastResult[],
 ): void => {
   if (process.env.GITHUB_ACTIONS !== "true" || marginal.length === 0) {
@@ -732,4 +752,15 @@ const main = (): void => {
   runChecks(args.includes("--strict"));
 };
 
-main();
+// CLI として直接実行されたときのみ動かす (テストからの import で副作用しないため)。
+// 判定は `path.basename` 経由で行い、OS 依存のパス区切り (POSIX `/` /
+// Windows `\\`) 双方で同じ結果になるようにする (`scripts/newPost.ts` と同パターン)。
+const isDirectInvocation =
+  typeof process !== "undefined" &&
+  Array.isArray(process.argv) &&
+  process.argv[1] !== undefined &&
+  basename(process.argv[1]) === "calculateContrast.ts";
+
+if (isDirectInvocation) {
+  main();
+}

--- a/scripts/calculateContrast.ts
+++ b/scripts/calculateContrast.ts
@@ -665,20 +665,10 @@ const formatRow = (result: ContrastResult): string => {
   return `  ${marker}[${verdictTag}] ${ratioStr}:1 (>= ${minStr}) ${result.pair.name}${marginalTag}`;
 };
 
-const main = (): void => {
-  const args = process.argv.slice(2);
-  const outputCsv = args.includes("--csv");
-  const strict = args.includes("--strict");
-
-  if (outputCsv) {
-    process.stdout.write(renderCsv());
-    return;
-  }
-
-  const pairs = getContrastPairs();
-  const results = pairs.map(computeContrast);
-  const semanticResults = verifySemanticPairs();
-
+const printReport = (
+  results: readonly ContrastResult[],
+  semanticResults: readonly ContrastResult[],
+): void => {
   console.log("== Editorial Citrus AAA コントラスト実測 ==");
   console.log(
     `本文閾値: ${contrastThresholds.bodyText} / 大文字: ${contrastThresholds.largeText}`,
@@ -693,6 +683,25 @@ const main = (): void => {
   for (const result of semanticResults) {
     console.log(formatRow(result));
   }
+};
+
+const emitGithubActionsWarnings = (
+  marginal: readonly ContrastResult[],
+): void => {
+  if (process.env.GITHUB_ACTIONS !== "true" || marginal.length === 0) {
+    return;
+  }
+  for (const result of marginal) {
+    console.log(
+      `::warning::マージン僅少 ratio=${result.ratio.toFixed(2)} ${result.pair.name}`,
+    );
+  }
+};
+
+const runChecks = (strict: boolean): void => {
+  const results = getContrastPairs().map(computeContrast);
+  const semanticResults = verifySemanticPairs();
+  printReport(results, semanticResults);
 
   const allResults = [...results, ...semanticResults];
   const failed = allResults.filter((r) => !r.passed);
@@ -707,20 +716,20 @@ const main = (): void => {
     console.error("\nNG ペアあり: AAA / AA を満たしていません");
     process.exit(1);
   }
-
   if (strict && marginal.length > 0) {
     console.error("\n--strict 指定: マージン僅少ペアあり");
     process.exit(1);
   }
+  emitGithubActionsWarnings(marginal);
+};
 
-  // GitHub Actions 上ではマージン僅少を ::warning:: で出力する
-  if (process.env.GITHUB_ACTIONS === "true" && marginal.length > 0) {
-    for (const result of marginal) {
-      console.log(
-        `::warning::マージン僅少 ratio=${result.ratio.toFixed(2)} ${result.pair.name}`,
-      );
-    }
+const main = (): void => {
+  const args = process.argv.slice(2);
+  if (args.includes("--csv")) {
+    process.stdout.write(renderCsv());
+    return;
   }
+  runChecks(args.includes("--strict"));
 };
 
 main();

--- a/scripts/calculateContrast.ts
+++ b/scripts/calculateContrast.ts
@@ -21,6 +21,20 @@
  *   pnpm contrast:matrix               # docs/contrast-matrix.csv を生成
  *   node scripts/calculateContrast.ts --strict
  *     # マージン僅少 (1.05 倍以内) も fail にする
+ *
+ * Biome 厳格化耐性 (Issue #623 で実機検証、2026-05-17):
+ *   - 本ファイルは biome を以下条件で厳格化しても違反 0 を維持する:
+ *     * `complexity.noExcessiveCognitiveComplexity`: error, `maxAllowedComplexity: 8`
+ *     * `correctness.noUnusedVariables`: error
+ *     * `suspicious.noImplicitAnyLet`: error
+ *   - 再現手順 (任意の検証ブランチで):
+ *     1. biome.json の上記 3 ルールを `"error"` + `maxAllowedComplexity: 8` に上げる
+ *     2. `pnpm lint` を実行し、scripts/calculateContrast.ts の違反 0 を確認
+ *     3. `pnpm test:run` で挙動の regression がないことを確認
+ *     4. `node scripts/calculateContrast.ts --csv` の出力が master HEAD と
+ *        完全一致することを `md5sum` で確認
+ *   - 維持コストを避けるため CI workflow としては常設化しない (Issue #623 で判断)。
+ *     再評価が必要になった場合は別 Issue を切ること。
  */
 
 import { basename } from "node:path";

--- a/scripts/calculateContrast.ts
+++ b/scripts/calculateContrast.ts
@@ -462,38 +462,48 @@ const verdict = (ratio: number): string => {
   return "FAIL";
 };
 
+const CSV_HEADER = "surface,fg,surface_oklch,fg_oklch,ratio,verdict,aaa,aa";
+
+const formatCsvRow = (
+  surface: NamedColor,
+  fg: NamedColor,
+  ratio: number,
+): string => {
+  const aaa = ratio >= 7.0 ? "yes" : "no";
+  const aa = ratio >= 4.5 ? "yes" : "no";
+  return [
+    surface.label,
+    fg.label,
+    `"${surface.value}"`,
+    `"${fg.value}"`,
+    ratio.toFixed(2),
+    verdict(ratio),
+    aaa,
+    aa,
+  ].join(",");
+};
+
+const buildCsvRow = (
+  surface: NamedColor,
+  fg: NamedColor,
+): string | undefined => {
+  const fgColor = parse(fg.value);
+  const bgColor = parse(surface.value);
+  if (!fgColor || !bgColor) {
+    return undefined;
+  }
+  const ratio = wcagContrast(fgColor, bgColor);
+  return formatCsvRow(surface, fg, ratio);
+};
+
 const renderCsv = (): string => {
   const { surfaces, fgs } = collectMatrixColors();
-  const lines: string[] = [
-    "surface,fg,surface_oklch,fg_oklch,ratio,verdict,aaa,aa",
-  ];
-
-  for (const surface of surfaces) {
-    for (const fg of fgs) {
-      const fgColor = parse(fg.value);
-      const bgColor = parse(surface.value);
-      if (!fgColor || !bgColor) {
-        continue;
-      }
-      const ratio = wcagContrast(fgColor, bgColor);
-      const aaa = ratio >= 7.0 ? "yes" : "no";
-      const aa = ratio >= 4.5 ? "yes" : "no";
-      lines.push(
-        [
-          surface.label,
-          fg.label,
-          `"${surface.value}"`,
-          `"${fg.value}"`,
-          ratio.toFixed(2),
-          verdict(ratio),
-          aaa,
-          aa,
-        ].join(","),
-      );
-    }
-  }
-
-  return `${lines.join("\n")}\n`;
+  const rows = surfaces.flatMap((surface) =>
+    fgs
+      .map((fg) => buildCsvRow(surface, fg))
+      .filter((row): row is string => row !== undefined),
+  );
+  return `${[CSV_HEADER, ...rows].join("\n")}\n`;
 };
 
 // =============================================================================


### PR DESCRIPTION
## 概要

Issue #623 (PR #619 / Closes #521 follow-up) への対応。`scripts/calculateContrast.ts` の cognitive complexity / 暗黙の any let / 未使用変数を予防的に解消し、将来 biome 厳格化時の追従コストを削減する。

Closes #623

## 変更内容

### renderCsv 関数分割 (`0766519`)
- `buildCsvRow` / `formatCsvRow` ヘルパー切り出し + `CSV_HEADER` 定数化
- ネストループを `flatMap` + 型ガード `filter((row): row is string => row !== undefined)` へ書き換え
- cognitive complexity 13 → 7 以下に低減

### main 関数分割 (`b46b1ab`)
- `main`: 引数解析のみに痩せさせ
- `runChecks`: 検証本体 + 集計 + exit 判定
- `printReport`: レポート整形 + console.log
- `emitGithubActionsWarnings`: GitHub Actions `::warning::` 出力
- cognitive complexity 10 → 7 以下に低減

### ヘルパー単体テスト追加 (`19e3263`, DA S-2 反映)
- `scripts/__tests__/calculateContrast.test.ts` (新規, 7 ケース)
- `buildCsvRow`: 正常系 / fg parse 失敗 / surface parse 失敗
- `emitGithubActionsWarnings`: `GITHUB_ACTIONS=true` 出力 / 未設定 / false / 空配列
- ヘルパーを `export` 化 + 型 (`NamedColor` / `ContrastPair` / `ContrastCategory` / `ContrastResult`) export
- `main()` 自動起動を `isDirectInvocation()` (`basename(process.argv[1]) === "calculateContrast.ts"`) でガード (`scripts/newPost.ts` と同パターン)

### Biome 厳格化耐性 JSDoc 追記 (`f7154ea`, DA S-1 反映)
- ファイル先頭 JSDoc に「Issue #623 で実機検証 (`maxAllowedComplexity:8` + 3 ルール error 昇格条件下でも違反 0)」と再現 4 ステップ (biome.json 編集 → pnpm lint → pnpm test:run → CSV md5sum 比較) を記載
- CI workflow 常設化を見送る判断も明記

### CSV_HEADER `as const` 付与 (`8d45dfd`, DA M-1 反映)
- リテラル型温存で将来の列追加時の型安全性向上

## ローカル実機検証

- `pnpm exec biome lint scripts/calculateContrast.ts` ( `maxAllowedComplexity:8` + 3 ルール error 昇格): **違反 0**
- `node scripts/calculateContrast.ts --csv | md5sum` = `5fd0823ce2e6c65f14ce46ff2200b106` (master HEAD と完全一致 → ロジック regression なし)
- 公開 API シグネチャ (`main` / `renderCsv`) 不変

## 既知の制約 (follow-up 候補)

- `runChecks` の更なる分割 (`aggregateResults` / `exitOnFailure` / `dispatchWarnings`) (DA M-2)
- `printReport` の純粋関数化 (`formatReportLines` 抽出 + console.log 薄ラッパー) (DA M-3)
- verdict 閾値 (7.0 / 4.5 / 3.0) を `contrastThresholds` から import で一元化 (DA N-1)
- 同様 8 関数 7 ファイル (lintTokens / newPost / api / hooks / resurface / anchors) の予防的リファクタ (実装担当が言及)

## ローカルレビュー結果

- DA レビュー: 要修正 → S-1 / S-2 / M-1 取り込み済み、マージ可
- /review: 承認、ブロッキング指摘なし
- /security-review: No findings (ローカル/CI 専用 Node CLI、untrusted 入力経路なし)

## 検証

- [x] `pnpm lint` pass (121 files)
- [x] `pnpm test:run` pass (52 files / 880 tests, 新規 7 件含む)
- [x] `pnpm build` pass (panda + tsc + vite build)
- [x] CSV 出力が master HEAD と完全一致 (md5sum 比較)
- [x] biome 厳格化条件下でも違反 0 (再現手順 JSDoc 記載)