### PR TITLE
chore: milestones.semantic.test.ts の fixture 共通化判断閾値を JSDoc に追記 (Closes #631)

### DIFF
--- a/src/lib/__tests__/milestones.semantic.test.ts
+++ b/src/lib/__tests__/milestones.semantic.test.ts
@@ -26,6 +26,19 @@ import { describe, expect, it } from "vitest";
 import milestonesJson from "../../../datasources/milestones.json";
 import type { Milestone } from "../anchors";
 
+/**
+ * 注意: 本ファイルの EXPECTED_MILESTONES は本番 milestones.json と同一の inline fixture。
+ * 共通化すると silent pass リスクが復活するため意図的に重複させているが、
+ * milestone 件数が 5 件を超えた場合は以下の代替案を再評価する:
+ *
+ * - 案 1: src/test/fixtures/expectedMilestones.ts に外出しし、Coordinate.allPosts.test.tsx /
+ *   AnchorPage.allPosts.test.tsx の testMilestones から再利用 (silent pass リスクは残るが
+ *   メンテ負荷削減)
+ * - 案 2: Issue #547 (Zod schema 検証) で fixture 自体を廃止し、schema parse による
+ *   意味的検証に置き換える
+ *
+ * (Issue #631 / PR #628 / Issue #615 follow-up)
+ */
 const EXPECTED_MILESTONES: readonly Milestone[] = [
   {
     date: "2025-08-05",

--- a/src/lib/__tests__/milestones.semantic.test.ts
+++ b/src/lib/__tests__/milestones.semantic.test.ts
@@ -19,7 +19,12 @@
  * 配列順は本番 JSON と完全に一致させる。
  *
  * 非スコープ:
- * - Zod 等の schema 検証による型レベル担保は Issue #547 で別途対応する
+ * - ランタイム schema 検証 (型 / 値域 / tone enum) は Issue #547 で
+ *   `src/lib/milestonesSchema.ts` (`parseMilestones` / `validateMilestonesStrict`)
+ *   として inline 自作実装済み (Zod 等の外部ライブラリは CLAUDE.md
+ *   「外部ライブラリの追加は原則しない」に従い不採用)。
+ *   本ファイルは schema 検証では捕まらない「label rename / 日付変更 / tone 変更」
+ *   という意味的変更を検知する責務に特化する。
  */
 
 import { describe, expect, it } from "vitest";
@@ -28,14 +33,25 @@ import type { Milestone } from "../anchors";
 
 /**
  * 注意: 本ファイルの EXPECTED_MILESTONES は本番 milestones.json と同一の inline fixture。
- * 共通化すると silent pass リスクが復活するため意図的に重複させているが、
- * milestone 件数が 5 件を超えた場合は以下の代替案を再評価する:
+ * 共通化すると silent pass リスクが復活する (冒頭 JSDoc の「背景」参照:
+ * rename / 日付変更 / tone 変更を inline fixture で固定することで silent pass を
+ * 防ぐ意図) ため意図的に重複させているが、milestone 件数が 5 件 (目安) を超えた
+ * 場合は以下の代替案を再評価する。「5 件」は現状 3 件、本ファイル内の inline fixture
+ * 視認性の境界として目安に設定したもので、厳密な閾値ではない。
  *
  * - 案 1: src/test/fixtures/expectedMilestones.ts に外出しし、Coordinate.allPosts.test.tsx /
  *   AnchorPage.allPosts.test.tsx の testMilestones から再利用 (silent pass リスクは残るが
- *   メンテ負荷削減)
- * - 案 2: Issue #547 (Zod schema 検証) で fixture 自体を廃止し、schema parse による
- *   意味的検証に置き換える
+ *   メンテ負荷削減)。
+ *   ただし案 1 を選ぶ場合、「本番 JSON と意味的にずれていないか」を inline fixture で
+ *   検証する本ファイルの設計思想自体が成立しなくなるため、本ファイルの存在意義自体を
+ *   再検討する必要がある (fixture を共有した時点で、本番 JSON 更新と fixture 更新が
+ *   同じ PR で必ず連動する保証が失われる)。
+ * - 案 2: Issue #547 で実装済みの validateMilestonesStrict (src/lib/milestonesSchema.ts) を
+ *   milestones.semantic.test.ts 側で活用し、本番 milestones.json を直接 strict 検証することで
+ *   fixture を廃止する (Issue #547 はランタイム schema 検証として完了済み。ただし strict 検証は
+ *   型 / 値域 / tone enum のみを担保し、label rename や日付変更は検知できないため、
+ *   本ファイルの意味的スナップショット責務をそのまま代替できるわけではない。
+ *   テスト側への適用は別途検討)。
  *
  * (Issue #631 / PR #628 / Issue #615 follow-up)
  */


### PR DESCRIPTION
## 概要

`src/lib/__tests__/milestones.semantic.test.ts` は本番 `datasources/milestones.json` (3件) と同一の `{ date, label, tone }` 配列を inline fixture として持つ。`Coordinate.allPosts.test.tsx` / `AnchorPage.allPosts.test.tsx` の `testMilestones` を含めると重複は 4 箇所。milestone 件数が増えた際にスケールしない構造のため、共通化判断の閾値を JSDoc に明記する。

Closes #631

## 変更内容

- `src/lib/__tests__/milestones.semantic.test.ts`:
  - `EXPECTED_MILESTONES` 定義直前に、共通化判断閾値 (milestone 件数 > 5 を目安) と代替案 2 つを JSDoc 化
  - 案 2 は Issue #547 で実装済みの `validateMilestonesStrict` (`src/lib/milestonesSchema.ts`) を活用する形に事実整合 (Zod は CLAUDE.md ルールに従い不採用)
  - 「5 件 (目安)」と弱め、根拠 (現状 3 件、inline 視認性の境界) を 1 行追加
  - silent pass リスク防止意図を冒頭 JSDoc 参照で補足
  - 案 1 採用時の「本ファイル存在意義自体の再検討」必要性を明示

## 備考

- DA レビュー 2 周 (M-1 Issue #547 CLOSED 事実乖離 + Should 3件) すべて解消
- /review APPROVE、/security-review HIGH/MEDIUM/LOW 該当なし
- 既存テスト 966 件全 pass、`pnpm lint` clean