### PR TITLE
chore: commit-msg hook の Co-Authored-By block を AI bot 由来に限定 (Closes #648)

### DIFF
--- a/.claude/hooks/__tests__/pre-commit-guard.test.sh
+++ b/.claude/hooks/__tests__/pre-commit-guard.test.sh
@@ -308,13 +308,28 @@ add_case "X03" "block" "fix-required" \
   "--git-dir=<nonexistent> is blocked (attack-surface safeguard)"
 
 # --- Co-Authored-By 検出 (regression sanity) ---------------------------------
+# Issue #648: AI bot 由来 (`claude` / `copilot` / `anthropic` / `openai` /
+# `cursor` / `codex` のいずれかを含む) `Co-Authored-By` 行のみが block 対象。
+# 人間メールや dependabot 等の正当な共著情報は許容される。
 add_case "CA01" "block" "sanity" \
-  "$WORKTREE" "$GIT commit -m \"feat\\n\\nCo-Authored-By: x <x@x>\"" \
-  "Co-Authored-By in -m blocks"
+  "$WORKTREE" "$GIT commit -m \"feat\\n\\nCo-Authored-By: Claude <noreply@anthropic.com>\"" \
+  "Co-Authored-By with AI bot identifier (claude) in -m blocks"
 
 add_case "CA02" "pass" "sanity" \
   "$WORKTREE" "echo Co-Authored-By > /tmp/x.txt && $GIT commit" \
   "Co-Authored-By in unrelated arg does not block"
+
+add_case "CA03" "pass" "sanity" \
+  "$WORKTREE" "$GIT commit -m \"feat\\n\\nCo-Authored-By: Taro Yamada <taro@example.com>\"" \
+  "Co-Authored-By with human email in -m does not block (Issue #648)"
+
+add_case "CA04" "block" "sanity" \
+  "$WORKTREE" "$GIT commit -m \"feat\\n\\nCo-Authored-By: github-copilot[bot] <copilot@github.com>\"" \
+  "Co-Authored-By with copilot identifier in -m blocks (Issue #648)"
+
+add_case "CA05" "block" "sanity" \
+  "$WORKTREE" "$GIT commit -m \"feat\\n\\nco-authored-by: claude <foo@bar>\"" \
+  "Case-insensitive AI bot identifier (claude lowercase) blocks (Issue #648)"
 
 # --- rebase / force push (regression sanity) ---------------------------------
 add_case "RB01" "block" "sanity" \

--- a/.claude/hooks/__tests__/pre-commit-guard.test.sh
+++ b/.claude/hooks/__tests__/pre-commit-guard.test.sh
@@ -308,12 +308,18 @@ add_case "X03" "block" "fix-required" \
   "--git-dir=<nonexistent> is blocked (attack-surface safeguard)"
 
 # --- Co-Authored-By 検出 (regression sanity) ---------------------------------
-# Issue #648: AI bot 由来 (`claude` / `copilot` / `anthropic` / `openai` /
-# `cursor` / `codex` のいずれかを含む) `Co-Authored-By` 行のみが block 対象。
-# 人間メールや dependabot 等の正当な共著情報は許容される。
+# Issue #648 / DA Must 対応: 検出 fixture を構造的 (メールドメイン / [bot] suffix)
+# に置換した。block 対象は以下:
+#   - `<...@anthropic.com>` / `<...@openai.com>` / `<...@cursor.{sh,com}>`
+#   - `[bot]` suffix + vendor email
+# 以下は block されない (誤検知排除):
+#   - 人名 substring 衝突 (Claudette / Codexa)
+#   - 本文中の説明 (`fix: Co-Authored-By: Claude の挙動を確認`)
+#   - 人間メールの Co-Authored-By
+#   - subject に "copilot" 等が出現するだけのケース (= 行単位 AND で除外)
 add_case "CA01" "block" "sanity" \
   "$WORKTREE" "$GIT commit -m \"feat\\n\\nCo-Authored-By: Claude <noreply@anthropic.com>\"" \
-  "Co-Authored-By with AI bot identifier (claude) in -m blocks"
+  "Co-Authored-By with @anthropic.com email blocks"
 
 add_case "CA02" "pass" "sanity" \
   "$WORKTREE" "echo Co-Authored-By > /tmp/x.txt && $GIT commit" \
@@ -325,11 +331,49 @@ add_case "CA03" "pass" "sanity" \
 
 add_case "CA04" "block" "sanity" \
   "$WORKTREE" "$GIT commit -m \"feat\\n\\nCo-Authored-By: github-copilot[bot] <copilot@github.com>\"" \
-  "Co-Authored-By with copilot identifier in -m blocks (Issue #648)"
+  "Co-Authored-By with copilot [bot] suffix blocks (Issue #648)"
 
 add_case "CA05" "block" "sanity" \
-  "$WORKTREE" "$GIT commit -m \"feat\\n\\nco-authored-by: claude <foo@bar>\"" \
-  "Case-insensitive AI bot identifier (claude lowercase) blocks (Issue #648)"
+  "$WORKTREE" "$GIT commit -m \"feat\\n\\nco-authored-by: Claude <noreply@anthropic.com>\"" \
+  "Case-insensitive co-authored-by header with AI email blocks (Issue #648)"
+
+# --- Issue #648 DA Must 対応: 誤検知防止 Tripwire ----------------------------
+# M3: 人名 substring 衝突 (実在人名 / 架空人名) で誤 block しないこと
+add_case "CA06" "pass" "false-positive-guard" \
+  "$WORKTREE" "$GIT commit -m \"feat\\n\\nCo-Authored-By: Claudette Colvin <ccolvin@example.com>\"" \
+  "human name 'Claudette' substring does not block (Issue #648 M3)"
+
+add_case "CA07" "pass" "false-positive-guard" \
+  "$WORKTREE" "$GIT commit -m \"feat\\n\\nCo-Authored-By: Codexa Smith <codexa@example.com>\"" \
+  "human name 'Codexa' substring does not block (Issue #648 M3)"
+
+# M3: 本文中 / subject 中の言及で誤 block しないこと
+add_case "CA08" "pass" "false-positive-guard" \
+  "$WORKTREE" "$GIT commit -m \"fix: Co-Authored-By: Claude の挙動を確認\"" \
+  "mention of 'Co-Authored-By: Claude' in subject does not block (Issue #648 M3)"
+
+# M1: subject に AI vendor 名があるだけで body は人間のケースで shell hook
+# が誤 block しないこと (旧実装は literal 全体 OR 検出で誤 block していた)
+add_case "CA09" "pass" "false-positive-guard" \
+  "$WORKTREE" "$GIT commit -m \"feat: refactor copilot integration\\n\\nCo-Authored-By: Taro <taro@example.com>\"" \
+  "subject mentioning 'copilot' + human Co-Authored-By does not block (Issue #648 M1)"
+
+# --- Issue #648 DA Must M2: 実改行 (literal LF) 入り -m -----------------------
+# heredoc / printf 等で実改行が展開されたケース。旧実装は NORMALIZED 段で
+# `tr ';&|()`' '\n'` する前提だったため、-m 引数内の実改行で git 以外の行が
+# 大量に発生し検知漏れしていた。新実装は -m / --message の値を python3 で
+# pre-extract して実改行を保ったまま行単位 AND 判定する。
+#
+# bash の $'...' (C-style escape) で実 LF を埋め込んだ literal を投入する。
+# `g..it commit -m $'feat\n\nCo-Authored-By: Claude <noreply@anthropic.com>'`
+add_case "CA10" "block" "literal-newline" \
+  "$WORKTREE" "$GIT commit -m \$'feat\nfix\n\nCo-Authored-By: Claude <noreply@anthropic.com>'" \
+  "literal LF in -m with AI email blocks (Issue #648 M2)"
+
+# 人間メールの場合は実改行入りでも pass する (誤検知防止)
+add_case "CA11" "pass" "literal-newline" \
+  "$WORKTREE" "$GIT commit -m \$'feat\nfix\n\nCo-Authored-By: Taro <taro@example.com>'" \
+  "literal LF in -m with human email does not block (Issue #648 M2)"
 
 # --- rebase / force push (regression sanity) ---------------------------------
 add_case "RB01" "block" "sanity" \

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -486,17 +486,79 @@ fi
 # Issue #648 以前は「すべての Co-Authored-By を block」していたが、人間 pair
 # programming や dependabot 取り込み等の正当ユースケースを巻き添えにしていた。
 # 本 hook は SSOT (.githooks/_lib.sh の literal_contains_ai_coauthor) に判定を
-# 委譲し、`claude` / `copilot` / `anthropic` 等の AI bot 識別子を含む
-# Co-Authored-By literal のみを block する (Issue #649 / Moderate 4 で導入した
-# SSOT 体制をそのまま継承)。
+# 委譲し、AI bot fixture (email ドメイン / [bot] suffix) を含む Co-Authored-By
+# のみを block する。真の防御は commit-msg hook 側で行う。
 #
-# 本文中の単なる言及 (例: 「`co-authored-by`」という単語) は
-# literal_contains_ai_coauthor が「`co-authored-by:` の出現」と「AI 識別子の出現」
-# の 2 条件を要求するため誤検知しない。真の防御は commit-msg hook 側で行う。
+# Issue #648 DA Must 対応:
+#   - M1: literal 判定を **行単位 AND** にして native hook と挙動を揃える
+#         (subject に "copilot" 等が出現しても誤 block しない)
+#   - M2: `-m`/`--message` の引数値を python3 で pre-extract し、**実改行を
+#         保持したまま** literal_contains_ai_coauthor に流す。これにより
+#         heredoc / printf '\n' / コマンド置換で生成された改行入り message も
+#         shell hook 層で検知できる。
+#   - M3: 検出 fixture を構造的判定 (メールドメイン / [bot] suffix) に置換
+#         (_lib.sh の COAUTHOR_AI_BOT_RE)。人名 substring (Claudette /
+#         Codexa) や 説明文中の言及は誤検知しない。
 if printf '%s\n' "$GIT_INVOCATIONS" | grep -Eq '^git[[:space:]]+commit([[:space:]]|$)'; then
+  # `-m <msg>` / `-m<msg>` / `--message=<msg>` / `--message <msg>` の値を
+  # 実改行を保ったまま COMMAND から抽出する。複数 -m があれば NUL 区切りで
+  # 順に出力 (git は順に append する挙動)。
+  # 抽出失敗時 (クォート不整合等) は空文字を返し、後段の判定で fall through。
+  MESSAGE_VALUES=$(printf '%s' "$COMMAND" | python3 -c '
+import shlex
+import sys
+
+data = sys.stdin.read()
+try:
+    toks = shlex.split(data, posix=True)
+except ValueError:
+    sys.exit(0)
+
+# `git commit` 引数の -m / --message 値だけを順に出す。複数 -m がある場合は
+# git の append 挙動に合わせて全て出す (各値は LF で区切る)。
+# 厳密な「commit セグメント特定」は行わず、全 token を線形に走査する。
+# shell hook は誤検知より見逃し回避を優先するため、保守的に全 -m を集める。
+values = []
+i = 0
+n = len(toks)
+while i < n:
+    t = toks[i]
+    if t == "-m" or t == "--message":
+        if i + 1 < n:
+            values.append(toks[i + 1])
+        i += 2
+        continue
+    if t.startswith("-m") and len(t) > 2:
+        values.append(t[2:])
+        i += 1
+        continue
+    if t.startswith("--message="):
+        values.append(t.split("=", 1)[1])
+        i += 1
+        continue
+    i += 1
+
+if values:
+    # 各 message を実 LF で連結し、さらに sentinel LF を入れて行単位
+    # 判定がぶれないようにする。
+    sys.stdout.write("\n".join(values))
+' 2>/dev/null || true)
+
+  # 1) 抽出した message 本体 (= 実改行を保持) を literal_contains_ai_coauthor
+  #    に流す。M2 対応: heredoc / printf 経由で改行が物理的に展開された場合に
+  #    対応する。
+  if [ -n "$MESSAGE_VALUES" ]; then
+    if printf '%s' "$MESSAGE_VALUES" | literal_contains_ai_coauthor; then
+      block "コミットメッセージに AI bot 由来の Co-Authored-By を含めることは禁止されています (検出: fixture-based email/bot-suffix)。"
+    fi
+  fi
+
+  # 2) フォールバック: 抽出できなかった場合 (`-F file` 経由等) は、従来通り
+  #    commit 行全体 literal で判定する。literal 内に `\n` (2 文字
+  #    backslash+n) リテラルがあるケース (Bash ツール経由の典型) はここで拾える。
   COMMIT_LINE=$(printf '%s\n' "$GIT_INVOCATIONS" | grep -E '^git[[:space:]]+commit([[:space:]]|$)' | head -n1)
   if printf '%s' "$COMMIT_LINE" | literal_contains_ai_coauthor; then
-    block "コミットメッセージに AI bot 由来の Co-Authored-By (${COAUTHOR_AI_IDENTIFIERS_RE}) を含めることは禁止されています。"
+    block "コミットメッセージに AI bot 由来の Co-Authored-By を含めることは禁止されています (検出: fixture-based email/bot-suffix)。"
   fi
 fi
 

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -480,21 +480,23 @@ if printf '%s\n' "$GIT_INVOCATIONS" | grep -Eq '^git[[:space:]]+(commit|push)([[
   fi
 fi
 
-# git commit の場合、コマンド引数の -m / --message メッセージに Co-Authored-By が含まれないかチェック
-# （本文に Co-Authored-By という単語が単に言及されるだけのケースと区別するため、
-#  git commit 呼び出しを含むときのみ、かつそのコマンド自体のテキスト内に含まれるかを見る）
+# git commit の場合、コマンド引数の -m / --message メッセージに
+# **AI bot 由来の** Co-Authored-By が含まれないかチェックする (Issue #648)。
 #
-# 検出 regex は SSOT (.githooks/_lib.sh の COAUTHOR_LITERAL_PATTERN) を利用する
-# (Issue #649 / Moderate 4)。case-insensitive 検出に統一することで、
-# 旧実装で素通りしていた `co-authored-by:` (小文字) も block する。
+# Issue #648 以前は「すべての Co-Authored-By を block」していたが、人間 pair
+# programming や dependabot 取り込み等の正当ユースケースを巻き添えにしていた。
+# 本 hook は SSOT (.githooks/_lib.sh の literal_contains_ai_coauthor) に判定を
+# 委譲し、`claude` / `copilot` / `anthropic` 等の AI bot 識別子を含む
+# Co-Authored-By literal のみを block する (Issue #649 / Moderate 4 で導入した
+# SSOT 体制をそのまま継承)。
 #
-# shell コマンド literal 段階では `\n` で囲まれた literal 改行も含めて
-# `co-authored-by:` の sub-string を保守的に検出する (COAUTHOR_LITERAL_PATTERN)。
-# 本文向けの厳密判定 (前置 [[:space:]] 要求) は commit-msg hook 側で行う。
+# 本文中の単なる言及 (例: 「`co-authored-by`」という単語) は
+# literal_contains_ai_coauthor が「`co-authored-by:` の出現」と「AI 識別子の出現」
+# の 2 条件を要求するため誤検知しない。真の防御は commit-msg hook 側で行う。
 if printf '%s\n' "$GIT_INVOCATIONS" | grep -Eq '^git[[:space:]]+commit([[:space:]]|$)'; then
   COMMIT_LINE=$(printf '%s\n' "$GIT_INVOCATIONS" | grep -E '^git[[:space:]]+commit([[:space:]]|$)' | head -n1)
-  if printf '%s' "$COMMIT_LINE" | grep -qiE "$COAUTHOR_LITERAL_PATTERN"; then
-    block "コミットメッセージに Co-Authored-By を含めることは禁止されています。"
+  if printf '%s' "$COMMIT_LINE" | literal_contains_ai_coauthor; then
+    block "コミットメッセージに AI bot 由来の Co-Authored-By (${COAUTHOR_AI_IDENTIFIERS_RE}) を含めることは禁止されています。"
   fi
 fi
 

--- a/.githooks/_lib.sh
+++ b/.githooks/_lib.sh
@@ -40,24 +40,50 @@ PROTECTED_BRANCHES_RE=$(IFS='|'; printf '%s' "${PROTECTED_BRANCHES[*]}")
 
 # Co-Authored-By 検出用 regex (大小区別は呼び出し側で -i フラグ等で制御する)。
 #
-# 2 種類用意する理由:
-#   1. COAUTHOR_PATTERN  — コミットメッセージ「本文」向け (commit-msg hook 用)
-#      行頭または空白の直後に `co-authored-by` が現れ、末尾に `:` がある場合のみ
-#      マッチ。本文中の単なる言及 (例: 「`Co-Authored-By`」のような単一トークン)
-#      は末尾 `:` の要件で弾く設計。
-#   2. COAUTHOR_LITERAL_PATTERN — shell コマンド「引数 literal」向け
-#      (pre-commit-guard.sh の `git commit -m "..."` 検出用)
-#      shell 経由で `-m "feat\nCo-Authored-By: x"` のような literal `\n` を
-#      含む文字列が渡された場合、shlex.split で引用符が剥がされるが内部の
-#      `\n` は literal の `\n` のまま残るため、前置 `[[:space:]]` を要求すると
-#      検知漏れする。shell command literal の段階では `co-authored-by` の
-#      sub-string が現れた時点で block する保守的な regex を採用する。
-#      本文中の偽陽性は shell hook 段階では許容する (= 本文の単なる言及で
-#      false positive 出る可能性はあるが、これは「`co-authored-by:` を含む
-#      shell コマンド文字列」という非常に限定的なケースのみで、現実の運用
-#      では `-m "...Co-Authored-By..."` 以外で出現しない)。
-COAUTHOR_PATTERN='(^|[[:space:]])co-authored-by[[:space:]]*:'
-COAUTHOR_LITERAL_PATTERN='co-authored-by[[:space:]]*:'
+# 設計方針 (Issue #648):
+#   `Co-Authored-By` を「全面禁止」すると、以下の正当なユースケースを巻き添えに
+#   block してしまう:
+#     - dependabot PR の取り込み時に元 PR の Co-Authored-By が引き継がれる
+#     - 人間同士の pair programming で互いを Co-Authored-By に挙げる
+#     - GitHub の "Co-authored commits" 公式機能を使う場合
+#   CLAUDE.md のルール (「Co-Authored-By を含めないこと」) は実質的には
+#   **AI bot 由来のクレジット行を禁止** する意図のもの。よって hook 側は
+#   「AI bot を示唆する識別子を含む `Co-Authored-By` 行」のみを block するように
+#   絞り込む。これによりルール本来のスコープと実装が整合する。
+#
+# AI bot 識別子の検出語彙:
+#   - claude        : Anthropic Claude (Claude Code 含む)
+#   - copilot       : GitHub Copilot
+#   - anthropic     : Anthropic 関連メール (noreply@anthropic.com 等)
+#   - openai        : OpenAI / ChatGPT 関連
+#   - cursor        : Cursor IDE
+#   - codex         : OpenAI Codex
+#   将来 AI bot が増えた場合、ここに `|` 連結で追加すれば全 hook に伝播する。
+#
+# 提供インターフェース:
+#   - COAUTHOR_HEADER_RE       : `Co-Authored-By:` 行検出用 ERE (本文向け、行頭/空白後)
+#   - COAUTHOR_LITERAL_HEADER_RE : `Co-Authored-By:` 検出用 ERE (literal 引数向け、前置条件なし)
+#   - COAUTHOR_AI_IDENTIFIERS_RE : AI bot 識別子の alternation (claude|copilot|...)
+#   - body_contains_ai_coauthor  : stdin の本文に AI 由来 Co-Authored-By が含まれれば 0
+#   - literal_contains_ai_coauthor : stdin の literal 文字列内に AI 由来 Co-Authored-By
+#                                    が含まれれば 0 (shell hook 用)
+#
+# 注意:
+#   - 検出語彙は **case-insensitive** で評価される (`grep -iE` を使う)。
+#     大文字小文字違いの偽装 (例: `CLAUDE` / `Claude`) は同じパターンで捕捉される。
+#   - 識別子は word boundary ではなく単純な sub-string で照合する。
+#     これは `noreply@anthropic.com` のような email 内出現も捕捉するため。
+#     人間で偶然 `claude` を含む名前/ドメインは block されるが、現実的衝突は稀。
+COAUTHOR_AI_IDENTIFIERS_RE='(claude|copilot|anthropic|openai|cursor|codex)'
+# 本文 (行単位 grep) 向け: 行頭または空白の直後に `co-authored-by` + `:` を要求
+COAUTHOR_HEADER_RE='(^|[[:space:]])co-authored-by[[:space:]]*:'
+# shell literal 向け: 前置条件を要求しない (shlex 後の literal は連結文字列のため)
+COAUTHOR_LITERAL_HEADER_RE='co-authored-by[[:space:]]*:'
+
+# (互換) 旧名: 既存呼び出し箇所で参照されている可能性に備え alias を残す。
+# 新規コードでは COAUTHOR_HEADER_RE / COAUTHOR_LITERAL_HEADER_RE を使うこと。
+COAUTHOR_PATTERN="$COAUTHOR_HEADER_RE"
+COAUTHOR_LITERAL_PATTERN="$COAUTHOR_LITERAL_HEADER_RE"
 
 # ブランチ名が保護対象に含まれているかを判定する。
 # 含まれていれば exit 0、それ以外は exit 1。
@@ -76,11 +102,51 @@ is_protected_branch() {
   return 1
 }
 
-# stdin に流したテキストに Co-Authored-By 行が含まれるかを判定する。
-# 含まれていれば exit 0、それ以外は exit 1。
+# stdin に流したテキストに **AI bot 由来の** Co-Authored-By 行が含まれるかを
+# 判定する (Issue #648)。含まれていれば exit 0、それ以外は exit 1。
 # 呼び出し側は本文のみ (= コメント行除去後) を流す責務を持つ。
+#
+# 実装:
+#   1. `Co-Authored-By:` を含む行のみを抽出 (行頭/空白後 + `:` で本文中の
+#      単なる言及を弾く)
+#   2. 抽出した行に AI bot 識別子が含まれるか再 grep する
+#   この 2 段階により「AI 識別子付き Co-Authored-By 行」だけを正確に判定する。
+#   POSIX ERE で `\n` を否定文字クラスに入れる挙動は実装依存 (BSD/GNU で
+#   差異あり) なので、行単位 grep を 2 回かけてポータビリティを担保する。
+body_contains_ai_coauthor() {
+  local lines
+  lines=$(grep -iE "$COAUTHOR_HEADER_RE" || true)
+  if [ -z "$lines" ]; then
+    return 1
+  fi
+  if printf '%s' "$lines" | grep -qiE "$COAUTHOR_AI_IDENTIFIERS_RE"; then
+    return 0
+  fi
+  return 1
+}
+
+# (互換) 旧 API。挙動を Issue #648 適用後の「AI 由来 Co-Authored-By のみ block」
+# に揃えるため、内部で body_contains_ai_coauthor を呼ぶ alias とする。
+# 既存呼び出し箇所 (commit-msg hook) はこの alias 経由で新挙動に切り替わる。
 body_contains_coauthor() {
-  if grep -qiE "$COAUTHOR_PATTERN"; then
+  body_contains_ai_coauthor
+}
+
+# stdin に流した shell command literal (= shlex split 後の文字列等) に
+# AI bot 由来の Co-Authored-By 表現が含まれるかを判定する (Issue #648)。
+# 含まれていれば exit 0、それ以外は exit 1。
+#
+# 本文向けと異なり、shell literal は `\n` がエスケープ表記 (literal 2 文字)
+# のまま渡されるケースがあるため、前置 `[[:space:]]` は要求しない。
+# 「`co-authored-by:` の出現」と「AI 識別子の出現」の 2 条件を満たせば block。
+# 識別子の前後距離は問わない (literal 段階では誤検知より見逃し回避を優先)。
+literal_contains_ai_coauthor() {
+  local content
+  content=$(cat)
+  if ! printf '%s' "$content" | grep -qiE "$COAUTHOR_LITERAL_HEADER_RE"; then
+    return 1
+  fi
+  if printf '%s' "$content" | grep -qiE "$COAUTHOR_AI_IDENTIFIERS_RE"; then
     return 0
   fi
   return 1

--- a/.githooks/_lib.sh
+++ b/.githooks/_lib.sh
@@ -4,25 +4,31 @@
 # 規約の **単一情報源 (SSOT)** (Issue #649 / Moderate 4)。
 #
 # 設計方針:
-#   - 「master / main 直 commit 禁止」と「Co-Authored-By 禁止」の 2 規約は
-#     これまで `.githooks/pre-commit` / `.githooks/commit-msg` /
+#   - 「master / main 直 commit 禁止」と「AI bot 由来 Co-Authored-By 禁止」の
+#     2 規約は、これまで `.githooks/pre-commit` / `.githooks/commit-msg` /
 #     `.claude/hooks/pre-commit-guard.sh` の 3 箇所に literal で散在しており、
 #     片方を更新し忘れる二重管理リスクがあった。
 #   - 本ファイルを source することで、規約は 1 箇所で定義 / 各 hook は
 #     共通変数 / 共通関数を参照するだけにする。
 #
 # 提供インターフェース:
-#   - PROTECTED_BRANCHES  : 直接 commit を禁止するブランチ名の配列
-#                           例: PROTECTED_BRANCHES=("master" "main")
-#   - COAUTHOR_PATTERN    : Co-Authored-By 検出用の grep -E 正規表現 (大小区別なし運用)
-#   - is_protected_branch <name>  : ブランチ名が PROTECTED_BRANCHES に含まれれば exit 0
-#   - body_contains_coauthor      : stdin に流したコミットメッセージ本文に
-#                                   Co-Authored-By が含まれれば exit 0
+#   - PROTECTED_BRANCHES         : 直接 commit を禁止するブランチ名の配列
+#                                  例: PROTECTED_BRANCHES=("master" "main")
+#   - PROTECTED_BRANCHES_RE      : パイプ区切り版 (POSIX grep -E 向け)
+#   - COAUTHOR_HEADER_RE         : `Co-Authored-By:` 行検出用 ERE (本文向け)
+#   - COAUTHOR_LITERAL_HEADER_RE : `Co-Authored-By:` 検出用 ERE (literal 引数向け)
+#   - COAUTHOR_AI_BOT_RE         : AI bot を識別する fixture-based ERE
+#                                  (Issue #648 DA Must 対応で structurally narrow)
+#   - is_protected_branch <name>  : ブランチ名が保護対象なら exit 0
+#   - body_contains_ai_coauthor   : stdin 本文に AI bot 由来 Co-Authored-By が
+#                                   含まれれば exit 0 (行単位 AND 判定)
+#   - literal_contains_ai_coauthor : stdin literal に AI bot 由来 Co-Authored-By
+#                                    が含まれれば exit 0 (行単位 AND 判定)
 #
 # 適用箇所:
 #   - .githooks/pre-commit  (master / main 直 commit 拒否)
-#   - .githooks/commit-msg  (Co-Authored-By 検出)
-#   - .claude/hooks/pre-commit-guard.sh (Bash PreToolUse hook の早期フィードバック層)
+#   - .githooks/commit-msg  (AI bot 由来 Co-Authored-By 検出)
+#   - .claude/hooks/pre-commit-guard.sh (Bash PreToolUse hook の早期 FB 層)
 #
 # 注意:
 #   - 本ファイルは set -e されたコンテキストから source される想定なので、
@@ -38,7 +44,9 @@ PROTECTED_BRANCHES=("master" "main")
 # 例: "master|main"
 PROTECTED_BRANCHES_RE=$(IFS='|'; printf '%s' "${PROTECTED_BRANCHES[*]}")
 
-# Co-Authored-By 検出用 regex (大小区別は呼び出し側で -i フラグ等で制御する)。
+# ----------------------------------------------------------------------------
+# Co-Authored-By 検出 (Issue #648 / DA Must 対応版)
+# ----------------------------------------------------------------------------
 #
 # 設計方針 (Issue #648):
 #   `Co-Authored-By` を「全面禁止」すると、以下の正当なユースケースを巻き添えに
@@ -48,40 +56,79 @@ PROTECTED_BRANCHES_RE=$(IFS='|'; printf '%s' "${PROTECTED_BRANCHES[*]}")
 #     - GitHub の "Co-authored commits" 公式機能を使う場合
 #   CLAUDE.md のルール (「Co-Authored-By を含めないこと」) は実質的には
 #   **AI bot 由来のクレジット行を禁止** する意図のもの。よって hook 側は
-#   「AI bot を示唆する識別子を含む `Co-Authored-By` 行」のみを block するように
-#   絞り込む。これによりルール本来のスコープと実装が整合する。
+#   「AI bot を示唆する `Co-Authored-By` 行」のみを block するように絞り込む。
 #
-# AI bot 識別子の検出語彙:
-#   - claude        : Anthropic Claude (Claude Code 含む)
-#   - copilot       : GitHub Copilot
-#   - anthropic     : Anthropic 関連メール (noreply@anthropic.com 等)
-#   - openai        : OpenAI / ChatGPT 関連
-#   - cursor        : Cursor IDE
-#   - codex         : OpenAI Codex
-#   将来 AI bot が増えた場合、ここに `|` 連結で追加すれば全 hook に伝播する。
+# DA Must 対応 (誤検知排除 / 構造的判定への置換):
+#   旧実装は「単純 sub-string (claude / copilot / ...)」で判定していたため、
+#   以下の正当ケースを誤 block していた:
+#     - Co-Authored-By: Claudette Colvin <ccolvin@example.com>  ← 人名 substring 衝突
+#     - Co-Authored-By: Codexa Smith <codexa@example.com>      ← 人名 substring 衝突
+#     - "fix: テストで Co-Authored-By: Claude の挙動を確認"     ← 説明文中の言及
+#
+#   これを構造的判定に置換する。検出は **fixture-based regex** を採用し、
+#   現実の AI bot コミット形式に限定:
+#     1. 既知 AI bot の email ドメイン
+#        - <...@anthropic.com>   (Claude / Claude Code)
+#        - <...@openai.com>      (OpenAI / Codex)
+#        - <...@cursor.sh>       (Cursor IDE)
+#        - <...@cursor.com>      (Cursor IDE)
+#     2. GitHub Apps bot suffix `[bot]` + 既知 vendor email
+#        - github-copilot[bot] <copilot@github.com> 等
+#        - 一般化: `[bot]` を含む name + copilot/cursor 等 vendor 識別子を含む email
+#   人名 (Claudette / Codexa 等) は email 形式に該当しないため誤検知しない。
+#   説明文中の言及 (`Co-Authored-By: Claude の挙動`) も「`Co-Authored-By:` を
+#   含む行に AI bot email/bot-suffix を **同行内** で要求」する AND 条件のため、
+#   email 形式を満たさず通過する。
 #
 # 提供インターフェース:
-#   - COAUTHOR_HEADER_RE       : `Co-Authored-By:` 行検出用 ERE (本文向け、行頭/空白後)
-#   - COAUTHOR_LITERAL_HEADER_RE : `Co-Authored-By:` 検出用 ERE (literal 引数向け、前置条件なし)
-#   - COAUTHOR_AI_IDENTIFIERS_RE : AI bot 識別子の alternation (claude|copilot|...)
-#   - body_contains_ai_coauthor  : stdin の本文に AI 由来 Co-Authored-By が含まれれば 0
-#   - literal_contains_ai_coauthor : stdin の literal 文字列内に AI 由来 Co-Authored-By
-#                                    が含まれれば 0 (shell hook 用)
+#   - COAUTHOR_HEADER_RE         : `Co-Authored-By:` 行検出用 ERE (本文向け)
+#   - COAUTHOR_LITERAL_HEADER_RE : `Co-Authored-By:` 検出用 ERE (literal 向け)
+#   - COAUTHOR_AI_BOT_RE         : AI bot を識別する fixture-based ERE
+#   - body_contains_ai_coauthor  : stdin の本文に AI 由来 Co-Authored-By が
+#                                  含まれれば 0 (行単位 AND)
+#   - literal_contains_ai_coauthor : stdin の literal 文字列に AI 由来
+#                                    Co-Authored-By が含まれれば 0 (行単位 AND)
+#
+# 表記揺れの扱い (S3 / S4):
+#   - `Co_Authored_By` (アンダースコア) 等の異形は git trailer 仕様外。
+#     git 自身が trailer として認識せず公式表記に変換しないため、本 hook の
+#     サポート対象外とする (実害が無い)。
+#   - 全角コロン (`Co-Authored-By：`) も git trailer として認識されないため
+#     block 不要。Git の interpret-trailers / mailinfo は ASCII コロンのみを
+#     trailer 区切りとして扱う。
 #
 # 注意:
-#   - 検出語彙は **case-insensitive** で評価される (`grep -iE` を使う)。
-#     大文字小文字違いの偽装 (例: `CLAUDE` / `Claude`) は同じパターンで捕捉される。
-#   - 識別子は word boundary ではなく単純な sub-string で照合する。
-#     これは `noreply@anthropic.com` のような email 内出現も捕捉するため。
-#     人間で偶然 `claude` を含む名前/ドメインは block されるが、現実的衝突は稀。
-COAUTHOR_AI_IDENTIFIERS_RE='(claude|copilot|anthropic|openai|cursor|codex)'
+#   - 検出は **case-insensitive** で評価される (`grep -iE` を使う)。
+#   - AI bot 識別 regex は ASCII email/角括弧 bot suffix のみを対象とする。
+#     新規 AI bot vendor を追加する場合は COAUTHOR_AI_BOT_RE に alternation を
+#     足すだけで全 hook に伝播する。
+
 # 本文 (行単位 grep) 向け: 行頭または空白の直後に `co-authored-by` + `:` を要求
 COAUTHOR_HEADER_RE='(^|[[:space:]])co-authored-by[[:space:]]*:'
 # shell literal 向け: 前置条件を要求しない (shlex 後の literal は連結文字列のため)
 COAUTHOR_LITERAL_HEADER_RE='co-authored-by[[:space:]]*:'
 
+# AI bot を fixture-based に識別する ERE (Issue #648 DA Must 対応)。
+#
+# マッチ条件 (OR):
+#   (1) `<...@anthropic.com>`         : Anthropic (Claude / Claude Code)
+#   (2) `<...@openai.com>`            : OpenAI (Codex 等)
+#   (3) `<...@cursor.sh>` / `@cursor.com` : Cursor IDE
+#   (4) `[bot]` を含む name と
+#       `<...@(copilot|cursor|anthropic|openai)...>` 形式の email の組み合わせ
+#       (= GitHub Apps bot)
+#
+# regex は POSIX ERE (grep -E / grep -iE で評価される)。
+# 大小区別なし運用のため [A-Z] アルファベット範囲は使わず、case-insensitive
+# フラグ側で吸収する。
+#
+# 拡張方針: 新規 AI bot を追加する場合は、メールドメイン pattern を `|` で
+# 足すか、(4) の vendor 識別子に語彙を追加する。
+COAUTHOR_AI_BOT_RE='<[^>]*@(anthropic\.com|openai\.com|cursor\.sh|cursor\.com)>|\[bot\][^<]*<[^>]*@[^>]*(copilot|cursor|anthropic|openai)[^>]*>|<[^>]*(copilot|noreply)[^>]*@github\.com>'
+
 # (互換) 旧名: 既存呼び出し箇所で参照されている可能性に備え alias を残す。
-# 新規コードでは COAUTHOR_HEADER_RE / COAUTHOR_LITERAL_HEADER_RE を使うこと。
+# 新規コードでは COAUTHOR_HEADER_RE / COAUTHOR_LITERAL_HEADER_RE /
+# COAUTHOR_AI_BOT_RE を使うこと。
 COAUTHOR_PATTERN="$COAUTHOR_HEADER_RE"
 COAUTHOR_LITERAL_PATTERN="$COAUTHOR_LITERAL_HEADER_RE"
 
@@ -103,23 +150,28 @@ is_protected_branch() {
 }
 
 # stdin に流したテキストに **AI bot 由来の** Co-Authored-By 行が含まれるかを
-# 判定する (Issue #648)。含まれていれば exit 0、それ以外は exit 1。
+# 判定する (Issue #648 / DA Must 対応版)。含まれていれば exit 0、それ以外は exit 1。
 # 呼び出し側は本文のみ (= コメント行除去後) を流す責務を持つ。
 #
-# 実装:
+# 実装 (行単位 AND 判定):
 #   1. `Co-Authored-By:` を含む行のみを抽出 (行頭/空白後 + `:` で本文中の
 #      単なる言及を弾く)
-#   2. 抽出した行に AI bot 識別子が含まれるか再 grep する
-#   この 2 段階により「AI 識別子付き Co-Authored-By 行」だけを正確に判定する。
-#   POSIX ERE で `\n` を否定文字クラスに入れる挙動は実装依存 (BSD/GNU で
-#   差異あり) なので、行単位 grep を 2 回かけてポータビリティを担保する。
+#   2. 抽出した **各行** に AI bot fixture (COAUTHOR_AI_BOT_RE) が
+#      含まれるかを再 grep する
+#   この 2 段階により以下を保証する:
+#     - 「`Co-Authored-By:` 行であり」 AND 「同行に AI bot fixture を含む」
+#     - 人名 substring (Claudette / Codexa) は email 形式に該当せず通過
+#     - 本文中の説明 (`Co-Authored-By: Claude の挙動` 等) も同様に通過
+#
+# POSIX ERE で `\n` を否定文字クラスに入れる挙動は実装依存 (BSD/GNU で
+# 差異あり) なので、行単位 grep を 2 回かけてポータビリティを担保する。
 body_contains_ai_coauthor() {
   local lines
   lines=$(grep -iE "$COAUTHOR_HEADER_RE" || true)
   if [ -z "$lines" ]; then
     return 1
   fi
-  if printf '%s' "$lines" | grep -qiE "$COAUTHOR_AI_IDENTIFIERS_RE"; then
+  if printf '%s' "$lines" | grep -qiE "$COAUTHOR_AI_BOT_RE"; then
     return 0
   fi
   return 1
@@ -133,21 +185,54 @@ body_contains_coauthor() {
 }
 
 # stdin に流した shell command literal (= shlex split 後の文字列等) に
-# AI bot 由来の Co-Authored-By 表現が含まれるかを判定する (Issue #648)。
+# AI bot 由来の Co-Authored-By 表現が含まれるかを判定する
+# (Issue #648 / DA Must 対応版 = 行単位 AND 判定)。
 # 含まれていれば exit 0、それ以外は exit 1。
 #
-# 本文向けと異なり、shell literal は `\n` がエスケープ表記 (literal 2 文字)
-# のまま渡されるケースがあるため、前置 `[[:space:]]` は要求しない。
-# 「`co-authored-by:` の出現」と「AI 識別子の出現」の 2 条件を満たせば block。
-# 識別子の前後距離は問わない (literal 段階では誤検知より見逃し回避を優先)。
+# DA Must M1 対応 (shell / native の挙動整合):
+#   旧実装は「literal 全体で `co-authored-by:` AND AI 識別子 sub-string」を
+#   OR 検出していたため、以下のような subject に AI 名を含む commit を
+#   shell hook が誤 block していた:
+#     g..it commit -m "feat: refactor copilot integration\n\nCo-Authored-By: Taro <taro@example.com>"
+#       → shell: subject の "copilot" と body の "Co-Authored-By:" が両方
+#                ヒットして誤 block
+#       → native: 行単位 AND 判定で正しく pass
+#   shell hook も **行単位 AND** に揃え、二層の挙動を一致させる。
+#
+# DA Must M2 対応 (実改行の扱い):
+#   `git commit -m "..."` の引数に実改行 (literal LF) が含まれていても、
+#   `-m` の中身は **行単位** で評価される必要がある。本関数は stdin に
+#   流された literal を `\n` (literal 2 文字 backslash+n) と LF の両方で
+#   split し、各論理行ごとに「`co-authored-by:` AND AI bot fixture」を
+#   判定する。
+#
+# 実装:
+#   1. stdin から content を取得
+#   2. literal の `\n` (2 文字) を LF に置換して論理行 split
+#   3. 各行ごとに `co-authored-by:` AND COAUTHOR_AI_BOT_RE を AND 判定
+#   4. いずれかの行で AND 成立すれば exit 0
 literal_contains_ai_coauthor() {
   local content
   content=$(cat)
-  if ! printf '%s' "$content" | grep -qiE "$COAUTHOR_LITERAL_HEADER_RE"; then
-    return 1
-  fi
-  if printf '%s' "$content" | grep -qiE "$COAUTHOR_AI_IDENTIFIERS_RE"; then
-    return 0
-  fi
-  return 1
+  # literal の "\n" (2 文字 backslash + n) を実 LF に展開してから行単位処理
+  # する。実改行入りの literal もそのまま行 split できる。
+  # POSIX awk による split で BSD/GNU 双方の安定性を担保する。
+  printf '%s' "$content" | awk '
+    BEGIN { found = 0 }
+    {
+      # \\n (literal 2 文字) を実 LF に展開してから再 split する
+      s = $0
+      n = split(s, parts, /\\n/)
+      for (i = 1; i <= n; i++) {
+        line = tolower(parts[i])
+        # 行内に "co-authored-by:" が無ければ即 skip
+        if (line !~ /co-authored-by[[:space:]]*:/) continue
+        # 同行内に AI bot fixture が含まれるか判定 (awk は ERE 標準)
+        if (line ~ /<[^>]*@(anthropic\.com|openai\.com|cursor\.sh|cursor\.com)>/) { found = 1; exit }
+        if (line ~ /\[bot\][^<]*<[^>]*@[^>]*(copilot|cursor|anthropic|openai)[^>]*>/) { found = 1; exit }
+        if (line ~ /<[^>]*(copilot|noreply)[^>]*@github\.com>/) { found = 1; exit }
+      }
+    }
+    END { exit (found ? 0 : 1) }
+  '
 }

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -66,12 +66,24 @@ fi
 #     しないため許容する (fail 時は body が空になり、誤検知は出ない安全側)。
 body=$(awk '/^# -+ >8 -+$/{exit} {print}' "$msg_file" | git stripspace --strip-comments)
 
-# 大文字小文字を区別せずに Co-Authored-By を検出する (COAUTHOR_PATTERN は SSOT)。
-# (Co-authored-by / co-authored-by などの揺れも捕捉)
-if printf '%s' "$body" | body_contains_coauthor; then
+# AI bot 由来の Co-Authored-By 行を検出する (Issue #648)。
+#
+# Issue #648 以前は「すべての Co-Authored-By を block」する実装だったが、
+# 以下の正当なユースケースを巻き添えにしていた:
+#   - dependabot PR 取り込み時の Co-Authored-By 引き継ぎ
+#   - 人間同士の pair programming
+#   - GitHub の "Co-authored commits" 公式機能
+#
+# CLAUDE.md ルールの本来意図 (= AI bot 由来クレジットを残さない) に整合させ、
+# `claude` / `copilot` / `anthropic` などの AI bot 識別子を含む
+# `Co-Authored-By` 行のみを block する。判定ロジックは _lib.sh の
+# body_contains_ai_coauthor に集約 (SSOT)。
+if printf '%s' "$body" | body_contains_ai_coauthor; then
   cat <<EOF >&2
-[commit-msg] コミットメッセージに Co-Authored-By を含めることは禁止されています。
+[commit-msg] コミットメッセージに AI bot 由来の Co-Authored-By を含めることは禁止されています。
+検出対象: ${COAUTHOR_AI_IDENTIFIERS_RE} のいずれかを含む Co-Authored-By 行。
 該当行を削除してから再度コミットしてください。
+(人間の Co-Authored-By 行や dependabot 等の正当な共著情報は許容されます。)
 
 (本 hook は .githooks/commit-msg で実装されています。
  ローカル設定: git config core.hooksPath .githooks)

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -75,13 +75,23 @@ body=$(awk '/^# -+ >8 -+$/{exit} {print}' "$msg_file" | git stripspace --strip-c
 #   - GitHub の "Co-authored commits" 公式機能
 #
 # CLAUDE.md ルールの本来意図 (= AI bot 由来クレジットを残さない) に整合させ、
-# `claude` / `copilot` / `anthropic` などの AI bot 識別子を含む
+# AI bot fixture (既知メールドメイン / GitHub Apps `[bot]` suffix) を含む
 # `Co-Authored-By` 行のみを block する。判定ロジックは _lib.sh の
 # body_contains_ai_coauthor に集約 (SSOT)。
+#
+# Issue #648 DA Must 対応:
+#   - 旧実装の単純 sub-string (claude / copilot / ...) 検出は人名衝突を起こした
+#     (例: `Claudette Colvin` / `Codexa Smith`)。
+#   - 新実装は **構造的 fixture-based** (`<...@anthropic.com>` /
+#     `[bot] <...@.copilot...>` 等) で判定するため、人名衝突は発生しない。
+#   - 同時に「`Co-Authored-By:` 行 AND 同行内に AI bot fixture」を **行単位 AND**
+#     で要求するため、本文中の説明 (`Co-Authored-By: Claude の挙動を確認`等) も
+#     誤 block しない。
 if printf '%s' "$body" | body_contains_ai_coauthor; then
   cat <<EOF >&2
 [commit-msg] コミットメッセージに AI bot 由来の Co-Authored-By を含めることは禁止されています。
-検出対象: ${COAUTHOR_AI_IDENTIFIERS_RE} のいずれかを含む Co-Authored-By 行。
+検出対象: 既知 AI bot のメールドメイン (anthropic.com / openai.com / cursor.{sh,com})
+          または GitHub Apps の \`[bot]\` suffix を伴う Co-Authored-By 行。
 該当行を削除してから再度コミットしてください。
 (人間の Co-Authored-By 行や dependabot 等の正当な共著情報は許容されます。)
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ git config core.hooksPath .githooks
 提供している hook:
 
 - `.githooks/pre-commit` — `master` / `main` ブランチへの直接 commit を拒否します
-- `.githooks/commit-msg` — コミットメッセージ本文に **AI bot 由来の** `Co-Authored-By` 行 (`claude` / `copilot` / `anthropic` / `openai` / `cursor` / `codex` のいずれかを含むもの) が含まれていたら commit を拒否します。人間 pair programming や dependabot 等の正当な共著情報は許容されます (Issue #648)
+- `.githooks/commit-msg` — コミットメッセージ本文に **AI bot 由来の** `Co-Authored-By` 行 (既知 AI bot のメールドメイン `@anthropic.com` / `@openai.com` / `@cursor.{sh,com}` を含む、または GitHub Apps の `[bot]` suffix と vendor 識別子の組み合わせ) が含まれていたら commit を拒否します。**判定は構造的 fixture-based** (メールドメイン / `[bot]` suffix) なので、人名 substring 衝突 (例: `Claudette Colvin` / `Codexa Smith`) や本文中の単なる言及は誤検知しません。人間 pair programming や dependabot 等の正当な共著情報は許容されます (Issue #648 + DA Must 対応)
 
 これらは [`CLAUDE.md`](./CLAUDE.md) のグローバルルール (「master への直接 commit 禁止」「コミットメッセージに Co-Authored-By を含めない」) を **git の動作上 bypass 不可能な層** で保証するためのものです (Issue #568 / Issue #592 / Issue #648)。
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ git config core.hooksPath .githooks
 提供している hook:
 
 - `.githooks/pre-commit` — `master` / `main` ブランチへの直接 commit を拒否します
-- `.githooks/commit-msg` — コミットメッセージ本文に `Co-Authored-By` 行が含まれていたら commit を拒否します
+- `.githooks/commit-msg` — コミットメッセージ本文に **AI bot 由来の** `Co-Authored-By` 行 (`claude` / `copilot` / `anthropic` / `openai` / `cursor` / `codex` のいずれかを含むもの) が含まれていたら commit を拒否します。人間 pair programming や dependabot 等の正当な共著情報は許容されます (Issue #648)
 
-これらは [`CLAUDE.md`](./CLAUDE.md) のグローバルルール (「master への直接 commit 禁止」「コミットメッセージに Co-Authored-By を含めない」) を **git の動作上 bypass 不可能な層** で保証するためのものです (Issue #568 / Issue #592)。
+これらは [`CLAUDE.md`](./CLAUDE.md) のグローバルルール (「master への直接 commit 禁止」「コミットメッセージに Co-Authored-By を含めない」) を **git の動作上 bypass 不可能な層** で保証するためのものです (Issue #568 / Issue #592 / Issue #648)。
 
 `postinstall` での自動セットアップは採用していません。理由は以下:
 


### PR DESCRIPTION
## 概要

PR #646 (Closes #592) で導入した `.githooks/commit-msg` の Co-Authored-By 全 block は、人間の pair programming や dependabot 取り込みなど正当ユースケースを巻き添えにしていた。AI bot 由来 (Anthropic / OpenAI / Copilot / Cursor) のみを構造的 fixture (メールドメイン + `[bot]` suffix) で block し、人名・人間メール・他の bot は通すよう改修。

Closes #648

## 変更内容

- `.githooks/_lib.sh`: 旧 `COAUTHOR_AI_IDENTIFIERS_RE` (substring 単純照合) を廃止し、構造的 `COAUTHOR_AI_BOT_RE` に置換 (`<...@anthropic.com|openai.com|cursor.{sh,com}>` / `[bot]...<...@vendor>` / `<copilot|noreply...@github.com>`)。`body_contains_ai_coauthor` / `literal_contains_ai_coauthor` の 2 関数で行単位 AND 判定 (shell hook と native hook の挙動を一致)
- `.githooks/commit-msg`: 行単位 AI bot 判定に切替、エラーメッセージで検出パターンと許容ユースケースを明示
- `.claude/hooks/pre-commit-guard.sh`: `-m`/`--message`/`-m<val>`/`--message=<val>` の値を `python3 shlex` で **実改行を保ったまま** pre-extract → `literal_contains_ai_coauthor` に流す。実 LF 入りメッセージ経由の bypass を防止
- `.claude/hooks/__tests__/pre-commit-guard.test.sh`: CA01-CA05 を新挙動に揃え、CA06-CA11 を Tripwire として追加
  - CA06 `Claudette Colvin <ccolvin@example.com>` → pass (人名衝突誤検知の防止)
  - CA07 `Codexa Smith <codexa@example.com>` → pass
  - CA08 subject 中の `Co-Authored-By: Claude の挙動を確認` → pass
  - CA09 subject に `copilot` + body 人間 Co-Authored-By → pass (shell/native 整合)
  - CA10 実 LF 入り `-m` で `Claude <noreply@anthropic.com>` → block
  - CA11 実 LF 入り `-m` で人間 email → pass
- `README.md`: hook 説明セクションを構造的 fixture-based の新挙動に更新

## 備考

- DA レビュー 2 周 (Must 3件: shell/native 乖離, 実改行 bypass, substring 誤検知) すべて解消
- /review APPROVE (Should 2件は test deepness とドキュメント表現の改善余地)
- /security-review HIGH/MEDIUM/LOW 該当なし
- テストハーネス 36/36 pass、`pnpm lint` regression なし