### PR TITLE
chore: pre-commit-guard.sh に core.hooksPath 設定漏れ preflight warning を追加 (Closes #647)

### DIFF
--- a/.claude/hooks/__tests__/pre-commit-guard.test.sh
+++ b/.claude/hooks/__tests__/pre-commit-guard.test.sh
@@ -440,8 +440,130 @@ for entry in "${TESTS[@]}"; do
 done
 
 echo "----------------------------------------"
+
+# -----------------------------------------------------------------------------
+# Phase 3: preflight (core.hooksPath 設定漏れ検知) のテスト (Issue #647 DA Must / S1)
+# -----------------------------------------------------------------------------
+# preflight は stderr に warning を出すだけで decision:block には影響しないため、
+# Phase 1 / 2 の枠組みでは検証できない。専用ハーネスとして stderr に
+# `[pre-commit-guard] WARNING:` が含まれるかを直接判定する。
+#
+# テストケース:
+#   PF01 core.hooksPath が `.githooks` (相対) → warning 出ない (= 既存挙動)
+#   PF02 core.hooksPath 未設定 → warning 出る、stdout 空、exit 0
+#   PF03 core.hooksPath が `other-dir` (別ディレクトリ) → warning 出る
+#   PF04 core.hooksPath が `<repo>/.githooks` (絶対パス) → warning 出ない
+#                  ← M1: worktree 環境では絶対パスでの設定が一般的
+#   PF05 git リポ外 (cwd=/tmp) → warning 出ない (= preflight 全体 skip)
+#                  ← M2: 任意ディレクトリ実行時の暴発を防ぐ
+
+run_preflight_case() {
+  local id="$1"
+  local cwd="$2"
+  local expect_warning="$3"   # "yes" or "no"
+  local label="$4"
+
+  # 最小限の git コマンド (= preflight が起動する条件) を投入
+  local json
+  json=$(python3 -c '
+import json, sys
+print(json.dumps({"tool_input": {"command": sys.argv[1]}}))
+' "$GIT status")
+
+  local stdout stderr exit_code
+  local stderr_file
+  stderr_file=$(mktemp -t pre-commit-guard-stderr.XXXXXX)
+  stdout=$(cd "$cwd" && printf "%s" "$json" | "$HOOK_PATH" 2>"$stderr_file")
+  exit_code=$?
+  stderr=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+
+  local has_warning="no"
+  if printf "%s" "$stderr" | grep -q '\[pre-commit-guard\] WARNING:'; then
+    has_warning="yes"
+  fi
+
+  # PF02 の追加検証: 未設定ケースは stdout が空 / exit 0 でなければ NG
+  # (preflight 自体は処理を止めない契約)
+  local extra_ok=1
+  if [ "$id" = "PF02" ]; then
+    if [ -n "$stdout" ] || [ "$exit_code" -ne 0 ]; then
+      extra_ok=0
+    fi
+  fi
+
+  if [ "$has_warning" = "$expect_warning" ] && [ "$extra_ok" -eq 1 ]; then
+    printf "  %-22s %-22s OK   (warning=%s)         %s\n" \
+      "$id" "[preflight]" "$has_warning" "$label"
+    return 0
+  fi
+
+  printf "  %-22s %-22s FAIL expected_warning=%s actual=%s exit=%d  %s\n" \
+    "$id" "[preflight]" "$expect_warning" "$has_warning" "$exit_code" "$label"
+  return 1
+}
+
+# preflight 専用に、core.hooksPath を per-case で切り替えられる隔離リポを用意する。
+# 既存の $MAIN_REPO は他テストとの兼ね合いで core.hooksPath=$GITHOOKS_DIR (本リポの)
+# が固定されているため、preflight 検証では別リポを作る。
+PREFLIGHT_REPO="$TEST_ROOT/preflight-repo"
+git init -q -b master "$PREFLIGHT_REPO"
+(
+  cd "$PREFLIGHT_REPO"
+  git config user.email test@example.com
+  git config user.name test-user
+  mkdir -p .githooks
+  : > .githooks/pre-commit
+  chmod +x .githooks/pre-commit
+  mkdir -p other-dir
+)
+
+preflight_fail=0
+
+# PF01: core.hooksPath=.githooks (相対) → warning 出ない
+(cd "$PREFLIGHT_REPO" && git config core.hooksPath .githooks)
+if ! run_preflight_case "PF01" "$PREFLIGHT_REPO" "no" "core.hooksPath=.githooks (relative) — no warning"; then
+  preflight_fail=$((preflight_fail + 1))
+fi
+
+# PF02: core.hooksPath 未設定 → warning 出る、stdout 空、exit 0
+(cd "$PREFLIGHT_REPO" && git config --unset core.hooksPath 2>/dev/null || true)
+if ! run_preflight_case "PF02" "$PREFLIGHT_REPO" "yes" "core.hooksPath unset — warning, stdout empty, exit 0"; then
+  preflight_fail=$((preflight_fail + 1))
+fi
+
+# PF03: core.hooksPath=other-dir → warning 出る
+(cd "$PREFLIGHT_REPO" && git config core.hooksPath other-dir)
+if ! run_preflight_case "PF03" "$PREFLIGHT_REPO" "yes" "core.hooksPath=other-dir — warning"; then
+  preflight_fail=$((preflight_fail + 1))
+fi
+
+# PF04: core.hooksPath=<absolute>/.githooks → warning 出ない (M1)
+(cd "$PREFLIGHT_REPO" && git config core.hooksPath "$PREFLIGHT_REPO/.githooks")
+if ! run_preflight_case "PF04" "$PREFLIGHT_REPO" "no" "core.hooksPath=<absolute>/.githooks — no warning (M1)"; then
+  preflight_fail=$((preflight_fail + 1))
+fi
+
+# PF05: git リポ外 → warning 出ない (M2)
+# /tmp 自身が外側で git init されていないことを念のため確認しつつ、
+# 任意の非リポ ディレクトリで実行する。
+NON_REPO_DIR=$(mktemp -d -t pre-commit-guard-nonrepo.XXXXXX)
+if ! run_preflight_case "PF05" "$NON_REPO_DIR" "no" "outside git repo — no warning (M2)"; then
+  preflight_fail=$((preflight_fail + 1))
+fi
+rm -rf "$NON_REPO_DIR" 2>/dev/null || true
+
+echo "----------------------------------------"
+
+preflight_total=5
+preflight_ok=$((preflight_total - preflight_fail))
+ok_count=$((ok_count + preflight_ok))
+fail_count=$((fail_count + preflight_fail))
+
+total_count=$(( ${#TESTS[@]} + preflight_total ))
+
 printf "TOTAL: %d  OK: %d  FAIL: %d\n" \
-  "${#TESTS[@]}" "$ok_count" "$fail_count"
+  "$total_count" "$ok_count" "$fail_count"
 
 if [ "$fail_count" -gt 0 ]; then
   exit 1

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -187,24 +187,67 @@ fi
 #   - 評価対象の git config は本 hook プロセスの cwd から見たもの (= 通常は
 #     リポジトリ本体 or worktree から)。worktree の場合も `git config` は
 #     親リポと同じ config を参照するため動作する。
-#   - 値が空 (= 未設定) または `.githooks` 以外であれば warning。
+#   - 値が空 (= 未設定) または「リポジトリルートの .githooks に解決されない値」
+#     であれば warning。worktree 環境では `core.hooksPath` が絶対パスで
+#     設定されているケースが多いため、相対 / 絶対の両方で正しく判定するため
+#     repo root を基準に正規化した絶対パスで比較する (Issue #647 DA Must M1)。
+#   - hook プロセスが git リポジトリ外で実行された場合 (例: `cd /tmp && git status`
+#     を Bash ツールで実行する etc.) は warning を出さず preflight 全体を skip
+#     する (Issue #647 DA Must M2)。
 #   - exit せず処理続行 (block しない)。受入基準: warning は stderr、commit
 #     は block しない。
-HOOKS_PATH_CURRENT=$(git config --get core.hooksPath 2>/dev/null || true)
-if [ "$HOOKS_PATH_CURRENT" != ".githooks" ]; then
-  if [ -z "$HOOKS_PATH_CURRENT" ]; then
-    _hp_display="(未設定)"
-  else
-    _hp_display="$HOOKS_PATH_CURRENT"
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  HOOKS_PATH_CURRENT=$(git config --get core.hooksPath 2>/dev/null || true)
+  _HOOKS_OK=0
+  if [ -n "$HOOKS_PATH_CURRENT" ]; then
+    # repo root 基準で「期待される .githooks の絶対パス」を組み立てる。
+    # worktree でも `--show-toplevel` は当該 worktree の作業ツリーを返すが、
+    # `core.hooksPath` は通常 main repo 基準の path で設定されるため、
+    # main の作業ツリー (`--path-format=absolute --git-common-dir` の親) も
+    # 候補に含めて両方一致を許す。
+    _REPO_TOP=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    _GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || true)
+    _MAIN_TOP=""
+    if [ -n "$_GIT_COMMON_DIR" ]; then
+      # --git-common-dir は worktree でも main repo の .git を返す
+      # (例: /path/to/repo/.git)。その親が main repo の作業ツリー。
+      _MAIN_TOP=$(cd "$_GIT_COMMON_DIR/.." 2>/dev/null && pwd -P || true)
+    fi
+    # 設定値の resolve: 相対の場合は cwd 基準で解決される。git の挙動に合わせ、
+    # `cd <value> && pwd -P` を試す。存在しなければ生値のまま比較する
+    # (= ディレクトリとして存在しない値は false positive 扱いで warning)。
+    _HOOKS_RESOLVED=$(cd "$HOOKS_PATH_CURRENT" 2>/dev/null && pwd -P || true)
+    for _expected in "$_REPO_TOP" "$_MAIN_TOP"; do
+      if [ -z "$_expected" ]; then
+        continue
+      fi
+      _EXPECTED_ABS="$_expected/.githooks"
+      if [ "$_HOOKS_RESOLVED" = "$_EXPECTED_ABS" ]; then
+        _HOOKS_OK=1
+        break
+      fi
+      # 念のため basename 一致 + 相対値 ".githooks" のケースもサポート
+      if [ "$HOOKS_PATH_CURRENT" = ".githooks" ]; then
+        _HOOKS_OK=1
+        break
+      fi
+    done
   fi
-  {
-    printf '\n'
-    printf '[pre-commit-guard] WARNING: core.hooksPath が .githooks に設定されていません (現在値: %s)\n' "$_hp_display"
-    printf '[pre-commit-guard]   → master/main 直 commit や Co-Authored-By を block する git ネイティブ hook が発火しません\n'
-    printf '[pre-commit-guard]   → リポジトリルートで次のコマンドを実行してください:\n'
-    printf '[pre-commit-guard]       git config core.hooksPath .githooks\n'
-    printf '\n'
-  } >&2
+  if [ "$_HOOKS_OK" != "1" ]; then
+    if [ -z "$HOOKS_PATH_CURRENT" ]; then
+      _hp_display="(未設定)"
+    else
+      _hp_display="$HOOKS_PATH_CURRENT"
+    fi
+    {
+      printf '\n'
+      printf '[pre-commit-guard] WARNING: core.hooksPath が .githooks に設定されていません (現在値: %s)\n' "$_hp_display"
+      printf '[pre-commit-guard]   → master/main 直 commit や Co-Authored-By を block する git ネイティブ hook が発火しません\n'
+      printf '[pre-commit-guard]   → リポジトリルートで次のコマンドを実行してください:\n'
+      printf '[pre-commit-guard]       git config core.hooksPath .githooks\n'
+      printf '\n'
+    } >&2
+  fi
 fi
 
 # rebase 禁止

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -172,6 +172,41 @@ if [ -z "$GIT_INVOCATIONS" ]; then
   exit 0
 fi
 
+# ------------------------------------------------------------------
+# preflight: core.hooksPath 設定漏れ検知 (Issue #647)
+# ------------------------------------------------------------------
+# PR #646 で真の防御を git ネイティブ hook (`.githooks/`) に移行したが、
+# `git config core.hooksPath .githooks` を実行しない開発者には native hook
+# が発火せず、設定漏れリスクが残る。本 preflight はその設定漏れを stderr
+# に通知する (block ではなく notify)。
+#
+# 設計判断:
+#   - git 系コマンドを含む呼び出しの段階でのみ警告を出す。`ls` 等の無関係な
+#     Bash ツール呼び出しでまで毎回出すと開発者疲弊するため、`GIT_INVOCATIONS`
+#     抽出後 (= git 操作が確実に対象になっているタイミング) に評価する。
+#   - 評価対象の git config は本 hook プロセスの cwd から見たもの (= 通常は
+#     リポジトリ本体 or worktree から)。worktree の場合も `git config` は
+#     親リポと同じ config を参照するため動作する。
+#   - 値が空 (= 未設定) または `.githooks` 以外であれば warning。
+#   - exit せず処理続行 (block しない)。受入基準: warning は stderr、commit
+#     は block しない。
+HOOKS_PATH_CURRENT=$(git config --get core.hooksPath 2>/dev/null || true)
+if [ "$HOOKS_PATH_CURRENT" != ".githooks" ]; then
+  if [ -z "$HOOKS_PATH_CURRENT" ]; then
+    _hp_display="(未設定)"
+  else
+    _hp_display="$HOOKS_PATH_CURRENT"
+  fi
+  {
+    printf '\n'
+    printf '[pre-commit-guard] WARNING: core.hooksPath が .githooks に設定されていません (現在値: %s)\n' "$_hp_display"
+    printf '[pre-commit-guard]   → master/main 直 commit や Co-Authored-By を block する git ネイティブ hook が発火しません\n'
+    printf '[pre-commit-guard]   → リポジトリルートで次のコマンドを実行してください:\n'
+    printf '[pre-commit-guard]       git config core.hooksPath .githooks\n'
+    printf '\n'
+  } >&2
+fi
+
 # rebase 禁止
 if printf '%s\n' "$GIT_INVOCATIONS" | grep -Eq '^git[[:space:]]+rebase([[:space:]]|$)'; then
   block "git rebase は禁止されています。コンフリクト解決は git merge を使用してください。"


### PR DESCRIPTION
## 概要

PR #646 (Closes #592) で真の防御を git ネイティブ hook (`.githooks/`) に移行したが、`git config core.hooksPath .githooks` を実行しない開発者には hook が発火せず、設定漏れリスクが残っていた。`.claude/hooks/pre-commit-guard.sh` の冒頭で `git config --get core.hooksPath` を確認し、`.githooks` 以外が設定されていれば stderr に warning を出す (block ではなく notify)。

Closes #647

## 変更内容

- `.claude/hooks/pre-commit-guard.sh`: `git rev-parse --git-dir >/dev/null 2>&1` でリポ外を skip、`--show-toplevel` / `--git-common-dir` 親を期待値候補に、`cd && pwd -P` で正規化した絶対パスと比較する preflight ブロックを git invocation 検出後に追加
- `.claude/hooks/__tests__/pre-commit-guard.test.sh`: Phase 3 として PF01-PF05 を追加
  - PF01 (相対 `.githooks`) → warning なし
  - PF02 (未設定) → warning あり / stdout 空 / exit 0
  - PF03 (`other-dir`) → warning あり
  - PF04 (絶対パス `<repo>/.githooks`) → warning なし (DA M1 検証)
  - PF05 (git リポ外) → warning なし (DA M2 検証)

## 備考

- DA レビュー 2 周 (M1 絶対パス false positive / M2 リポ外 warning 暴発) すべて解消
- /review APPROVE (Should/Could はドキュメント表現の改善余地のみ)
- /security-review HIGH/MEDIUM/LOW 該当なし
- テストハーネス 32/32 pass、`pnpm lint` regression なし