### PR TITLE
chore: tsconfig.scripts.json 分離で scripts/ ambient 型の attack surface を制御 (Closes #634)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,17 +35,18 @@ jobs:
         run: pnpm lint:tokens
 
       # Issue #580: tsc --incremental の .tsbuildinfo を cache し、
-      # type-check / type-check:test の cold ビルドを高速化する。
-      # メインキー: lockfile + tsconfig.json / tsconfig.test.json + src/scripts の hash が完全一致した場合のみ hit
+      # type-check / type-check:test / type-check:scripts の cold ビルドを高速化する。
+      # メインキー: lockfile + tsconfig.json / tsconfig.test.json / tsconfig.scripts.json + src/scripts の hash が完全一致した場合のみ hit
       # restoreKeys: lockfile + tsconfig が一致なら部分的に再利用 (src 差分のみ再計算)
       # tsconfig.build.json は本 cache のスコープ外 (build 側 / vite build 前 tsc) のため除外 (DA M-3)
+      # tsconfig.scripts.json は Issue #634 で新設 (scripts/ ambient 型の attack surface 制御)
       - name: Cache tsc incremental build info (Issue #580)
         uses: actions/cache@v5
         with:
           path: .tsbuildinfo
-          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts') }}
+          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts') }}
           restore-keys: |
-            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json') }}-
+            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-
             tsc-${{ runner.os }}-
 
       - name: Type check
@@ -53,3 +54,6 @@ jobs:
 
       - name: Type check (test)
         run: pnpm type-check:test
+
+      - name: Type check (scripts) (Issue #634)
+        run: pnpm type-check:scripts

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "panda --watch & vite",
-    "build": "pnpm run lint && pnpm run test:run && pnpm run type-check && panda && tsc && vite build",
+    "build": "pnpm run lint && pnpm run test:run && pnpm run type-check && pnpm run type-check:scripts && panda && tsc && vite build",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
@@ -17,6 +17,7 @@
     "lint:tokens": "node scripts/lintTokens.ts",
     "type-check": "tsc --noEmit",
     "type-check:test": "tsc --noEmit --project tsconfig.test.json",
+    "type-check:scripts": "tsc --noEmit --project tsconfig.scripts.json",
     "prepare": "panda codegen",
     "new-post": "node scripts/newPost.ts",
     "contrast:check": "node scripts/calculateContrast.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,6 @@
     /* Types */
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["src", "scripts"],
+  "include": ["src"],
   "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,19 @@
+{
+  // tsconfig.json (本体) を継承し、scripts/ 配下専用に Node 環境向けの設定を上書きする。
+  // 本体 tsconfig の include から "scripts" を除外する代わりに、
+  // 本ファイルで scripts/ を対象にすることで、scripts/ 由来の ambient 型
+  // (@types/node の globals.d.ts 等) が src/ 側に漏出するのを防ぐ (Issue #634)。
+  //
+  // scripts/__tests__ は vitest ベースで実行されるため、vitest/globals も types に含める。
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // scripts/ は Node スクリプトとして実行されるため、明示的に @types/node の
+    // ambient globals (process / Buffer / __dirname 等) を有効化する。
+    // scripts/__tests__ が vitest で実行されるため vitest/globals も含める。
+    "types": ["node", "vitest/globals"],
+    // Incremental build (Issue #580): tsconfig.json / tsconfig.test.json と独立した
+    // .tsbuildinfo を出力する。include が異なるため別ファイルにしないと衝突する。
+    "tsBuildInfoFile": "./.tsbuildinfo/tsconfig.scripts.tsbuildinfo"
+  },
+  "include": ["scripts"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,8 @@
 {
   // tsconfig.json (本体) を継承し、テスト実行時のみ必要な型と緩和設定を上書きする。
-  // include は本体の ["src", "scripts"] を継承するため (Issue #522)、
-  // src 配下 / scripts 配下の __tests__ も自動的にカバーされる。
+  // include は本体の ["src"] を継承する (Issue #634 で本体から "scripts" を除外したため、
+  // ここでも src 配下のテストのみが対象となる)。
+  // scripts 配下の __tests__ は tsconfig.scripts.json 側で型チェックする。
   "extends": "./tsconfig.json",
   "compilerOptions": {
     // vite/client は src 配下のテストが import.meta.env 等を参照するため必要


### PR DESCRIPTION
## 概要

Issue #634 への対応。PR #632 (Issue #601) DA M-2 から派生した follow-up。`tsconfig.json` の `include: [\"src\", \"scripts\"]` で src/ と scripts/ が同一 tsconfig で扱われていたため、scripts/ 由来の `@types/node` ambient 型 (`globals.d.ts` の `process` / `Buffer` 等) が src/ 側にも漏出可能だった状態を、`tsconfig.scripts.json` を新設して scripts/ を分離することで遮断する。

Closes #634

## 変更内容

- `tsconfig.scripts.json` (新規): scripts/ 専用 tsconfig。`extends: \"./tsconfig.json\"` で本体を継承し、`include: [\"scripts\"]` / `types: [\"node\", \"vitest/globals\"]` を指定。incremental .tsbuildinfo は `tsconfig.scripts.tsbuildinfo` に分離して本体 / test との衝突を回避
- `tsconfig.json`: `include` を `[\"src\", \"scripts\"]` から `[\"src\"]` に変更。scripts/ 由来の `@types/node/index.d.ts` → `globals.d.ts` ロード経路を本体 tsc から切り離す
- `tsconfig.test.json`: include は本体継承で自動的に `[\"src\"]` となるため、コメントを更新して新しい設計意図 (scripts/__tests__ は `tsconfig.scripts.json` 側で型チェック) を明示
- `package.json`: `type-check:scripts` (= `tsc --noEmit --project tsconfig.scripts.json`) を追加し、`build` でも実行
- `.github/workflows/ci.yml`: `Type check (scripts)` ステップを追加。`.tsbuildinfo` cache key の hashFiles に `tsconfig.scripts.json` を追加し、scripts 側 tsconfig の変更でも cache key が更新されるようにする (Issue #580 の incremental build cache 仕様との整合)

## 設計判断

### attack surface 縮小の達成範囲と限界

本 PR の達成事項は **「scripts/ 起因の ambient 型ロード経路を本体 tsc から遮断する」** に限定される。次の点は本 PR スコープ外:

- `src/api/posts.ts` / `src/api/images.ts` が `import \"node:fs\"` / `import \"node:http\"` を使っており、これらの明示的 import 経由で `@types/node/index.d.ts` → `globals.d.ts` は依然ロードされる
- 結果として src/ の純粋ブラウザコードからも `process` / `Buffer` 等が ambient 参照可能な状態は残る
- これを完全に遮断するには Vite サーバサイドコード (Vite plugin / dev server middleware) と純粋ブラウザコードの tsconfig 分離が必要 → **別 follow-up Issue で追跡推奨**

ただし scripts/ 経由のロードは確実に止まるため、scripts/ を経路としたサプライズな ambient 拡散リスクは解消される。

### `tsconfig.test.json` の include に scripts を再追加しない判断

本体 tsconfig の include から scripts を抜いたことで、test 側も自動的に `[\"src\"]` のみとなる。scripts/__tests__ の型チェックは `tsconfig.scripts.json` 側 (types に `vitest/globals` を含む) で担保し、test 用 tsconfig の責務を src/ に絞ることで設計責務の明確化を図る。

### vite.config.ts / panda.config.ts への影響なし

`tsconfig.build.json` は `include: [\"vite.config.ts\", \"panda.config.ts\"]` で scripts/ を含まないため、ビルドフロー側への影響はない。Vite 本体は内部で esbuild が TS をトランスパイルする (tsc を使わない) ため、tsconfig include の変更は dev / build の挙動に影響しない。

## ローカル検証

- [x] `pnpm exec tsc --noEmit -p tsconfig.json` pass (src/ のみが対象)
- [x] `pnpm exec tsc --noEmit -p tsconfig.scripts.json` pass (scripts/ 対象、@types/node 解決)
- [x] `pnpm exec tsc --noEmit -p tsconfig.test.json` pass
- [x] `pnpm lint` pass (124 files)
- [x] `pnpm test:run` pass (55 files / 966 tests)
- [x] `pnpm build` pass (lint + test + type-check + type-check:scripts + panda + tsc + vite build 全成功)
- [x] `pnpm contrast:check` 実機 pass (合計 47 / NG 0)
- [x] `pnpm lint:tokens` 実機 pass (72 files scanned, no legacy token reference found)

## 関連

- PR #632 (Issue #601) DA M-2 から派生
- Issue #580 (incremental build cache) との整合