### PR TITLE
chore: Coordinate/PostDetailPage の axe テストを境界パターンで拡充 (Closes #538)

### DIFF
--- a/src/components/common/__tests__/Coordinate.test.tsx
+++ b/src/components/common/__tests__/Coordinate.test.tsx
@@ -334,5 +334,60 @@ describe("Coordinate", () => {
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
+
+    // Issue #538: 境界パターン (heavy 除外 / 0 件 / 非表示) を axe 違反検出網に
+    // 追加する。既存の「複数座標 + 1 パターン」のみでは、heavy 除外で表示件数
+    // が縮んだ状態 (separator が出ない 1 件描画) や、early return で
+    // `container.firstChild` が null になるケースで生じうる axe 違反 (= 例えば
+    // 将来 wrapper 構造が変わって aria-label を持たない空 ul が残る等) を
+    // 検出できない。境界 3 パターンを最小コストで axe 通過保証する。
+    it("heavy 除外で表示件数が縮んだ状態でも axe a11y 違反が 0 件である", async () => {
+      // 全節目が過去だが heavy (休職開始) は除外され、表示は neutral / light の
+      // 2 件に縮む構成。Coordinate 内部で `excludeHeavy: true` が効くため
+      // separator は 1 件のみ描画される (境界: 「heavy あり入力」 vs 「heavy なし出力」)
+      const { container } = render(
+        <Coordinate
+          publishedAt="2026-01-01T00:00:00+09:00"
+          milestones={baseMilestones}
+        />,
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("座標 0 件で非描画になった状態で axe a11y 違反が 0 件である", async () => {
+      // 全節目が publishedAt より未来のため early return で何も描画しない。
+      // 描画ノードが空 (container.firstChild === null) の境界でも axe が
+      // 違反を検出しないこと (= 空 DOM が axe 違反として誤検出されないこと) を
+      // 保証する。Issue #538 補足の「DOM が空のケースに axe は不要」観点も
+      // あるが、将来 wrapper を残す形に変えた際に違反が出る可能性を構造的に
+      // 抑える価値があるため境界として網に入れる。
+      const { container } = render(
+        <Coordinate
+          publishedAt="2024-12-31T00:00:00+09:00"
+          milestones={baseMilestones}
+        />,
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("show=false で非描画になった状態で axe a11y 違反が 0 件である", async () => {
+      // 表示 OFF フラグ (撤退可能性) で early return される境界。0 件 early
+      // return と同じく描画ノードが空になるが、判定経路が異なる (show 判定が
+      // milestones フィルタより前に走る) ため独立した境界として網に入れる。
+      const { container } = render(
+        <Coordinate
+          publishedAt="2026-01-01T00:00:00+09:00"
+          milestones={baseMilestones}
+          show={false}
+        />,
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
   });
 });

--- a/src/components/pages/__tests__/PostDetailPage.test.tsx
+++ b/src/components/pages/__tests__/PostDetailPage.test.tsx
@@ -532,5 +532,91 @@ describe("PostDetailPage", () => {
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
+
+    // Issue #538: Coordinate の境界パターン (heavy 除外 / milestones=[] /
+    // showCoordinate=false / publishedAt 推定不可) を統合した状態でも
+    // PostDetailPage 全体の axe 違反が 0 件であることを保証する。
+    // 既存の「Coordinate を含む」1 パターンのみでは、Coordinate が縮んだ /
+    // 消えた状態でページ全体の ARIA 構造に副作用が生じないか検出できない。
+    // 境界 4 パターンを最小コストで axe 通過保証する。
+    it("Coordinate が heavy 除外で縮んだ PostDetailPage 全体で axe a11y 違反が 0 件である", async () => {
+      // neutral / light / heavy の 3 件を渡し、Coordinate 内部で heavy を
+      // 除外して 2 件描画する状態を再現する境界。
+      const mixedMilestones: readonly Milestone[] = [
+        { date: "2025-01-01", label: "サイト開設", tone: "neutral" },
+        { date: "2025-02-01", label: "社会復帰", tone: "light" },
+        { date: "2025-03-01", label: "休職開始", tone: "heavy" },
+      ];
+      const { container } = render(
+        <MemoryRouter>
+          <PostDetailPage
+            post={mockPostWithTimestamp}
+            olderPost={null}
+            newerPost={null}
+            milestones={mixedMilestones}
+          />
+        </MemoryRouter>,
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("milestones=[] で Coordinate を描画しない PostDetailPage 全体で axe a11y 違反が 0 件である", async () => {
+      // 撤退時の挙動 (milestones を空配列にして Coordinate を黙らせる) で
+      // ページ全体の ARIA 構造が axe 違反を起こさないことを保証する。
+      const { container } = render(
+        <MemoryRouter>
+          <PostDetailPage
+            post={mockPostWithTimestamp}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
+        </MemoryRouter>,
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("showCoordinate=false で Coordinate を OFF にした PostDetailPage 全体で axe a11y 違反が 0 件である", async () => {
+      // 表示 OFF フラグ経路の境界。milestones は渡っているが showCoordinate
+      // で個別に黙らせるケース。
+      const { container } = render(
+        <MemoryRouter>
+          <PostDetailPage
+            post={mockPostWithTimestamp}
+            olderPost={null}
+            newerPost={null}
+            milestones={baseMilestones}
+            showCoordinate={false}
+          />
+        </MemoryRouter>,
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("publishedAt 推定不可 (非タイムスタンプ id) の PostDetailPage 全体で axe a11y 違反が 0 件である", async () => {
+      // mockPost.id="test-post" は YYYYMMDDhhmmss にマッチせず inferPublishedAt
+      // が null を返すため、PostDetailPage 側の条件分岐 (publishedAt !== null)
+      // で Coordinate 自体がレンダーされない経路。Coordinate 内部の early
+      // return とは別の境界 (= 親の条件分岐) で違反が生じないことを保証する。
+      const { container } = render(
+        <MemoryRouter>
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={baseMilestones}
+          />
+        </MemoryRouter>,
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
   });
 });


### PR DESCRIPTION
## 概要

Issue #491 PR の Reviewer Round 2 / DA Round 2 で情報共有レベル指摘された axe テストカバレッジ拡充。既存の axe テストは「複数座標 + 1 パターン」のみで、境界 (heavy 除外 / 0 件 / 非表示 / publishedAt 推定不可) を網に入れていなかった。Coordinate / PostDetailPage の両層に境界 axe テストを追加し、将来の Coordinate 構造変更で空 DOM 経路や縮退経路に axe 違反が混入するのを構造的に検出できるようにする。

Closes #538

## 変更内容

- `src/components/common/__tests__/Coordinate.test.tsx`: 境界 axe テスト 3 件追加
  - heavy 除外で表示件数が縮んだ状態 (separator が 1 件のみ描画される構成)
  - 座標 0 件で early return された状態 (空 DOM が axe 違反として誤検出されないこと)
  - show=false で early return された状態 (撤退可能性経路)
- `src/components/pages/__tests__/PostDetailPage.test.tsx`: 境界 axe テスト 4 件追加
  - heavy 除外で Coordinate 描画件数が縮んだ状態
  - milestones=[] で Coordinate 自体が非描画 (撤退時の挙動)
  - showCoordinate=false で Coordinate を OFF にした状態
  - publishedAt 推定不可 (非タイムスタンプ id) で親条件分岐により Coordinate がレンダーされない経路

## 備考

- 追加テストは Issue #538 補足の「DOM が空のケースに axe は不要」観点に対し、将来 wrapper を残す形に変えた際に違反が出る可能性を構造的に抑える価値があるため境界 3 / 4 すべてを採用した
- 既存テスト 873 件 + 追加 7 件 = 全 880 件 PASS、lint / build PASS
- Tripwire (data-* 属性) には触れず axe 違反検出網のみを拡充