### PR TITLE
chore: dark mode Tripwire に上限ガード不採用の設計判断と baseline 実測値を JSDoc 化 (Closes #645)

### DIFF
--- a/src/lib/__tests__/colorTokens.test.ts
+++ b/src/lib/__tests__/colorTokens.test.ts
@@ -560,6 +560,48 @@ describe("Issue #537: fg.muted 補助情報の WCAG 1.4.3 AA (4.5:1) 検証", ()
   // 未追加だった。本 describe で fg.muted を補助情報文字色として使うパターン
   // (Coordinate / Resurface の見出し等) を全 bg 階層について Tripwire 化する。
   //
+  // ─────────────────────────────────────────────────────────────────────────
+  // 設計判断: 上限ガード (AAA 超過の最大値) は採用しない (Issue #645)
+  // ─────────────────────────────────────────────────────────────────────────
+  // Tripwire の assert は **AA 下限 (4.5:1) のみ** を要求する。dark の fg.muted ×
+  // bg.canvas (14.84:1) / fg.muted × bg.muted (11.87:1) は AAA を大幅に超過するが、
+  // これに対する上限 assertion (例: `r <= 18.0` 等の上限ガード) は意図的に追加しない。
+  //
+  // 採用案: A (上限ガード不採用、JSDoc で baseline を documented snapshot として明記)
+  // 不採用案:
+  //   - B (上限 18:1 等の数値ガード): 「より高コントラストにする改善」を阻むため不採用。
+  //     アクセシビリティの方向性 (= 高い方が良い) に逆行する hard assertion は CI の
+  //     役割として不適切。color token の改善 (例: bone-100 → bone-50 への引き上げ等)
+  //     が技術的に望ましい場合に、無関係な Tripwire fail で改善 PR がブロックされる。
+  //   - C 完全採用 (snapshot 値そのものを fixture 化): 値の微変動 (OKLCH パース誤差、
+  //     色空間ライブラリ更新等) でも fail するため過剰検出になる。
+  //
+  // 採用 = A + C のハイブリッド: hard な test assertion は AA 下限のみ。
+  // baseline 実測値は本 JSDoc にコメント snapshot として残し、色設計変更時に
+  // 「数値が大幅に変化したか」をレビュー観点として手動確認できる足場にする。
+  //
+  // ─────────────────────────────────────────────────────────────────────────
+  // baseline 実測値 (2026-05-18 時点、`pnpm contrast:check` および
+  // colorTokens.ts + culori `wcagContrast()` で実測)
+  // ─────────────────────────────────────────────────────────────────────────
+  //   light:
+  //     - fg.muted × bg.canvas  (sumi-600 × cream-50)  =  6.54:1  (AA pass / AAA 未達)
+  //     - fg.muted × bg.surface (sumi-600 × cream-100) =  6.17:1  (AA pass / AAA 未達)
+  //     - fg.muted × bg.muted   (sumi-600 × cream-75)  =  6.35:1  (AA pass / AAA 未達)
+  //   dark:
+  //     - fg.muted × bg.canvas  (bone-100 × sumi-950)  = 14.84:1  (AAA 大幅超過)
+  //     - fg.muted × bg.surface (bone-100 × sumi-700)  =  7.91:1  (AAA pass)
+  //     - fg.muted × bg.muted   (bone-100 × sumi-650)  = 11.87:1  (AAA 大幅超過)
+  //
+  // 色設計変更時のレビュー観点 (= この describe を触る PR の reviewer 向け):
+  //   1. 上記 baseline 値から **±30% 以上の変化** があれば、token (fg.muted, bg.*) の
+  //      意味変更が伴っているはずなので、Issue の議論 / RFC との整合を確認する。
+  //   2. dark 側が AA 下限 (4.5:1) 近傍まで低下する変更は、「補助情報専用」用途を
+  //      逸脱していないか (本文用途への転用の兆候がないか) を確認する。
+  //   3. light 側が AAA (7.0:1) を満たすほど上昇した場合は、fg.secondary との
+  //      役割重複がないか (fg.muted の存在理由が薄れていないか) を確認する。
+  //   4. baseline 値そのもの (上記コメント) も同じ PR で実測値に更新すること。
+  //
   // 留意点 (実測値の事実):
   //   - light の fg.muted (sumi-600) は **AA pass / AAA 未達** (bg.surface 上 6.17:1)。
   //     fg.muted は本文ではなく「補助情報のみ」用途に限定するルール (panda.config.ts
@@ -629,4 +671,7 @@ describe("Issue #537: fg.muted 補助情報の WCAG 1.4.3 AA (4.5:1) 検証", ()
   // ドキュメント化している。値が将来改善されて AAA を満たした場合でも、それは
   // 純粋な改善変更であり Tripwire でブロックすべきではないため、本 describe では
   // 「AAA を満たさない」ことを assert する negative test は持たない。
+  //
+  // 同様の理由で dark 側の AAA 大幅超過 (14.84:1 等) に対する上限 assertion も
+  // 追加していない (Issue #645 で確定した設計判断、本 describe 冒頭 JSDoc 参照)。
 });

--- a/src/lib/__tests__/colorTokens.test.ts
+++ b/src/lib/__tests__/colorTokens.test.ts
@@ -585,28 +585,52 @@ describe("Issue #537: fg.muted 補助情報の WCAG 1.4.3 AA (4.5:1) 検証", ()
   // colorTokens.ts + culori `wcagContrast()` で実測)
   // ─────────────────────────────────────────────────────────────────────────
   //   light:
-  //     - fg.muted × bg.canvas  (sumi-600 × cream-50)  =  6.54:1  (AA pass / AAA 未達)
-  //     - fg.muted × bg.surface (sumi-600 × cream-100) =  6.17:1  (AA pass / AAA 未達)
-  //     - fg.muted × bg.muted   (sumi-600 × cream-75)  =  6.35:1  (AA pass / AAA 未達)
+  //     - fg.muted × bg.canvas   (sumi-600 × cream-50)  =  6.54:1  (AA pass / AAA 未達)
+  //     - fg.muted × bg.surface  (sumi-600 × cream-100) =  6.17:1  (AA pass / AAA 未達)
+  //     - fg.muted × bg.muted    (sumi-600 × cream-75)  =  6.35:1  (AA pass / AAA 未達)
+  //     - fg.muted × bg.elevated (sumi-600 × cream-50)  =  6.54:1  (AA pass / AAA 未達)
+  //       ※ light の bg.elevated は cream-50 = bg.canvas と同値のため数値も同じ
   //   dark:
-  //     - fg.muted × bg.canvas  (bone-100 × sumi-950)  = 14.84:1  (AAA 大幅超過)
-  //     - fg.muted × bg.surface (bone-100 × sumi-700)  =  7.91:1  (AAA pass)
-  //     - fg.muted × bg.muted   (bone-100 × sumi-650)  = 11.87:1  (AAA 大幅超過)
+  //     - fg.muted × bg.canvas   (bone-100 × sumi-950)  = 14.84:1  (AAA 大幅超過)
+  //     - fg.muted × bg.surface  (bone-100 × sumi-700)  =  7.91:1  (AAA pass)
+  //     - fg.muted × bg.muted    (bone-100 × sumi-650)  = 11.87:1  (AAA 大幅超過)
+  //     - fg.muted × bg.elevated (bone-100 × sumi-600)  =  5.39:1  (AA pass / AAA 未達、6 ペア中最低)
+  //       ※ dark の bg.elevated (sumi-600) は FeaturedCard.tsx / CardSkeleton.tsx /
+  //          ArticleSkeleton.tsx で使用中。現状 fg.muted を直接これらカード上に置く
+  //          コンポーネントは無いが、将来配置される場合の baseline 観測点として記録。
   //
   // 色設計変更時のレビュー観点 (= この describe を触る PR の reviewer 向け):
-  //   1. 上記 baseline 値から **±30% 以上の変化** があれば、token (fg.muted, bg.*) の
-  //      意味変更が伴っているはずなので、Issue の議論 / RFC との整合を確認する。
-  //   2. dark 側が AA 下限 (4.5:1) 近傍まで低下する変更は、「補助情報専用」用途を
+  //   1. 上記 baseline 値から **経験的目安として ±30% 以上の変化** があれば、token
+  //      (fg.muted, bg.*) の意味変更が伴っているはずなので、Issue の議論 / RFC との
+  //      整合を確認する (「±30%」は Issue #645 で initial value として導入した経験的
+  //      目安であり、規格根拠を持つ閾値ではない。運用しながら値域は調整する想定)。
+  //   2. 経験則と独立した **絶対値ベースのトリガー** として、以下が観測されたら必ず
+  //      個別に意図を確認する (WCAG 規格と直結する hard line):
+  //        - dark の最低 baseline (現状 5.39:1 = bg.elevated 上) が AA 下限 (4.5:1) を
+  //          下回ったら、補助情報用途として WCAG 1.4.3 を割り込むため要再設計。
+  //        - dark の最高 baseline (現状 14.84:1) が更に上昇した場合は、bone-100 の
+  //          token 役割 (補助情報) を逸脱して本文寄りになっていないか確認。
+  //   3. dark 側が AA 下限 (4.5:1) 近傍まで低下する変更は、「補助情報専用」用途を
   //      逸脱していないか (本文用途への転用の兆候がないか) を確認する。
-  //   3. light 側が AAA (7.0:1) を満たすほど上昇した場合は、fg.secondary との
+  //   4. light 側が AAA (7.0:1) を満たすほど上昇した場合は、fg.secondary との
   //      役割重複がないか (fg.muted の存在理由が薄れていないか) を確認する。
-  //   4. baseline 値そのもの (上記コメント) も同じ PR で実測値に更新すること。
+  //   5. baseline 値そのもの (上記コメント) も同じ PR で実測値に更新すること。
+  //
+  // **注意**: 上記 5 つのレビュー観点 (特に観点 5 = baseline 更新義務) は **CI で
+  // 機械的に強制できない**。本コメントは Tripwire テスト fixture ではなく純然たる
+  // JSDoc コメントであり、token 値が変わっても本ファイルのコメントは自動更新されず、
+  // テストも fail しない。**reviewer の目視確認が唯一の防御線** である。
+  // baseline と実測値の乖離を確認する際は、reviewer が手元で `pnpm contrast:check`
+  // を実行し、本コメントの値と差分があれば PR 内で実測値への更新を要求すること
+  // (bg.elevated × fg.muted は現状 `contrast:check` スクリプトの出力対象に含まれて
+  // いないため、必要に応じて culori `wcagContrast()` で直接検算する)。
   //
   // 留意点 (実測値の事実):
   //   - light の fg.muted (sumi-600) は **AA pass / AAA 未達** (bg.surface 上 6.17:1)。
   //     fg.muted は本文ではなく「補助情報のみ」用途に限定するルール (panda.config.ts
   //     §accent ガイドライン参照)。本文として転用する場合は fg.secondary に振り直す。
   //   - dark の fg.muted (bone-100) は全 bg 階層で AA 以上 (bg.surface 上 7.91:1 で AAA)。
+  //     最低値は bg.elevated (sumi-600) 上の 5.39:1 で、AAA 未達ながら AA pass。
 
   it("fg.muted × bg.surface (light) が WCAG 1.4.3 AA 4.5:1 を満たす", () => {
     // Coordinate / Resurface 見出しが想定する主要配置。
@@ -661,6 +685,29 @@ describe("Issue #537: fg.muted 補助情報の WCAG 1.4.3 AA (4.5:1) 検証", ()
     const r = ratio(
       semanticColorTokens.fgMuted.dark,
       semanticColorTokens.bgMuted.dark,
+    );
+    expect(r).toBeGreaterThanOrEqual(contrastThresholds.largeText);
+  });
+
+  it("fg.muted × bg.elevated (light) が WCAG 1.4.3 AA 4.5:1 を満たす", () => {
+    // light の bg.elevated は cream-50 = bg.canvas と同値のため数値も同じ。
+    // 実測 6.54:1: AA pass / AAA 未達。FeaturedCard 等が将来 light でも
+    // bg.elevated を使い、その上に fg.muted の補助情報を載せた場合の保険。
+    const r = ratio(
+      semanticColorTokens.fgMuted.light,
+      semanticColorTokens.bgElevated.light,
+    );
+    expect(r).toBeGreaterThanOrEqual(contrastThresholds.largeText);
+  });
+
+  it("fg.muted × bg.elevated (dark) が WCAG 1.4.3 AA 4.5:1 を満たす", () => {
+    // FeaturedCard.tsx / CardSkeleton.tsx / ArticleSkeleton.tsx で bg.elevated
+    // (sumi-600) を使用。将来 fg.muted がこれらカード上に置かれた場合の baseline。
+    // 実測 5.39:1: AA pass / AAA 未達 (6 ペア中最低)。
+    // この値が AA 下限 (4.5:1) を下回ったら sumi-600 / bone-100 の再設計が必要。
+    const r = ratio(
+      semanticColorTokens.fgMuted.dark,
+      semanticColorTokens.bgElevated.dark,
     );
     expect(r).toBeGreaterThanOrEqual(contrastThresholds.largeText);
   });


### PR DESCRIPTION
## 概要

PR (Issue #537) で追加した Tripwire は AA 下限 (4.5:1) のみ assert する。dark mode の `fg.muted × bg.canvas` は実測 14.84:1 (AAA 大幅超過)、`fg.muted × bg.muted` は 11.87:1。「意図的に高い」か「偶発的に高い」かの Tripwire 設計上の問いに対して **案 A (上限ガード不採用) + 案 C (baseline snapshot JSDoc) のハイブリッド** を採用する。

Closes #645

## 変更内容

- `src/lib/__tests__/colorTokens.test.ts`:
  - `describe("Issue #537: ...")` 冒頭に「設計判断」JSDoc を追加 (採用案 A の根拠 / 不採用案 B (上限 18:1 等) と C 完全採用の不採用理由)
  - baseline 実測値を 8 ペアの snapshot として明記 (light/dark × bg.canvas/surface/muted/elevated)
    - dark fg.muted × bg.elevated = **5.39:1** が 6 ペア中最低 (FeaturedCard / CardSkeleton / ArticleSkeleton で bg.elevated 使用)
  - 「色設計変更時のレビュー観点」5 項目 + 「±30% は経験的目安」明記 + 絶対値ベーストリガー (dark 最低が AA 下限 4.5:1 を下回ったら確認) 併記
  - **CI で機械強制不可** (純然たる JSDoc コメントのため) と reviewer 目視確認が唯一の防御線である旨を明示
  - `bg.elevated × fg.muted` の Tripwire テスト 2 件追加 (light/dark)

## 備考

- DA レビュー 2 周 (Should 3件: ±30% 根拠 / bg.elevated 欠落 / 運用義務の機械強制不可性) すべて解消
- /review APPROVE、/security-review 該当なし (テストコメント追加のみで attack surface 増加ゼロ)
- 既存 + 新規テスト 968/968 pass、`pnpm lint` clean、`pnpm build` 成功