### PR TITLE
chore: deploy.yml の build job にも tsc incremental cache を配線 (Closes #655)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,11 +42,17 @@ jobs:
       #   は deploy 時の incremental cache に対しても valid (test 用 tsconfig の hash が変わっても src の
       #   .tsbuildinfo 自体は再利用可能であり、key が変わることで再生成されても害がない)
       # - deploy 頻度は master push 時のみで頻度が低く、cache 書き込み衝突リスクは小さい
+      #   (最悪ケース: ci.yml の同 key 書き込みと同時刻実行が衝突した際に片方の cache 書き込みが失われるが、
+      #   `actions/cache` は cache miss → 再生成に degrade するだけで build correctness には影響しない)
       # - 別 key にすると ci.yml の build 成果を再利用できず deploy 時に毎回 cold ビルドになる
       # tsconfig.build.json は本 cache のスコープ外 (build script では `tsc` (= tsconfig.json) を使うため)
       # NOTE: Issue #654 (PR #669) で ci.yml の cache key に追加された `'scripts/**/*.tsx'` glob と
       # 整合させるため、ここにも同 glob を含める。これにより #654 / #655 のいずれが先にマージされても
       # ci.yml と deploy.yml の cache key が drift しない。
+      # **重要**: 本 cache step の `key` / `restore-keys` / `path` を変更する際は ci.yml
+      # (lint-and-typecheck job) 側の同 step も同期して変更すること。逆も同様。drift すると
+      # ci.yml が warm にした .tsbuildinfo を deploy.yml 側が再利用できず (またはその逆)、warm cache が
+      # 無駄になる。
       - name: Cache tsc incremental build info (Issue #655)
         uses: actions/cache@v5
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,25 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Issue #655: ci.yml (lint-and-typecheck job) と同じ cache key を共有し、
+      # deploy 時の tsc (pnpm run build 内の `tsc` / `type-check` / `type-check:scripts`) の
+      # cold ビルドを回避する。
+      # ci.yml と key を共有する理由:
+      # - ci.yml の key 構成 (tsconfig.json / tsconfig.test.json / tsconfig.scripts.json の hash + src/scripts の hash)
+      #   は deploy 時の incremental cache に対しても valid (test 用 tsconfig の hash が変わっても src の
+      #   .tsbuildinfo 自体は再利用可能であり、key が変わることで再生成されても害がない)
+      # - deploy 頻度は master push 時のみで頻度が低く、cache 書き込み衝突リスクは小さい
+      # - 別 key にすると ci.yml の build 成果を再利用できず deploy 時に毎回 cold ビルドになる
+      # tsconfig.build.json は本 cache のスコープ外 (build script では `tsc` (= tsconfig.json) を使うため)
+      - name: Cache tsc incremental build info (Issue #655)
+        uses: actions/cache@v5
+        with:
+          path: .tsbuildinfo
+          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts') }}
+          restore-keys: |
+            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-
+            tsc-${{ runner.os }}-
+
       - name: Build project
         run: pnpm run build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,11 +44,14 @@ jobs:
       # - deploy 頻度は master push 時のみで頻度が低く、cache 書き込み衝突リスクは小さい
       # - 別 key にすると ci.yml の build 成果を再利用できず deploy 時に毎回 cold ビルドになる
       # tsconfig.build.json は本 cache のスコープ外 (build script では `tsc` (= tsconfig.json) を使うため)
+      # NOTE: Issue #654 (PR #669) で ci.yml の cache key に追加された `'scripts/**/*.tsx'` glob と
+      # 整合させるため、ここにも同 glob を含める。これにより #654 / #655 のいずれが先にマージされても
+      # ci.yml と deploy.yml の cache key が drift しない。
       - name: Cache tsc incremental build info (Issue #655)
         uses: actions/cache@v5
         with:
           path: .tsbuildinfo
-          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts') }}
+          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts', 'scripts/**/*.tsx') }}
           restore-keys: |
             tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-
             tsc-${{ runner.os }}-


### PR DESCRIPTION
## 概要

PR #639 (Closes #580) で `.github/workflows/ci.yml` の `lint-and-typecheck` job に追加した tsc incremental cache (`.tsbuildinfo` の actions/cache) を、`.github/workflows/deploy.yml` の build job (master push 時) にも配線する。

Closes #655

## 変更内容

- `.github/workflows/deploy.yml`: `pnpm install` 後に `actions/cache@v5` step を追加
  - cache key は **ci.yml と完全共有** (`tsc-${runner.os}-${hashFiles(tsconfig.{json,test,scripts}.json)}-${hashFiles(src/**/*.ts(x), scripts/**/*.ts(x))}`)
  - PR #669 (Closes #654) で ci.yml に追加された `'scripts/**/*.tsx'` glob を先回り含めて drift を防止
  - コメントブロックに「key を変更する際は ci.yml 側も同期する」「最悪ケースは cache miss に degrade するだけ」を明記 (DA Should 対応)

## 備考

- DA 承認 (Must 0、Should 2 件は本 PR で軽微修正済)、/review APPROVE、/security-review 該当なし (cache poisoning 経路は fork PR 制限で塞がれている)
- YAML 構文 OK (actionlint)
- 残 Should: cold/warm 実機計測 → **マージ後 master push 1-2 回で観測し、効果が薄ければ revert 検討**