### PR TITLE
chore: tsconfig.build.json は build/CI 経路で未使用と判明、調査結果コメントで close (Closes #641)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       # type-check / type-check:test / type-check:scripts の cold ビルドを高速化する。
       # メインキー: lockfile + tsconfig.json / tsconfig.test.json / tsconfig.scripts.json + src/scripts の hash が完全一致した場合のみ hit
       # restoreKeys: lockfile + tsconfig が一致なら部分的に再利用 (src 差分のみ再計算)
-      # tsconfig.build.json は本 cache のスコープ外 (build 側 / vite build 前 tsc) のため除外 (DA M-3)
+      # tsconfig.build.json は build/CI 経路で実行されないため対象外 (Issue #641 実機検証, 2026-05-18 / follow-up #678)
       # tsconfig.scripts.json は Issue #634 で新設 (scripts/ ambient 型の attack surface 制御)
       - name: Cache tsc incremental build info (Issue #580)
         uses: actions/cache@v5

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,14 +1,7 @@
-// Issue #641 調査結果 (2026-05-18):
-//   本ファイルは元々 Vite テンプレート由来の `vite.config.ts` / `panda.config.ts`
-//   型チェック用 config として導入されたが、現状の build 経路 (package.json の
-//   `build` script: `panda && tsc && vite build`) では `tsc` が `--build` フラグ
-//   なし & `tsconfig.json` 側に `noEmit: true` があるため、project references で
-//   参照されている本 config はビルドされない (実機検証: `pnpm exec tsc` 実行後
-//   `.tsbuildinfo/tsconfig.build.tsbuildinfo` は生成されない)。
-//   そのため Issue #641 「tsconfig.build.json 側の incremental 化」については、
-//   incremental 化しても build/CI 経路で実行されないため意味がないと判断し、
-//   設定追加を見送った。死設定状態の解消 (tsconfig.build.json 自体の削除や
-//   `tsc -b` ベースへの切替) は本 Issue のスコープを超えるため別 Issue とする。
+// 壊れた死設定 (Issue #641 / follow-up #678 参照)。
+//   build script (`panda && tsc && vite build`) では未実行、かつ `tsc -b` で
+//   直接呼ぶと include 範囲不整合 (`src/api/*` / `vite.config.ts` の type 依存が
+//   include 外) でエラーになる。incremental 化しても効果ゼロ。削除候補。
 {
   "compilerOptions": {
     "composite": true,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,3 +1,14 @@
+// Issue #641 調査結果 (2026-05-18):
+//   本ファイルは元々 Vite テンプレート由来の `vite.config.ts` / `panda.config.ts`
+//   型チェック用 config として導入されたが、現状の build 経路 (package.json の
+//   `build` script: `panda && tsc && vite build`) では `tsc` が `--build` フラグ
+//   なし & `tsconfig.json` 側に `noEmit: true` があるため、project references で
+//   参照されている本 config はビルドされない (実機検証: `pnpm exec tsc` 実行後
+//   `.tsbuildinfo/tsconfig.build.tsbuildinfo` は生成されない)。
+//   そのため Issue #641 「tsconfig.build.json 側の incremental 化」については、
+//   incremental 化しても build/CI 経路で実行されないため意味がないと判断し、
+//   設定追加を見送った。死設定状態の解消 (tsconfig.build.json 自体の削除や
+//   `tsc -b` ベースへの切替) は本 Issue のスコープを超えるため別 Issue とする。
 {
   "compilerOptions": {
     "composite": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,10 +29,7 @@
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src"],
-  // references: tsconfig.build.json は Vite テンプレート由来の死設定状態
-  // (Issue #641 調査結果, 2026-05-18)。素の `tsc` (本体 build script の
-  // `panda && tsc && vite build`) は `noEmit: true` のため references を
-  // build しない。incremental 化しても呼ばれないため対応見送り。詳細は
-  // tsconfig.build.json 先頭コメント参照。
+  // references の tsconfig.build.json は壊れた死設定 (Issue #641 / follow-up #678)。
+  // 詳細は tsconfig.build.json 先頭コメント参照。
   "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,5 +29,10 @@
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src"],
+  // references: tsconfig.build.json は Vite テンプレート由来の死設定状態
+  // (Issue #641 調査結果, 2026-05-18)。素の `tsc` (本体 build script の
+  // `panda && tsc && vite build`) は `noEmit: true` のため references を
+  // build しない。incremental 化しても呼ばれないため対応見送り。詳細は
+  // tsconfig.build.json 先頭コメント参照。
   "references": [{ "path": "./tsconfig.build.json" }]
 }


### PR DESCRIPTION
## 概要

`tsconfig.build.json` 側 (vite build 前の独立 tsc 実行想定) の incremental 化を検討するため実機調査した結果、**`tsconfig.build.json` は build/CI 経路で実行されていない死設定**であることが判明。さらに `tsc -b` で直接呼んでも include 範囲不整合 (`src/api/*` / `vite.config.ts` の type 依存が include 外) でエラーになる構成のため、**incremental 化の効果はゼロ**。

調査結果をファイル冒頭コメントとして残し、削除 / `tsc -b` ベース切替の判断は follow-up Issue #678 に委ねる方針で close する。

Closes #641
Related #678 (follow-up: 死設定整理)

## 変更内容

- `tsconfig.build.json`: 冒頭コメント (4 行) 追加。「壊れた死設定」「`tsc -b` 直接実行でも include 範囲不整合でエラー」「incremental 化しても効果ゼロ」「削除候補」「詳細は #678」
- `tsconfig.json`: `references` 配列直前にコメント (2 行) 追加。「壊れた死設定 (Issue #641 / follow-up #678)」+ 詳細は build 側参照
- `.github/workflows/ci.yml`: L41 の事実誤認コメント (「vite build 前 tsc」) を実態 (「build/CI 経路で実行されないため対象外」) に修正

## 実機検証結果

| シナリオ | 結果 |
|---|---|
| `pnpm exec tsc` (default project) | `.tsbuildinfo/tsconfig.tsbuildinfo` と `tsconfig.scripts.tsbuildinfo` のみ生成、`tsconfig.build.tsbuildinfo` は生成されない |
| `pnpm exec tsc -b tsconfig.build.json` | TS6307 (`src/api/*` not listed) + TS2769 (`vite.config.ts` の `test` プロパティ未解決) でエラー |
| Cold/warm `pnpm exec tsc` (本体 tsconfig.json) | 2.36s → 1.10s (既存 PR #580 の incremental が機能) |

## 備考

- DA 2 周承認 (Must 2 件: ci.yml 事実誤認 + 「壊れた死設定」精度向上、Should 3 件: follow-up #678 起票 + コメント圧縮 + Issue 側コメント)、/review APPROVE、/security-review HIGH/MEDIUM/LOW 該当なし
- `pnpm type-check` / `type-check:test` / `type-check:scripts` / `test:run` (966 件) / `build` / `lint` 全 pass