### PR TITLE
chore: pre-commit hook の規約二重管理解消と git cleanup robust 化 (Closes #649)

### DIFF
--- a/.claude/hooks/__tests__/pre-commit-guard.test.sh
+++ b/.claude/hooks/__tests__/pre-commit-guard.test.sh
@@ -105,6 +105,32 @@ setup_test_repo() {
   )
   # consecutive cd テスト用の subdir
   mkdir -p "$WORKTREE/src"
+
+  # Issue #649 (履歴肥大化対策): Phase 2 で実際に commit が試行されるケース
+  # (= block-via-native の構造的 bypass 群) では、native hook が block に失敗すると
+  # 隔離リポに commit が積まれて履歴が伸びる。各ケース実行後に setup 時点の HEAD まで
+  # `git reset --hard` で戻すことで、ケース順序に依存しない独立性を保ち、テスト
+  # リポのオブジェクト累積も抑える。
+  SETUP_HEAD_MAIN=$(git -C "$MAIN_REPO" rev-parse HEAD)
+  SETUP_HEAD_WORKTREE=$(git -C "$WORKTREE" rev-parse HEAD)
+}
+
+# Issue #649 (harness 履歴肥大化対策):
+# Phase 2 ケース実行後に、main-repo / worktree を setup 直後の状態へ巻き戻す。
+# - reset --hard で setup commit まで戻す
+# - clean -fdx でステージ前ファイル / dummy-*.txt 残骸 / untracked を全削除
+# - --no-verify は不要 (reset/clean は hook をトリガしない)
+reset_test_repos_to_setup_head() {
+  if [ -n "${SETUP_HEAD_MAIN:-}" ] && [ -d "$MAIN_REPO/.git" ]; then
+    git -C "$MAIN_REPO" reset --hard -q "$SETUP_HEAD_MAIN" 2>/dev/null || true
+    git -C "$MAIN_REPO" clean -fdxq 2>/dev/null || true
+  fi
+  if [ -n "${SETUP_HEAD_WORKTREE:-}" ] && [ -d "$WORKTREE" ]; then
+    git -C "$WORKTREE" reset --hard -q "$SETUP_HEAD_WORKTREE" 2>/dev/null || true
+    # consecutive cd 用 subdir は clean -fdx で消えるので再作成する
+    git -C "$WORKTREE" clean -fdxq 2>/dev/null || true
+    mkdir -p "$WORKTREE/src"
+  fi
 }
 
 # Phase 2 用: 「commit を試みる前にステージ済み変更を作る」ヘルパ。
@@ -404,6 +430,11 @@ for entry in "${TESTS[@]}"; do
       else
         fail_count=$((fail_count + 1))
       fi
+      # Issue #649: Phase 2 ケース実行後にテストリポを setup 直後の状態へ巻き戻す。
+      # - Phase 2 では bash -c で実コマンドを eval するため、native hook が block
+      #   に失敗した場合に commit が積まれて履歴が肥大化する
+      # - 各ケース独立性を担保するため、reset --hard + clean -fdx で fixture を再現
+      reset_test_repos_to_setup_head
       ;;
   esac
 done

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -29,8 +29,13 @@
 #      (native hook 側の対応は本 Issue #592 のスコープ外。shell hook が唯一の防御)
 #   3. コミットメッセージ内に `Co-Authored-By` を含めない — `-m`/`--message` 引数の文字列判定
 #      ※ 真の防御は `.githooks/commit-msg`。本 hook は -m "..." の literal のみ早期検知
-#   4. master/main ブランチへの直接 commit/push 拒否 (best-effort)
+#   4. 保護ブランチ (master/main) への直接 commit/push 拒否 (best-effort)
 #      ※ 真の防御は `.githooks/pre-commit`。本 hook は素朴な経路のみ早期検知
+#
+# 規約 SSOT (Issue #649 / Moderate 4):
+#   「保護ブランチ名 (master/main)」「Co-Authored-By 検出 regex」は
+#   `.githooks/_lib.sh` に集約済み。本 hook 起動時に source して
+#   PROTECTED_BRANCHES / COAUTHOR_PATTERN / is_protected_branch を共有する。
 #
 # 既知の限界 (= shell 文字列解析の本質的限界。これらは git ネイティブ hook で塞ぐ):
 #   - env 変数 prefix (`PAGER=cat git commit ...`)
@@ -57,6 +62,25 @@
 #       本 hook が allowlist で追加カバーする必要は無くなった。
 
 set -euo pipefail
