### PR TITLE
chore: @types/node を Node 24 LTS 系へ upgrade (Closes #602)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/culori": "~4.0.0",
     "@types/jest-axe": "^3.5.9",
-    "@types/node": "^20.19.41",
+    "@types/node": "^24.12.4",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/react-router-dom": "^5.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^3.5.9
         version: 3.5.9
       '@types/node':
-        specifier: ^20.19.41
-        version: 20.19.41
+        specifier: ^24.12.4
+        version: 24.12.4
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -77,7 +77,7 @@ importers:
         version: 5.3.3
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.10(@types/node@20.19.41))
+        version: 6.0.1(vite@8.0.10(@types/node@24.12.4))
       culori:
         specifier: ~4.0.0
         version: 4.0.2
@@ -95,10 +95,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.0.10
-        version: 8.0.10(@types/node@20.19.41)
+        version: 8.0.10(@types/node@24.12.4)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@20.19.41)(jsdom@29.1.1)(vite@8.0.10(@types/node@20.19.41))
+        version: 4.1.5(@types/node@24.12.4)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.12.4))
 
 packages:
 
@@ -837,6 +837,9 @@ packages:
 
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -2125,6 +2128,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
@@ -3053,6 +3059,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.12.4':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -3083,10 +3093,10 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@20.19.41))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.10(@types/node@20.19.41)
+      vite: 8.0.10(@types/node@24.12.4)
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -3097,13 +3107,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@20.19.41))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@24.12.4))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@20.19.41)
+      vite: 8.0.10(@types/node@24.12.4)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -4296,6 +4306,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.16.0: {}
+
   undici@7.25.0: {}
 
   universalify@2.0.1: {}
@@ -4316,7 +4328,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.10(@types/node@20.19.41):
+  vite@8.0.10(@types/node@24.12.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -4324,13 +4336,13 @@ snapshots:
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 20.19.41
+      '@types/node': 24.12.4
       fsevents: 2.3.3
 
-  vitest@4.1.5(@types/node@20.19.41)(jsdom@29.1.1)(vite@8.0.10(@types/node@20.19.41)):
+  vitest@4.1.5(@types/node@24.12.4)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.12.4)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@20.19.41))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.4))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -4347,10 +4359,10 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@20.19.41)
+      vite: 8.0.10(@types/node@24.12.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.19.41
+      '@types/node': 24.12.4
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## 概要

PR #599 (Issue #589) で `ImportMeta.dirname` を non-readonly 化した予防修正の効果を、`@types/node` upgrade で実機検証する。CI ランタイム / `.nvmrc` / ローカル Node がすべて Node 24 で揃っているため、Issue 候補の `^20.11.0` ではなく **`@types/node@^24.12.4` (Node 24 LTS 系) を採用** し、型とランタイムを整合させた。

Closes #602
Closes #589 (= 予防修正と整合)

## 変更内容

- `package.json`: `@types/node` `^20.19.41` → `^24.12.4`
- `pnpm-lock.yaml`: 上記 upgrade を反映 (vite / vitest / @vitejs/plugin-react の peer 参照も追従)

## 備考

- Issue 本文の前提 (`scripts/scripts-env.d.ts` の `ImportMeta` interface merge / `@types/node` が transitive のみ) は古く、PR #632 (Issue #601) で既に解消済み (= devDependencies 明示済み + scripts-env.d.ts 削除済み)
- Issue #589 で予防対応した `ImportMeta.dirname` の non-readonly 化と整合 (Node 24 の `@types/node` 公式宣言も non-readonly のため TS2687 modifier conflict ゼロ)
- DA 承認 (Must 0)、/review APPROVE、/security-review 0件 (devDependency 型定義のみで attack surface 増加なし)
- 実機検証: `pnpm type-check` / `type-check:test` / `type-check:scripts` / `test:run` (966 件) / `build` / `lint` 全 pass