### PR TITLE
chore: tryStat silent skip 件数を可視化する onSkip callback と main ログ出力を追加 (Closes #637)

### DIFF
--- a/scripts/__tests__/lintTokens.test.ts
+++ b/scripts/__tests__/lintTokens.test.ts
@@ -16,7 +16,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   collectTargetFiles,
   extractSanitizedLine,
@@ -27,12 +27,14 @@ import {
   iterateMatches,
   type LintPattern,
   processChar,
+  reportSkippedTargets,
   type ScanState,
   sanitizeFile,
   scanFile,
   scanFileScope,
   scanLineScope,
   shouldSkipEntry,
+  type SkipRecord,
   stripComments,
   tryStat,
   type Violation,
@@ -75,6 +77,52 @@ describe("tryStat", () => {
     symlinkSync(join(tmpDir, "nonexistent-target"), link);
     expect(() => tryStat(link)).not.toThrow();
     expect(tryStat(link)).toBeUndefined();
+  });
+
+  // ====================================================================
+  // skip 通知コールバック (Issue #637)
+  //
+  // tryStat は ENOENT / EACCES / EMFILE 等を一律 silent skip するが、
+  // permission tampering を疑う場合に件数を可視化したい。
+  // onSkip コールバックでパスと reason (errno code) を呼び出し側に
+  // 通知できることを検証する。
+  // ====================================================================
+  describe("onSkip コールバック", () => {
+    it("存在しないパスでは onSkip が ENOENT reason 付きで呼ばれる", () => {
+      const onSkip = vi.fn();
+      const missing = join(tmpDir, "missing-file");
+      const result = tryStat(missing, onSkip);
+      expect(result).toBeUndefined();
+      expect(onSkip).toHaveBeenCalledTimes(1);
+      expect(onSkip).toHaveBeenCalledWith(missing, "ENOENT");
+    });
+
+    it("broken symlink でも onSkip が ENOENT reason 付きで呼ばれる", () => {
+      const onSkip = vi.fn();
+      const link = join(tmpDir, "broken-link");
+      symlinkSync(join(tmpDir, "nonexistent-target"), link);
+      tryStat(link, onSkip);
+      expect(onSkip).toHaveBeenCalledTimes(1);
+      const callArgs = onSkip.mock.calls[0];
+      expect(callArgs?.[0]).toBe(link);
+      // ENOENT が一般的だが、OS / Node によって ELOOP 等が返る可能性も
+      // 残しておく (errno code が何かしら文字列で来ることだけを保証)。
+      expect(typeof callArgs?.[1]).toBe("string");
+      expect(String(callArgs?.[1]).length).toBeGreaterThan(0);
+    });
+
+    it("存在するファイルでは onSkip は呼ばれない", () => {
+      const file = join(tmpDir, "exists.ts");
+      writeFileSync(file, "x", "utf8");
+      const onSkip = vi.fn();
+      tryStat(file, onSkip);
+      expect(onSkip).not.toHaveBeenCalled();
+    });
+
+    it("onSkip 未指定 (省略) でも従来通り undefined を返す (silent skip)", () => {
+      // 後方互換: onSkip を渡さなくても従来通り静かに skip できる。
+      expect(tryStat(join(tmpDir, "missing-no-cb"))).toBeUndefined();
+    });
   });
 });
 
@@ -168,6 +216,35 @@ describe("walkDirectory", () => {
     const results: string[] = [];
     walkDirectory(tmpDir, results);
     expect(results).toContain(join(sub, "deep.ts"));
+  });
+
+  // ====================================================================
+  // skip 通知コールバック伝播 (Issue #637)
+  //
+  // walkDirectory 内で tryStat が失敗した場合、main() 側で件数集計
+  // できるよう onSkip コールバックがそのまま伝播することを検証する。
+  // ====================================================================
+  it("broken symlink で onSkip が呼ばれ件数集計できる", () => {
+    writeFileSync(join(tmpDir, "real.ts"), "x", "utf8");
+    symlinkSync(join(tmpDir, "missing-target"), join(tmpDir, "dangling"));
+    const results: string[] = [];
+    const onSkip = vi.fn();
+    walkDirectory(tmpDir, results, onSkip);
+    expect(results).toContain(join(tmpDir, "real.ts"));
+    // dangling symlink 1 件分の skip 通知が来る。
+    expect(onSkip).toHaveBeenCalledTimes(1);
+    expect(onSkip).toHaveBeenCalledWith(
+      join(tmpDir, "dangling"),
+      expect.any(String),
+    );
+  });
+
+  it("onSkip 未指定でも従来通り skip 件を集めずに走査を継続する", () => {
+    writeFileSync(join(tmpDir, "real.ts"), "x", "utf8");
+    symlinkSync(join(tmpDir, "missing-target"), join(tmpDir, "dangling"));
+    const results: string[] = [];
+    expect(() => walkDirectory(tmpDir, results)).not.toThrow();
+    expect(results).toContain(join(tmpDir, "real.ts"));
   });
 });
 