+
+# 規約 SSOT (.githooks/_lib.sh) を読み込む (Issue #649 / Moderate 4)。
+# 本 shell hook と git ネイティブ hook で「保護ブランチ」「Co-Authored-By regex」を
+# 1 箇所で定義し、二重管理を解消する。
+#
+# 解決方針:
+#   - 本 hook は常に `<repo>/.claude/hooks/pre-commit-guard.sh` に置かれる前提のため、
+#     $0 基点で `../../.githooks/_lib.sh` を参照する。
+#   - source 失敗時 (= 想定外の path で実行) は安全側に何もせず exit 0 する
+#     (= Bash ツール呼び出しを spurious block しない)。SSOT 読み込み失敗は
+#     git ネイティブ hook 側で本来の防御層が機能するため致命傷ではない。
+_GUARD_LIB="$(cd "$(dirname "$0")" && pwd)/../../.githooks/_lib.sh"
+if [ -f "$_GUARD_LIB" ]; then
+  # shellcheck source=../../.githooks/_lib.sh
+  . "$_GUARD_LIB"
+else
+  # SSOT が無い環境では本 hook は何もしない (native hook が真の防御層)。
+  exit 0
+fi
 
 INPUT=$(cat)
 
@@ -449,17 +473,27 @@ if printf '%s\n' "$GIT_INVOCATIONS" | grep -Eq '^git[[:space:]]+(commit|push)([[
     CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
   fi
 
-  if [ "$CURRENT_BRANCH" = "master" ] || [ "$CURRENT_BRANCH" = "main" ]; then
-    block "master/main ブランチへの直接 commit/push は禁止です。作業ブランチを切ってください。"
+  # 保護ブランチ判定は SSOT (.githooks/_lib.sh の is_protected_branch) を利用する
+  # (Issue #649 / Moderate 4)。
+  if is_protected_branch "$CURRENT_BRANCH"; then
+    block "保護ブランチ (${PROTECTED_BRANCHES_RE}) への直接 commit/push は禁止です。作業ブランチを切ってください。"
   fi
 fi
 
 # git commit の場合、コマンド引数の -m / --message メッセージに Co-Authored-By が含まれないかチェック
 # （本文に Co-Authored-By という単語が単に言及されるだけのケースと区別するため、
 #  git commit 呼び出しを含むときのみ、かつそのコマンド自体のテキスト内に含まれるかを見る）
+#
+# 検出 regex は SSOT (.githooks/_lib.sh の COAUTHOR_LITERAL_PATTERN) を利用する
+# (Issue #649 / Moderate 4)。case-insensitive 検出に統一することで、
+# 旧実装で素通りしていた `co-authored-by:` (小文字) も block する。
+#
+# shell コマンド literal 段階では `\n` で囲まれた literal 改行も含めて
+# `co-authored-by:` の sub-string を保守的に検出する (COAUTHOR_LITERAL_PATTERN)。
+# 本文向けの厳密判定 (前置 [[:space:]] 要求) は commit-msg hook 側で行う。
 if printf '%s\n' "$GIT_INVOCATIONS" | grep -Eq '^git[[:space:]]+commit([[:space:]]|$)'; then
   COMMIT_LINE=$(printf '%s\n' "$GIT_INVOCATIONS" | grep -E '^git[[:space:]]+commit([[:space:]]|$)' | head -n1)
-  if printf '%s' "$COMMIT_LINE" | grep -q 'Co-Authored-By'; then
+  if printf '%s' "$COMMIT_LINE" | grep -qiE "$COAUTHOR_LITERAL_PATTERN"; then
     block "コミットメッセージに Co-Authored-By を含めることは禁止されています。"
   fi
 fi

