### PR TITLE
chore: ci.yml の tsc cache key glob に scripts/**/*.tsx を追加 (Closes #654)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .tsbuildinfo
-          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts') }}
+          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts', 'scripts/**/*.tsx') }}
           restore-keys: |
             tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-
             tsc-${{ runner.os }}-


### PR DESCRIPTION
## 概要

PR #639 (Closes #580) のフォロー。`.github/workflows/ci.yml` の `actions/cache` の cache key に含まれる `hashFiles` glob に `scripts/**/*.tsx` を追加し、将来 `scripts/` 配下に `.tsx` が置かれた場合の false-green リスク（古い buildinfo が hit する）を予防的に排除する。

Closes #654

## 変更内容

- `.github/workflows/ci.yml`: cache key の第2引数 `hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts')` に `'scripts/**/*.tsx'` を追加（保険）

## 備考

- 現状 `scripts/` 配下に `.tsx` は存在しないため `hashFiles` は変わらず、既存 cache は invalidate されない（DA レビュー観点 2 で実機確認済）
- 他 workflow への伝播: `grep -rn "hashFiles" .github/workflows/` で ci.yml のみが対象であることを確認（DA レビュー観点 1）
- ローカル検証: `pnpm lint` / `pnpm build` / `pnpm test:run` (966 tests) すべて pass