@@ -480,5 +557,50 @@ describe("scanFile", () => {
       },
     ]);
     expect(violations).toEqual([]);
+  });
+});
+
+// ====================================================================
+// reportSkippedTargets (Issue #637)
+//
+// main() 末尾で呼ばれる skip 件数ログ出力の挙動を検証する。
+// - 件数 0 のときは何も出さない (通常 CI ログのノイズを増やさない)
+// - 件数 > 0 のときは件数行 + 各 skip パス / reason を warn ログとして出す
+// ====================================================================
+describe("reportSkippedTargets", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("skip 件数 0 のときは console.warn を呼ばない", () => {
+    reportSkippedTargets([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("skip 件数 > 0 のときは件数行 + パス / reason を warn 出力できる", () => {
+    const skipped: SkipRecord[] = [
+      { path: "/repo/src/a.ts", reason: "EACCES" },
+      { path: "/repo/src/b.ts", reason: "EMFILE" },
+    ];
+    reportSkippedTargets(skipped);
+    // 件数行 1 + 各 skip 1 行ずつ = 計 3 回呼ばれる。
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+    // 件数行に件数が含まれること。
+    const headerCall = warnSpy.mock.calls[0]?.[0];
+    expect(String(headerCall)).toContain("2 path(s) skipped");
+    // 各 skip 行に reason とパス (の一部) が含まれること。
+    const detailCalls = warnSpy.mock.calls
+      .slice(1)
+      .map((c: unknown[]) => String(c[0]));
+    expect(detailCalls.join("\n")).toContain("EACCES");
+    expect(detailCalls.join("\n")).toContain("EMFILE");
+    expect(detailCalls.join("\n")).toContain("a.ts");
+    expect(detailCalls.join("\n")).toContain("b.ts");
   });
 });

--- a/scripts/lintTokens.ts
+++ b/scripts/lintTokens.ts
@@ -191,6 +191,16 @@ interface Violation {
 }
 
 /**
+ * skip された対象 (パスと reason) を呼び出し側に通知するコールバック。
+ *
+ * - `path`: stat に失敗した絶対パス
+ * - `reason`: 失敗の理由。Node の `NodeJS.ErrnoException.code`
+ *   (`ENOENT` / `EACCES` / `EMFILE` 等) をそのまま渡す。code が取得
+ *   できない例外は `"unknown"` にフォールバックする
+ */
+type SkipCallback = (path: string, reason: string) => void;
+
+/**
  * `statSync` を try/catch でラップし、対象が存在しない場合は undefined を返す。
  * `collectTargetFiles` / `walkDirectory` の cognitive complexity を抑え、
  * broken symlink 経路でも例外伝播を起こさないようにするための補助関数。
@@ -205,13 +215,30 @@ interface Violation {
  *     責務が「読める範囲のソースを走査して旧 token 検出する」ことであり、
  *     部分的な stat 失敗を理由に CI を落とすより、走査を継続して
  *     検出可能な違反を確実に拾うほうが価値が高いため
- *   - 結果として、走査されなかったファイル数を別途検知したい場合は
- *     呼び出し側で件数 / ログを別管理する必要がある (現状未実装)
+ *
+ * 可視化 (Issue #637):
+ *   攻撃者が permission を細工して特定ファイルを Tripwire 走査から外す
+ *   経路への防御として、`onSkip` callback で skip 件数を呼び出し側に
+ *   通知できる。呼び出し側 (`walkDirectory` / `main()`) は件数を集計し、
+ *   `main()` 末尾で stderr に件数 / パス一覧を warn ログとして出力する
+ *   ことで、CI ログから不審な skip 異常を一目で検知可能にする。
+ *
+ *   `onSkip` を渡さない呼び出しは従来通り「静かに skip」を維持する。
  */
-const tryStat = (target: string): Stats | undefined => {
+const tryStat = (
+  target: string,
+  onSkip?: SkipCallback,
+): Stats | undefined => {
   try {
     return statSync(target);
-  } catch {
+  } catch (error) {
+    if (onSkip) {
+      const reason =
+        error && typeof error === "object" && "code" in error
+          ? String((error as NodeJS.ErrnoException).code ?? "unknown")
+          : "unknown";
+      onSkip(target, reason);
+    }
     return undefined;
   }
 };
@@ -254,20 +281,26 @@ const shouldSkipEntry = (entry: string): boolean => {
  *
  * @param results **in-out**: 検出した受理可能ファイルのパスを末尾に push する
  *   (Issue #621 / N1)
+ * @param onSkip 省略可。stat 失敗で skip した場合に呼ばれるコールバック
+ *   (Issue #637)。`main()` が件数集計用に渡す
  */
-const walkDirectory = (current: string, results: string[]): void => {
+const walkDirectory = (
+  current: string,
+  results: string[],
+  onSkip?: SkipCallback,
+): void => {
   const entries = readdirSync(current);
   for (const entry of entries) {
     if (shouldSkipEntry(entry)) {
       continue;
     }
     const fullPath = join(current, entry);
-    const entryStats = tryStat(fullPath);
+    const entryStats = tryStat(fullPath, onSkip);
     if (!entryStats) {
       continue;
     }
     if (entryStats.isDirectory()) {
-      walkDirectory(fullPath, results);
+      walkDirectory(fullPath, results, onSkip);
       continue;
     }
     if (entryStats.isFile() && isAcceptableFile(fullPath)) {
@@ -287,9 +320,12 @@ const walkDirectory = (current: string, results: string[]): void => {
  *   将来 PROJECT_ROOT 走査に変えたとき耐えるためガードを入れておく)。
  * - 走査対象が存在しない場合は空配列を返す (例: e2e/ 未配置構成でも壊れない)。
  */
-const collectTargetFiles = (target: string): string[] => {
+const collectTargetFiles = (
+  target: string,
+  onSkip?: SkipCallback,
+): string[] => {
   const results: string[] = [];
-  const stats = tryStat(target);
+  const stats = tryStat(target, onSkip);
   if (!stats) {
     return results;
   }
@@ -306,7 +342,7 @@ const collectTargetFiles = (target: string): string[] => {
     return results;
   }
 
-  walkDirectory(target, results);
+  walkDirectory(target, results, onSkip);
   return results;
 };
 
@@ -755,11 +791,46 @@ const formatViolation = (v: Violation): string => {
   return `${relPath}:${v.line}:${v.column}  [${v.patternName}] ${v.description}\n    ${v.snippet}`;
 };
 
+interface SkipRecord {
+  readonly path: string;
+  readonly reason: string;
+}
+
+/**
+ * skip 集計結果を stderr に warn ログとして出力する (Issue #637)。
+ *
+ * - 件数 0 の場合は何も出力しない (通常 CI ログのノイズを増やさない)
+ * - 件数 > 0 の場合は件数とパス一覧 / reason を 1 行ずつ出力する
+ *   ことで、CI ログで grep / scroll 時に skip 異常が一目で分かるようにする
+ */
+const reportSkippedTargets = (skipped: readonly SkipRecord[]): void => {
+  if (skipped.length === 0) {
+    return;
+  }
+  console.warn(
+    `lint:tokens WARN: ${skipped.length} path(s) skipped during stat. ` +
+      "permission tampering を疑う場合は以下を確認してください:",
+  );
+  for (const record of skipped) {
+    const relPath = relative(PROJECT_ROOT, record.path);
+    console.warn(`  - [${record.reason}] ${relPath}`);
+  }
+};
+
 const main = (): void => {
   const files: string[] = [];
+  const skipped: SkipRecord[] = [];
+  const onSkip: SkipCallback = (path, reason) => {
+    skipped.push({ path, reason });
+  };
   for (const target of TARGET_PATHS) {
-    files.push(...collectTargetFiles(target));
+    files.push(...collectTargetFiles(target, onSkip));
   }
+
+  // skip 件数の可視化 (Issue #637)。
+  // 0 files ガードや旧 token 検出より先に出すことで、構成不備で exit 2/1
+  // した場合でも skip 異常が CI ログに残るようにする。
+  reportSkippedTargets(skipped);
 
   // 0 files scanned ガード (Issue #413 / DA 致命 2 対応)。
   // `LINT_TOKENS_SRC_DIR=/nonexistent` のような誤設定や `TARGET_PATHS` の
@@ -841,6 +912,8 @@ export type {
   QuoteChar,
   SanitizedFile,
   ScanState,
+  SkipCallback,
+  SkipRecord,
   StepResult,
   Violation,
 };
@@ -855,6 +928,7 @@ export {
   LINT_PATTERNS,
   offsetToLineColumn,
   processChar,
+  reportSkippedTargets,
   sanitizeFile,
   scanFile,
   scanFileScope,

--- a/src/lib/__tests__/lintTokens.test.ts
+++ b/src/lib/__tests__/lintTokens.test.ts
@@ -1,5 +1,11 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -518,6 +524,55 @@ describe("lint:tokens (scripts/lintTokens.ts)", () => {
       } finally {
         rmSync(emptyDir, { recursive: true, force: true });
       }
+    });
+  });
+
+  // ====================================================================
+  // skip 件数ログ (Issue #637)
+  //
+  // tryStat は ENOENT / EACCES / EMFILE 等を一律 silent skip するため、
+  // 攻撃者が permission を細工して特定ファイルを Tripwire 走査から外す
+  // 経路が懸念される。
+  // main() 末尾で skip 件数 / パス一覧を stderr に warn 出力することで
+  // CI ログから skip 異常を一目で検知可能にする。
+  //
+  // ENOENT を確実に再現できる broken symlink を仕込んで検証する。
+  // ====================================================================
+  describe("skip 件数ログ出力", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "lint-tokens-skip-log-"));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("skip が発生したら stderr に件数とパス一覧が warn 出力される", () => {
+      // 走査対象になる通常ファイル (0 files ガード回避)。
+      writeFileSync(join(tmpDir, "real.ts"), "const v = 1;\n", "utf8");
+      // broken symlink 1 件 (stat で ENOENT が出る)。
+      symlinkSync(join(tmpDir, "missing-target"), join(tmpDir, "dangling"));
+      const result = runScript({ LINT_TOKENS_SRC_DIR: tmpDir });
+      // 旧 token は無いので exit 0。
+      expect(result.status).toBe(0);
+      // stderr に skip 件数行が出る。
+      expect(result.stderr).toContain("lint:tokens WARN");
+      expect(result.stderr).toContain("1 path(s) skipped");
+      // skip パスに対応する relative path が含まれること。
+      expect(result.stderr).toContain("dangling");
+      // reason (errno code) が出ること。
+      expect(result.stderr).toMatch(/\[E[A-Z]+\]/);
+    });
+
+    it("skip 件数 0 のときは WARN ログを出さない", () => {
+      writeFileSync(join(tmpDir, "real.ts"), "const v = 1;\n", "utf8");
+      const result = runScript({ LINT_TOKENS_SRC_DIR: tmpDir });
+      expect(result.status).toBe(0);
+      // skip が無いので WARN は一切出ない (CI ログのノイズを増やさない)。
+      expect(result.stderr).not.toContain("lint:tokens WARN");
+      expect(result.stderr).not.toContain("path(s) skipped");
     });
   });
 });


### PR DESCRIPTION
## 概要

PR (Issue #621) で `tryStat` が ENOENT 以外 (EACCES / EBUSY / EMFILE 等) も silent skip する設計を明記したが、攻撃者が permission を細工して特定ファイルを Tripwire 走査から外せる潜在経路の懸念があった。CI 実行時に走査スキップ件数 / パス / reason を可視化し、不審なスキップを検知可能にする。

Closes #637

## 変更内容

- `scripts/lintTokens.ts`:
  - `SkipCallback` 型 + `SkipRecord` 型を追加
  - `tryStat` に optional `onSkip?: (path, reason) => void` を追加 (省略時は従来通り silent skip、後方互換)
  - `walkDirectory` / `collectTargetFiles` に `onSkip` を持ち回し
  - `reportSkippedTargets(skipped)` を追加。件数 0 のときは何も出さない、件数 > 0 で件数行 + 各パス / reason を `console.warn` (stderr) に出力
  - `main()` で 0 files ガード / 違反検出より先に `reportSkippedTargets` を呼び、exit 2 / 1 でも skip 異常が CI ログに残る
- `scripts/__tests__/lintTokens.test.ts`: unit test 9 件追加 (callback / 件数 0 / 件数 > 0 / onSkip 省略時の後方互換)
- `src/lib/__tests__/lintTokens.test.ts`: E2E test 2 件追加 (broken symlink で stderr に件数 + パス + `[E…]` reason が出る / 件数 0 で WARN が一切出ない)

## 備考

- DA 承認、/review APPROVE (Could 5件はいずれも別 Issue 候補レベル)、/security-review HIGH/MEDIUM/LOW 該当なし
- ユニットテスト 55/55 + E2E 33/33 + 全体 976/976 pass、`pnpm lint` clean、`pnpm build` 成功