### PR TITLE
chore: fg.muted を使う全コンポーネントの JSDoc コントラスト記述を実測値に整合 (Closes #644, Closes #659)

### DIFF
--- a/src/components/atoms/IndexRow.tsx
+++ b/src/components/atoms/IndexRow.tsx
@@ -33,6 +33,10 @@ interface IndexRowProps {
  * - bg.canvas × fg.primary: 17.16:1 AAA / 16.98:1 AAA
  * - bg.canvas × fg.secondary: 9.59:1 AAA / 14.84:1 AAA
  * - bg.canvas × accent.featured: 5.74:1 AA / 5.17:1 AA
+ * - bg.canvas × fg.muted: light 6.54:1 (AA / AAA 未達) / dark 14.84:1 AAA
+ *   (Index 行は bg.canvas 上に置かれる。hover 時は bg.surface に切り替わるが
+ *    その場合も light 6.17:1 / dark 7.91:1 で AA を満たす。番号は装飾扱い
+ *    だが補助情報として AA 4.5:1 を確保。検証は colorTokens.test.ts §"Issue #537")
  *
  * borderBottom の WCAG 1.4.11 (Non-text Contrast / Issue #445):
  * 旧 token (bg.elevated) は light 環境で外側 bg.canvas との差が 1.06:1 と
@@ -85,8 +89,10 @@ const indexRowStyles = css({
 });
 
 // 番号 (01, 02, ...)。tabular-nums で桁ぞろえ。
-// fg.muted (light 6.54:1 AA) は装飾扱いなので問題なし。bold + 小フォントなので
-// 14pt 未満でも装飾的役割。意味は隣接の (link) タイトルが伝える。
+// fg.muted (bg.canvas 上 light 6.54:1 / dark 14.84:1) は補助情報トーンで AA 4.5:1
+// を満たす (light は AAA 7:1 未達のため本文転用は不可)。bold + 小フォントだが
+// 装飾的役割で、意味は隣接の (link) タイトルが伝える。検証は
+// colorTokens.test.ts §"Issue #537"。
 const indexNumberStyles = css({
   fontSize: "sm",
   fontWeight: "700",
@@ -175,6 +181,8 @@ const indexMetaStyles = css({
 });
 
 // メタ間の区切り。視覚絵文字は使わず Em ダッシュで控えめに。
+// aria-hidden の装飾要素のため WCAG 1.4.3 対象外だが、fg.muted は bg.canvas 上
+// (light 6.54:1 / dark 14.84:1) で補助情報トーンとして十分視認可能。
 const indexMetaSeparatorStyles = css({
   color: "fg.muted",
 });

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -62,9 +62,10 @@ export const EmptyState = ({
         </h3>
         {/*
          * description は記事一覧の excerpt と同じく本文寄り用途のため、
-         * fg.muted (light: 6.54:1 AA) ではなく fg.secondary (light: 9.59:1 AAA /
-         * dark: 14.84:1 AAA) を採用する。
-         * (R-2c レビュー指摘: 補助情報ではなく読まれる前提のテキストのため。)
+         * fg.muted (bg.canvas 上 light 6.54:1 AA / AAA 未達、dark 14.84:1 AAA)
+         * ではなく fg.secondary (bg.canvas 上 light 9.59:1 AAA / dark 14.84:1 AAA)
+         * を採用する (R-2c レビュー指摘: 補助情報ではなく読まれる前提のテキスト
+         * のため。fg.muted の検証は colorTokens.test.ts §"Issue #537")。
          */}
         <p
           className={css({

--- a/src/components/common/MetaInfo.tsx
+++ b/src/components/common/MetaInfo.tsx
@@ -62,7 +62,10 @@ const itemCompactStyles = css({
 });
 
 // Editorial Citrus トークン (R-2b / Issue #389)
-// - card variant: 補助情報のため fg.muted を使用
+// - card variant: 補助情報のため fg.muted を使用。bg.surface 上に置かれる前提で
+//   WCAG 1.4.3 AA (4.5:1) を満たす (実測 light 6.17:1 / dark 7.91:1。light は
+//   AAA 7:1 未達のため補助情報専用で本文転用は不可。検証は colorTokens.test.ts
+//   §"Issue #537")。
 // - header variant: 見出し相当のため fg.primary を使用
 // - featured variant: Featured 大見出しの上に置く控えめな補助行 (case 変形なし)
 //   のため fg.secondary を使い、上部に静かに配置する (Issue #395 / #424)。

--- a/src/components/common/Resurface.tsx
+++ b/src/components/common/Resurface.tsx
@@ -55,6 +55,9 @@ interface ResurfaceProps {
  * AA 担保 (calculateContrast.ts による実測値、BentoCard / IndexRow と同様):
  * - bg.surface × fg.primary: 16.19:1 (light) / 7.93:1 (dark) AAA
  * - bg.surface × fg.secondary: light 9.59:1 / dark 14.84:1 AAA
+ * - bg.canvas × fg.muted: light 6.54:1 (AA / AAA 未達) / dark 14.84:1 AAA
+ *   (セクション見出し "過去の記事" が bg.canvas 上に置かれる前提。light は
+ *    補助情報専用で本文転用は不可。検証は colorTokens.test.ts §"Issue #537")
  * - border.subtle × bg.canvas: light 3.49:1 / dark 6.18:1 (WCAG 1.4.11 非テキスト 3:1)
  */
 
@@ -70,6 +73,10 @@ const sectionStyles = css({
 });
 
 // セクション見出し ("過去の記事")。Index 見出しと同じスタイル語彙で並列にする。
+// 補助情報のため fg.muted を採用 (Coordinate / Index 見出しと同じ語彙)。
+// bg.canvas 上の補助情報として WCAG 1.4.3 AA (4.5:1) を満たす
+// (実測 light 6.54:1 / dark 14.84:1。light は AAA 7:1 未達のため補助情報専用で
+//  本文転用は不可。検証は colorTokens.test.ts §"Issue #537")。
 const headingStyles = css({
   fontSize: "xs",
   fontWeight: "700",

--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -29,6 +29,12 @@ export const Footer = () => {
       >
         <BrandName variant="footer" />
       </div>
+      {/*
+       * 著作権表記は補助情報のため fg.muted を採用。Footer の bg.surface 上に
+       * 置かれる前提で WCAG 1.4.3 AA (4.5:1) を満たす (実測 light 6.17:1 /
+       * dark 7.91:1。light は AAA 7:1 未達のため補助情報専用で本文転用は不可。
+       * 検証は colorTokens.test.ts §"Issue #537")。
+       */}
       <div
         className={css({
           color: "fg.muted",

--- a/src/components/pages/AnchorPage.tsx
+++ b/src/components/pages/AnchorPage.tsx
@@ -90,6 +90,17 @@ interface AnchorPageProps {
  * デザイン語彙:
  * - Resurface / Coordinate と同じ補助情報トーン (fg.muted / border.subtle)
  * - Editorial 雑誌風の小型見出し (uppercase + tracking) で章間を意識
+ *
+ * AA 担保 (calculateContrast.ts による実測値):
+ * - bg.canvas × fg.primary: 17.16:1 (light) / 16.98:1 (dark) AAA
+ *   (h1 ページ見出し / 節目項目本文 / 記事タイトル)
+ * - bg.canvas × fg.secondary: light 9.59:1 / dark 14.84:1 AAA
+ *   (ページ説明文)
+ * - bg.canvas × fg.muted: light 6.54:1 (AA / AAA 未達) / dark 14.84:1 AAA
+ *   (section 見出し / 節目の日付・tone タグ / 各記事の座標一覧 / 空状態テキスト /
+ *    スキップ件数注記。いずれも補助情報用途で本文転用は不可。検証は
+ *    colorTokens.test.ts §"Issue #537")
+ * - border.subtle × bg.canvas: light 3.49:1 / dark 6.18:1 (WCAG 1.4.11 非テキスト 3:1)
  */
 
 const containerStyles = css({
@@ -215,6 +226,10 @@ const postCoordinatesStyles = css({
   gap: "xs-sm",
 });
 
+// 空状態テキストは穏やかなトーン優先で fg.muted を採用。AnchorPage の bg.canvas
+// 上に置かれる前提で WCAG 1.4.3 AA (4.5:1) を満たす (実測 light 6.54:1 /
+// dark 14.84:1。light は AAA 7:1 未達のため補助情報専用で本文転用は不可。
+// 検証は colorTokens.test.ts §"Issue #537")。
 const emptyStateStyles = css({
   fontSize: "sm",
   color: "fg.muted",
@@ -224,7 +239,8 @@ const emptyStateStyles = css({
 
 // publishedAt 推定不可でスキップした記事の件数注記。Issue #544 で追加。
 // 運用画面の透明性を優先するため、件数 N >= 1 のとき末尾に小さく出す。
-// emptyStateStyles と同じ補助情報トーン (fg.muted) に揃え、過剰可視化を避ける。
+// emptyStateStyles と同じ補助情報トーン (fg.muted: bg.canvas 上 light 6.54:1 /
+// dark 14.84:1 で AA pass、AAA は light のみ未達) に揃え、過剰可視化を避ける。
 // section の枠 (= border.subtle の境界) は重ねず、文章として控えめに添える。
 const skippedNoteStyles = css({
   fontSize: "xs",

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -131,6 +131,10 @@ const indexListStyles = css({
 
 // Index セクションの見出し (Editorial 風)。
 // "Index" のような小さな目印で雑誌の章タイトルを意識。
+// 補助情報のため fg.muted を採用 (Resurface / AnchorPage 見出しと同じ語彙)。
+// HomePage の bg.canvas 上に置かれる前提で WCAG 1.4.3 AA (4.5:1) を満たす
+// (実測 light 6.54:1 / dark 14.84:1。light は AAA 7:1 未達のため補助情報専用で
+//  本文転用は不可。検証は colorTokens.test.ts §"Issue #537")。
 const indexHeadingStyles = css({
   fontSize: "xs",
   fontWeight: "700",


### PR DESCRIPTION
## 概要

PR #643 (Closes #537) で Coordinate.tsx の JSDoc を実測値ベース (light 6.17:1 AA / AAA 未達、dark 7.91:1 AAA) に修正したが、同じ `fg.muted` token を使う他コンポーネントの JSDoc / コメントには「1.4.6 (7:1) を満たす」等の旧表記や、コントラスト記述自体の欠落が残っていた。本 PR は Issue #644 / #659 (両者は実質完全重複) を一括で解消する。

## 変更内容

- src/components/common/Resurface.tsx: AA 担保 JSDoc に bg.canvas × fg.muted の実測値 (light 6.54:1 / dark 14.84:1) を追加。headingStyles 直上にも同等のコメントを追記
- src/components/common/MetaInfo.tsx: card variant コメントに bg.surface × fg.muted の実測値 (light 6.17:1 / dark 7.91:1) を補強
- src/components/layouts/Footer.tsx: 著作権表記の fg.muted 採用根拠を bg.surface × fg.muted の実測値 (light 6.17:1 / dark 7.91:1) で明文化
- src/components/atoms/IndexRow.tsx: AA 担保 JSDoc に bg.canvas × fg.muted (light 6.54:1 / dark 14.84:1) と hover 時の bg.surface 上 (light 6.17:1 / dark 7.91:1) を追加。番号 / 区切りのコメントも実測値ベースに統一
- src/components/pages/HomePage.tsx: Index セクション見出しの fg.muted 採用根拠を bg.canvas × fg.muted の実測値 (light 6.54:1 / dark 14.84:1) で明文化
- src/components/pages/AnchorPage.tsx: 主要 JSDoc に AA 担保ブロックを追加し bg.canvas × fg.muted の実測値 (light 6.54:1 / dark 14.84:1) を併記。emptyStateStyles / skippedNoteStyles のコメントも実測値ベースに統一
- src/components/common/EmptyState.tsx: description の fg.secondary 採用根拠コメント中の fg.muted 実測値表記に前提 bg (bg.canvas) を明示

修正方針 (Coordinate.tsx の PR #643 で確立されたフォーマットに統一):

- 実測 light / dark コントラスト値を併記
- light が AAA 7:1 未達のため補助情報専用で本文転用は不可である旨を明示
- 検証先として `colorTokens.test.ts §"Issue #537"` を grep 可能な形で参照

## Issue #659 との重複判定

Issue #644 と Issue #659 はタイトル・本文ともに同一スコープ (fg.muted を使う他コンポーネントの JSDoc 整合)。両方とも本 PR で要件を満たすため、本 PR で同時に close する。

## 受け入れ基準

- [x] `fg.muted` を使う全コンポーネントの JSDoc / コメントのコントラスト記述が実測値と整合する
- [x] JSDoc 内に対応 Tripwire テストへの参照 (`colorTokens.test.ts §"Issue #537"`) が含まれる
- [x] 既存 Tripwire テスト全 pass (55 files / 966 tests)
- [x] `bg.surface` 以外 (`bg.canvas` / `bg.muted` 等) 上に置かれるコンポーネントは前提 bg を明示する

## 備考

- PostNavigation.tsx は当初 fg.muted を採用していたが既に fg.secondary に格上げ済みで、実測値も併記済みのため修正対象外
- Coordinate.tsx は PR #643 で既に対応済みのため本 PR では触らない
- 文書 / コメント変更のみで実行コードに変更なし。テスト・lint・build いずれも PASS