--- a/.githooks/_lib.sh
+++ b/.githooks/_lib.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# .githooks/_lib.sh
+# git ネイティブ hook と PreToolUse hook (pre-commit-guard.sh) で共有する
+# 規約の **単一情報源 (SSOT)** (Issue #649 / Moderate 4)。
+#
+# 設計方針:
+#   - 「master / main 直 commit 禁止」と「Co-Authored-By 禁止」の 2 規約は
+#     これまで `.githooks/pre-commit` / `.githooks/commit-msg` /
+#     `.claude/hooks/pre-commit-guard.sh` の 3 箇所に literal で散在しており、
+#     片方を更新し忘れる二重管理リスクがあった。
+#   - 本ファイルを source することで、規約は 1 箇所で定義 / 各 hook は
+#     共通変数 / 共通関数を参照するだけにする。
+#
+# 提供インターフェース:
+#   - PROTECTED_BRANCHES  : 直接 commit を禁止するブランチ名の配列
+#                           例: PROTECTED_BRANCHES=("master" "main")
+#   - COAUTHOR_PATTERN    : Co-Authored-By 検出用の grep -E 正規表現 (大小区別なし運用)
+#   - is_protected_branch <name>  : ブランチ名が PROTECTED_BRANCHES に含まれれば exit 0
+#   - body_contains_coauthor      : stdin に流したコミットメッセージ本文に
+#                                   Co-Authored-By が含まれれば exit 0
+#
+# 適用箇所:
+#   - .githooks/pre-commit  (master / main 直 commit 拒否)
+#   - .githooks/commit-msg  (Co-Authored-By 検出)
+#   - .claude/hooks/pre-commit-guard.sh (Bash PreToolUse hook の早期フィードバック層)
+#
+# 注意:
+#   - 本ファイルは set -e されたコンテキストから source される想定なので、
+#     副作用ある exit / return は関数内に閉じ込めること。
+#   - 配列 (PROTECTED_BRANCHES) は bash 固有機能。POSIX sh から呼ぶ場合は
+#     `PROTECTED_BRANCHES_RE` (パイプ区切り regex) を併用すること。
+
+# 直接 commit を禁止するブランチ名 (SSOT)
+# 追加する場合はここに足すだけで全 hook に伝播する。
+PROTECTED_BRANCHES=("master" "main")
+
+# パイプ区切り版 (POSIX grep -E などで使う)。
+# 例: "master|main"
+PROTECTED_BRANCHES_RE=$(IFS='|'; printf '%s' "${PROTECTED_BRANCHES[*]}")
+
+# Co-Authored-By 検出用 regex (大小区別は呼び出し側で -i フラグ等で制御する)。
+#
+# 2 種類用意する理由:
+#   1. COAUTHOR_PATTERN  — コミットメッセージ「本文」向け (commit-msg hook 用)
+#      行頭または空白の直後に `co-authored-by` が現れ、末尾に `:` がある場合のみ
+#      マッチ。本文中の単なる言及 (例: 「`Co-Authored-By`」のような単一トークン)
+#      は末尾 `:` の要件で弾く設計。
+#   2. COAUTHOR_LITERAL_PATTERN — shell コマンド「引数 literal」向け
+#      (pre-commit-guard.sh の `git commit -m "..."` 検出用)
+#      shell 経由で `-m "feat\nCo-Authored-By: x"` のような literal `\n` を
+#      含む文字列が渡された場合、shlex.split で引用符が剥がされるが内部の
+#      `\n` は literal の `\n` のまま残るため、前置 `[[:space:]]` を要求すると
+#      検知漏れする。shell command literal の段階では `co-authored-by` の
+#      sub-string が現れた時点で block する保守的な regex を採用する。
+#      本文中の偽陽性は shell hook 段階では許容する (= 本文の単なる言及で
+#      false positive 出る可能性はあるが、これは「`co-authored-by:` を含む
+#      shell コマンド文字列」という非常に限定的なケースのみで、現実の運用
+#      では `-m "...Co-Authored-By..."` 以外で出現しない)。
+COAUTHOR_PATTERN='(^|[[:space:]])co-authored-by[[:space:]]*:'
+COAUTHOR_LITERAL_PATTERN='co-authored-by[[:space:]]*:'
+
+# ブランチ名が保護対象に含まれているかを判定する。
+# 含まれていれば exit 0、それ以外は exit 1。
+# 引数: $1 = ブランチ名 (例: master / feat/foo / 空文字)
+is_protected_branch() {
+  local name="${1:-}"
+  if [ -z "$name" ]; then
+    return 1
+  fi
+  local b
+  for b in "${PROTECTED_BRANCHES[@]}"; do
+    if [ "$name" = "$b" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# stdin に流したテキストに Co-Authored-By 行が含まれるかを判定する。
+# 含まれていれば exit 0、それ以外は exit 1。
+# 呼び出し側は本文のみ (= コメント行除去後) を流す責務を持つ。
+body_contains_coauthor() {
+  if grep -qiE "$COAUTHOR_PATTERN"; then
+    return 0
+  fi
+  return 1
+}

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -35,14 +35,40 @@ if [ ! -f "$msg_file" ]; then
   exit 1
 fi
 
-# コメント行 (# で始まる行) を除外したメッセージ本文を作る。
-# git は commit-msg hook の段階ではコメント行を含むファイルを渡してくる
-# ことがあるため、本文のみを抽出してから判定する。
-body=$(grep -v '^#' "$msg_file" || true)
+# 規約 SSOT を読み込む (Issue #649 / Moderate 4)
+# - COAUTHOR_PATTERN / body_contains_coauthor は .githooks/_lib.sh に定義
+_LIB="$(cd "$(dirname "$0")" && pwd)/_lib.sh"
+if [ ! -f "$_LIB" ]; then
+  echo "[commit-msg] FATAL: .githooks/_lib.sh が見つかりません: $_LIB" >&2
+  exit 1
+fi
+# shellcheck source=./_lib.sh
+. "$_LIB"
 
-# 大文字小文字を区別せずに Co-Authored-By を検出する。
+# コミットメッセージ本文を抽出する (Issue #649 / Moderate 5 + scissors line 厳密除外)。
+#
+# git 公式の cleanup ロジックに揃える:
+#   - `git commit --verbose` は scissors line `# ------------------------ >8 ------------------------`
+#     以降に staged diff を出力する。生のメッセージファイルにこれが含まれていると、
+#     コメント行除去後でも diff 内に `Co-Authored-By:` のような literal が
+#     含まれていた場合に誤検知する余地がある (= 不当 block の原因になる)。
+#   - そのため、まず awk で scissors line (`^# ` 以下の任意 `>8` mark を含む行) を
+#     検出して、それ以降を完全に切り落とす。`git cat-file` 内部の `mailinfo` も
+#     scissors line を本文の終端として扱う運用 (Documentation/git-commit.txt 参照)。
+#   - 続いて `git stripspace --strip-comments` で全コメント行 / 末尾空行を除去する。
+#     これは git 自体が `commit.cleanup=strip|default` で実行する cleanup と同等の
+#     ロジックなので、独自実装の `grep -v '^#'` よりも将来仕様変更へ追随しやすい。
+#
+# 注意:
+#   - `git stripspace` は stdin/stdout のフィルタ。awk で scissors 除去した
+#     ストリームをそのまま pipe する。
+#   - `set -e` 下では pipe 中の途中 fail で停止しうるが、stripspace は通常 fail
+#     しないため許容する (fail 時は body が空になり、誤検知は出ない安全側)。
+body=$(awk '/^# -+ >8 -+$/{exit} {print}' "$msg_file" | git stripspace --strip-comments)
+
+# 大文字小文字を区別せずに Co-Authored-By を検出する (COAUTHOR_PATTERN は SSOT)。
 # (Co-authored-by / co-authored-by などの揺れも捕捉)
-if printf '%s' "$body" | grep -qiE '(^|[[:space:]])co-authored-by[[:space:]]*:'; then
+if printf '%s' "$body" | body_contains_coauthor; then
   cat <<EOF >&2
 [commit-msg] コミットメッセージに Co-Authored-By を含めることは禁止されています。
 該当行を削除してから再度コミットしてください。

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -24,20 +24,31 @@
 
 set -euo pipefail
 
+# 規約 SSOT を読み込む (Issue #649 / Moderate 4)
+# - PROTECTED_BRANCHES の定義は .githooks/_lib.sh に集約されている
+# - 本 hook は always `.githooks/` 配下に置かれるため、$0 基点の相対 source で
+#   core.hooksPath / worktree / 隔離リポ等の実行コンテキストに依存しない
+_LIB="$(cd "$(dirname "$0")" && pwd)/_lib.sh"
+if [ ! -f "$_LIB" ]; then
+  echo "[pre-commit] FATAL: .githooks/_lib.sh が見つかりません: $_LIB" >&2
+  exit 1
+fi
+# shellcheck source=./_lib.sh
+. "$_LIB"
+
 # 現在のブランチ名を取得する。
 # - 通常コミット: `git symbolic-ref --short HEAD` で feat/xxx / master 等が取れる
 # - detached HEAD (rebase / cherry-pick 中等): symbolic-ref は失敗するので skip
 # - merge commit や revert 中も symbolic-ref は有効なので通常通り判定する
 
 if ! current_branch=$(git symbolic-ref --short HEAD 2>/dev/null); then
-  # detached HEAD の場合は master/main 判定不能なので素通し
+  # detached HEAD の場合は保護ブランチ判定不能なので素通し
   exit 0
 fi
 
-case "$current_branch" in
-  master|main)
-    cat <<EOF >&2
-[pre-commit] master/main ブランチへの直接 commit は禁止されています。
+if is_protected_branch "$current_branch"; then
+  cat <<EOF >&2
+[pre-commit] 保護ブランチ (${PROTECTED_BRANCHES_RE}) への直接 commit は禁止されています。
 作業ブランチを切ってから commit してください。
 
   git switch -c feat/your-branch-name
@@ -45,8 +56,7 @@ case "$current_branch" in
 (本 hook は .githooks/pre-commit で実装されています。
  ローカル設定: git config core.hooksPath .githooks)
 EOF
-    exit 1
-    ;;
-esac
+  exit 1
+fi
 
 exit 0

--- a/.github/workflows/precommit-guard-tests.yml
+++ b/.github/workflows/precommit-guard-tests.yml
@@ -37,9 +37,12 @@ jobs:
       - name: Assert .githooks files exist and are executable
         # Issue #592 (Counterpoint 31): git native hook の同梱を CI で保証する。
         # ローカル開発者が hook ファイルを誤って削除した PR を CI で検知できる。
+        # Issue #649 (Moderate 4): _lib.sh は両 hook が source する SSOT のため、
+        # 同様に存在 / executable bit を保証する。削除されると hook 起動時に
+        # FATAL で fail するため、CI で先回り検知する。
         run: |
           set -uo pipefail
-          for hook in .githooks/pre-commit .githooks/commit-msg; do
+          for hook in .githooks/pre-commit .githooks/commit-msg .githooks/_lib.sh; do
             if [ ! -f "$hook" ]; then
               echo "::error::Required git native hook is missing: $hook"
               exit 1

--- a/.github/workflows/precommit-guard-tests.yml
+++ b/.github/workflows/precommit-guard-tests.yml
@@ -77,8 +77,19 @@ jobs:
         # harness の TOTAL 行例:
         #   TOTAL: 27  OK: 27  FAIL: 0
         #
-        # 期待値: TOTAL 27 / FAIL 0。新たにケースが追加された (= TOTAL 増) 場合は
-        # 本 grep を更新する運用に倒す (harness と workflow を同 PR で更新)。
+        # Issue #649 (Moderate 3) で grep を retrofit:
+        #   - 旧: `TOTAL: 27  OK: 27  FAIL: 0` 完全一致
+        #   - 新: 「FAIL: 0」+「TOTAL >= 27 (下限固定)」分離型
+        #   - 理由: 「新ケースを追加した PR」で TOTAL が増えると workflow 文字列も
+        #          同 PR で更新せねばならず、片方を忘れた regression を CI で
+        #          検出できなくなる懸念があった。下限 (= MIN_TOTAL) を固定して
+        #          上限は開ける運用にすれば、ケース追加時に workflow 更新を
+        #          必須にせず、ケース削除 (= 下限割れ) のみを regression として弾ける。
+        #
+        # 下限 MIN_TOTAL の更新タイミング:
+        #   - ケースを追加するだけなら MIN_TOTAL は据え置きで OK。
+        #   - ケース削除 / 統合で件数が減る方向に更新する場合は本 step の
+        #     MIN_TOTAL を同 PR で減らす (= 新規 baseline の宣言)。
         run: |
           set -uo pipefail
           out_file="${{ steps.harness.outputs.out_file }}"
@@ -86,10 +97,31 @@ jobs:
             echo "::error::harness output file not found: $out_file"
             exit 1
           fi
-          if ! grep -qE '^TOTAL: 27  OK: 27  FAIL: 0$' "$out_file"; then
-            echo "::error::Expected 'TOTAL: 27  OK: 27  FAIL: 0' but harness output diverged."
-            echo "::error::Check harness output below and update either the harness or this workflow in the same PR."
+          # 下限: 現在の baseline は 27 (Issue #592 完了時点)。減らす方向のみ
+          # 同 PR で更新する。
+          MIN_TOTAL=27
+          total_line=$(grep -E '^TOTAL:' "$out_file" | head -n1 || true)
+          if [ -z "$total_line" ]; then
+            echo "::error::harness output に TOTAL 行が見つかりません"
             grep -E '^TOTAL:' "$out_file" || echo "(TOTAL line not found in harness output)"
+            exit 1
+          fi
+          # FAIL: 0 を厳密確認 (regression の主要シグナル)
+          if ! printf '%s\n' "$total_line" | grep -qE '(^|[[:space:]])FAIL: 0([[:space:]]|$)'; then
+            echo "::error::Expected 'FAIL: 0' in TOTAL line but got: $total_line"
+            exit 1
+          fi
+          # TOTAL 件数を抽出して下限と比較
+          total_num=$(printf '%s\n' "$total_line" \
+            | sed -nE 's/^TOTAL:[[:space:]]+([0-9]+).*/\1/p')
+          if [ -z "$total_num" ]; then
+            echo "::error::TOTAL 件数を抽出できません: $total_line"
+            exit 1
+          fi
+          if [ "$total_num" -lt "$MIN_TOTAL" ]; then
+            echo "::error::TOTAL ($total_num) が下限 $MIN_TOTAL を下回りました。"
+            echo "::error::ケースが意図せず削除された可能性があります。harness を確認するか、"
+            echo "::error::意図的な削減であれば本 workflow の MIN_TOTAL も同 PR で更新してください。"
             exit 1
           fi
 


### PR DESCRIPTION
## 概要

Issue #649 (PR #646 follow-up) 対応。pre-commit hook 周辺の規約二重管理を解消し、
git 標準の cleanup ロジックへ寄せて robust 化する。あわせて harness 実行履歴の
肥大化対策と workflow grep の retrofit を行う。

Closes #649

## 変更内容

- **Moderate 4 (規約 SSOT 化)**: `master|main` ブランチ名と `Co-Authored-By`
  検出 regex が 3 ファイル (`.githooks/pre-commit` / `.githooks/commit-msg` /
  `.claude/hooks/pre-commit-guard.sh`) に散在していたのを `.githooks/_lib.sh` に
  集約。`is_protected_branch` / `body_contains_coauthor` 関数 +
  `PROTECTED_BRANCHES` / `PROTECTED_BRANCHES_RE` / `COAUTHOR_PATTERN` /
  `COAUTHOR_LITERAL_PATTERN` 変数を提供
- **Moderate 5 (`git stripspace --strip-comments` 採用)**: commit-msg hook の
  `grep -v '^#'` 独自実装を git 標準 cleanup ロジックへ差し替え
- **scissors line 厳密除外**: `git commit --verbose` 出力の `# ----- >8 -----`
  以降を `awk` で完全に切り落とし、diff 内の `Co-Authored-By:` 文字列による
  誤検知を防止
- **Moderate 3 (workflow grep retrofit)**: `^TOTAL: 27  OK: 27  FAIL: 0$` 完全
  一致 grep を「FAIL: 0 検出」+「TOTAL >= MIN_TOTAL=27」分離型に変更。ケース
  追加時に workflow 更新を必須にせず、ケース削減のみを regression として検知
- **harness 履歴肥大化対策**: Phase 2 (= native hook 実 eval) 後にテストリポを
  `git reset --hard` + `git clean -fdx` で setup 直後の状態へ巻き戻し、commit
  累積を抑制 + ケース順序独立性を担保
- **Co-Authored-By 検出強化 (副次効果)**: shell hook 側を case-insensitive
  検出 (`COAUTHOR_LITERAL_PATTERN`) に統一し、旧実装で素通りしていた小文字
  `co-authored-by:` も block
- **devils-advocate 指摘対応**: workflow に `_lib.sh` の存在 + executable bit
  assert を追加し、SSOT 削除を CI で先回り検知

## 検証

- [x] bash 構文 valid (`bash -n` 全 hook ファイル)
- [x] test harness: `TOTAL: 27  OK: 27  FAIL: 0`
- [x] commit-msg hook 5 ケース (body / scissors / コメント / case-insensitive /
      末尾 colon なし言及) 期待通り
- [x] pre-commit hook 3 ケース (master block / feat pass / detached pass) 期待通り
- [x] workflow grep retrofit 9 シナリオ手元 simulate で期待通り
- [x] `pnpm lint` pass
- [x] `pnpm test:run` 966 件 pass
- [x] `pnpm build` pass

## ローカル self-review 結果

- reviewer: PASS
- security-reviewer: PASS
- devils-advocate: PASS (workflow `_lib.sh` assert 追加で対応済み)

## 残課題 (本 PR スコープ外)

- core.hooksPath 設定漏れ preflight (DA Should 1 / PR #646 既知制約)
- AI bot 由来限定 Co-Authored-By block (DA Should 2 / PR #646 既知制約)

## 備考

<details>
<summary>Anchor 型を扱う PR のみチェック (Issue #556)</summary>

本 PR は Anchor 型と無関係 (hook / workflow の改修のみ) のため該当なし。

</details>