### PR TITLE
chore: lintTokens.ts のテスト専用 export に @internal JSDoc を一括付与 (Closes #636)

### DIFF
--- a/scripts/lintTokens.ts
+++ b/scripts/lintTokens.ts
@@ -98,7 +98,7 @@ const EXCLUDED_FILE_SUFFIXES = [
  *     (例: `bg: {\n  "0": { value: ... }\n}`) を検出するため。
  *     コメント除去はファイル単位で適用する。
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 interface LintPattern {
   readonly name: string;
@@ -107,7 +107,7 @@ interface LintPattern {
   readonly scope?: "line" | "file";
 }
 
-/** @internal Test 専用 export. 本番コードから import しないこと */
+/** @internal テスト専用 export. 本番コードから import しないこと */
 const LINT_PATTERNS: readonly LintPattern[] = [
   {
     name: "old-bg-numeric",
@@ -184,7 +184,7 @@ const LINT_PATTERNS: readonly LintPattern[] = [
   },
 ] as const;
 
-/** @internal Test 専用 export. 本番コードから import しないこと */
+/** @internal テスト専用 export. 本番コードから import しないこと */
 interface Violation {
   readonly file: string;
   readonly line: number;
@@ -202,13 +202,11 @@ interface Violation {
  *   (`ENOENT` / `EACCES` / `EMFILE` 等) をそのまま渡す。code が取得
  *   できない例外は `"unknown"` にフォールバックする
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 type SkipCallback = (path: string, reason: string) => void;
 
 /**
- * @internal Test 専用 export. 本番コードから import しないこと
- *
  * `statSync` を try/catch でラップし、対象が存在しない場合は undefined を返す。
  * `collectTargetFiles` / `walkDirectory` の cognitive complexity を抑え、
  * broken symlink 経路でも例外伝播を起こさないようにするための補助関数。
@@ -232,6 +230,8 @@ type SkipCallback = (path: string, reason: string) => void;
  *   ことで、CI ログから不審な skip 異常を一目で検知可能にする。
  *
  *   `onSkip` を渡さない呼び出しは従来通り「静かに skip」を維持する。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const tryStat = (
   target: string,
@@ -256,7 +256,7 @@ const tryStat = (
  * - 拡張子が `TARGET_EXTENSIONS` に含まれること
  * - `EXCLUDED_FILE_SUFFIXES` のいずれにも該当しないこと
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const isAcceptableFile = (filePath: string): boolean => {
   if (!TARGET_EXTENSIONS.has(extname(filePath))) {
@@ -275,7 +275,7 @@ const isAcceptableFile = (filePath: string): boolean => {
  * 判定) を素通りしてしまい、テストコード中の旧 token 言及で CI が
  * 落ちる潜在バグになる (Issue #413 / DA 重大 2 対応)。
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const shouldSkipEntry = (entry: string): boolean => {
   return (
@@ -296,7 +296,7 @@ const shouldSkipEntry = (entry: string): boolean => {
  * @param onSkip 省略可。stat 失敗で skip した場合に呼ばれるコールバック
  *   (Issue #637)。`main()` が件数集計用に渡す
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const walkDirectory = (
   current: string,
@@ -334,7 +334,7 @@ const walkDirectory = (
  *   将来 PROJECT_ROOT 走査に変えたとき耐えるためガードを入れておく)。
  * - 走査対象が存在しない場合は空配列を返す (例: e2e/ 未配置構成でも壊れない)。
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const collectTargetFiles = (
   target: string,
@@ -390,7 +390,7 @@ interface CommentStripResult {
  * `stripComments` の状態機械内部状態。
  * 状態ごとのハンドラ間で受け渡される、行内の文字種コンテキスト。
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 interface ScanState {
   inBlockComment: boolean;
@@ -404,7 +404,7 @@ interface ScanState {
  * `advance` は追加で消費すべきインデックス数 (0 もしくは 1)。
  * `terminated` が true の場合、その時点で行の処理を打ち切る (行コメント検出時)。
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 interface StepResult {
   readonly advance: number;
@@ -436,7 +436,7 @@ const NO_ADVANCE: StepResult = { advance: 0, terminated: false };
  * @param out **in-out**: 処理後の sanitized 文字を末尾に push する (push only)
  * @param state **in-out**: `inBlockComment` を必要に応じて mutate する
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const handleBlockComment = (
   ch: string,
@@ -461,7 +461,7 @@ const handleBlockComment = (
  * ようにし、呼び出し側で都度 `closer` クロージャを生成していた micro-allocation
  * を排除する (Issue #621 / M2, M3)。
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 type QuoteChar = "'" | '"' | "`";
 type QuoteStateField = "inSingle" | "inDouble" | "inBacktick";
@@ -483,7 +483,7 @@ const QUOTE_FIELD: Readonly<Record<QuoteChar, QuoteStateField>> = {
  * @param out **in-out**: sanitized 文字を末尾に push する (push only)
  * @param state **in-out**: 終端クォート検出時に対応する `in*` フラグを下ろす
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const handleStringLiteral = (
   ch: string,
@@ -513,7 +513,7 @@ const handleStringLiteral = (
  * @param out **in-out**: sanitized 文字 / 空白を末尾に push する (push only)
  * @param state **in-out**: 検出した状態遷移に応じて `in*` フラグを mutate する
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const handleDefault = (
   ch: string,
@@ -559,7 +559,7 @@ const handleDefault = (
  * @param out **in-out**: 配下ハンドラへそのまま渡される push only バッファ
  * @param state **in-out**: 配下ハンドラへそのまま渡される共有状態
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const processChar = (
   ch: string,
@@ -583,7 +583,7 @@ const processChar = (
   return handleDefault(ch, next, out, state, remainingLength);
 };
 
-/** @internal Test 専用 export. 本番コードから import しないこと */
+/** @internal テスト専用 export. 本番コードから import しないこと */
 const stripComments = (
   line: string,
   state: CommentStripState,
@@ -616,7 +616,7 @@ const stripComments = (
  * `scope: "file"` パターンの match.index (ファイル全体オフセット) から
  * 行番号 / カラム位置 / 元行 snippet を逆引きするのに使う。
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 interface SanitizedFile {
   /** コメント領域を空白に置換したファイル全体テキスト */
@@ -627,7 +627,7 @@ interface SanitizedFile {
   readonly lineStartOffsets: number[];
 }
 
-/** @internal Test 専用 export. 本番コードから import しないこと */
+/** @internal テスト専用 export. 本番コードから import しないこと */
 const sanitizeFile = (content: string): SanitizedFile => {
   const lines = content.split(/\r?\n/);
   const sanitizedLines: string[] = [];
@@ -655,7 +655,7 @@ const sanitizeFile = (content: string): SanitizedFile => {
  * sanitized 全体オフセットから「何行目の何カラム目か」を逆引きする。
  * lineStartOffsets は昇順なので二分探索で O(log n)。
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const offsetToLineColumn = (
   offset: number,
@@ -686,7 +686,7 @@ const offsetToLineColumn = (
  * regex.exec を反復し、ヒットごとに `onMatch` を呼ぶ汎用イテレータ。
  * 0 幅マッチによる無限ループを避けるため、lastIndex を強制前進させる。
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const iterateMatches = (
   pattern: RegExp,
@@ -710,7 +710,7 @@ const iterateMatches = (
  *
  * @param violations **in-out**: 検出した違反を末尾に push する (Issue #621 / N1)
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const scanFileScope = (
   filePath: string,
@@ -734,8 +734,6 @@ const scanFileScope = (
 };
 
 /**
- * @internal Test 専用 export. 本番コードから import しないこと
- *
  * sanitized テキスト上で `lineIndex` 行目に対応する範囲を切り出す。
  * `scanLineScope` の内部ヘルパー。
  *
@@ -751,6 +749,8 @@ const scanFileScope = (
  *   (将来 `lineStartOffsets` 計算ロジックを書き換えた際の安全網) に対して
  *   slice の end が start を下回って空でない結果を返してしまうケースを
  *   防ぐためのディフェンシブガードである。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const extractSanitizedLine = (
   sanitized: string,
@@ -768,7 +768,7 @@ const extractSanitizedLine = (
  *
  * @param violations **in-out**: 検出した違反を末尾に push する (Issue #621 / N1)
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const scanLineScope = (
   filePath: string,
@@ -811,7 +811,7 @@ const scanLineScope = (
  * - 大文字小文字は区別する (token 名は確定的にケースが決まっている)。
  * - 行コメント / ブロックコメント内は検査対象から除外する (Issue #413)。
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const scanFile = (
   filePath: string,
@@ -837,7 +837,7 @@ const formatViolation = (v: Violation): string => {
   return `${relPath}:${v.line}:${v.column}  [${v.patternName}] ${v.description}\n    ${v.snippet}`;
 };
 
-/** @internal Test 専用 export. 本番コードから import しないこと */
+/** @internal テスト専用 export. 本番コードから import しないこと */
 interface SkipRecord {
   readonly path: string;
   readonly reason: string;
@@ -850,7 +850,7 @@ interface SkipRecord {
  * - 件数 > 0 の場合は件数とパス一覧 / reason を 1 行ずつ出力する
  *   ことで、CI ログで grep / scroll 時に skip 異常が一目で分かるようにする
  *
- * @internal Test 専用 export. 本番コードから import しないこと
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 const reportSkippedTargets = (skipped: readonly SkipRecord[]): void => {
   if (skipped.length === 0) {

--- a/scripts/lintTokens.ts
+++ b/scripts/lintTokens.ts
@@ -97,6 +97,8 @@ const EXCLUDED_FILE_SUFFIXES = [
  *     panda.config.ts のような複数行にまたがるオブジェクトリテラル
  *     (例: `bg: {\n  "0": { value: ... }\n}`) を検出するため。
  *     コメント除去はファイル単位で適用する。
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 interface LintPattern {
   readonly name: string;
@@ -105,6 +107,7 @@ interface LintPattern {
   readonly scope?: "line" | "file";
 }
 
+/** @internal Test 専用 export. 本番コードから import しないこと */
 const LINT_PATTERNS: readonly LintPattern[] = [
   {
     name: "old-bg-numeric",
@@ -181,6 +184,7 @@ const LINT_PATTERNS: readonly LintPattern[] = [
   },
 ] as const;
 
+/** @internal Test 専用 export. 本番コードから import しないこと */
 interface Violation {
   readonly file: string;
   readonly line: number;
@@ -197,10 +201,14 @@ interface Violation {
  * - `reason`: 失敗の理由。Node の `NodeJS.ErrnoException.code`
  *   (`ENOENT` / `EACCES` / `EMFILE` 等) をそのまま渡す。code が取得
  *   できない例外は `"unknown"` にフォールバックする
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 type SkipCallback = (path: string, reason: string) => void;
 
 /**
+ * @internal Test 専用 export. 本番コードから import しないこと
+ *
  * `statSync` を try/catch でラップし、対象が存在しない場合は undefined を返す。
  * `collectTargetFiles` / `walkDirectory` の cognitive complexity を抑え、
  * broken symlink 経路でも例外伝播を起こさないようにするための補助関数。
@@ -247,6 +255,8 @@ const tryStat = (
  * 走査対象ファイルとして受理可能か判定する。
  * - 拡張子が `TARGET_EXTENSIONS` に含まれること
  * - `EXCLUDED_FILE_SUFFIXES` のいずれにも該当しないこと
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const isAcceptableFile = (filePath: string): boolean => {
   if (!TARGET_EXTENSIONS.has(extname(filePath))) {
@@ -264,6 +274,8 @@ const isAcceptableFile = (filePath: string): boolean => {
  * 非 `.test.ts` ファイル) が `EXCLUDED_FILE_SUFFIXES` (suffix だけで
  * 判定) を素通りしてしまい、テストコード中の旧 token 言及で CI が
  * 落ちる潜在バグになる (Issue #413 / DA 重大 2 対応)。
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const shouldSkipEntry = (entry: string): boolean => {
   return (
@@ -283,6 +295,8 @@ const shouldSkipEntry = (entry: string): boolean => {
  *   (Issue #621 / N1)
  * @param onSkip 省略可。stat 失敗で skip した場合に呼ばれるコールバック
  *   (Issue #637)。`main()` が件数集計用に渡す
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const walkDirectory = (
   current: string,
@@ -319,6 +333,8 @@ const walkDirectory = (
  *   (scripts/ から実行する都合、`src/` 配下に限ればこれらは出てこないが
  *   将来 PROJECT_ROOT 走査に変えたとき耐えるためガードを入れておく)。
  * - 走査対象が存在しない場合は空配列を返す (例: e2e/ 未配置構成でも壊れない)。
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const collectTargetFiles = (
   target: string,
@@ -373,6 +389,8 @@ interface CommentStripResult {
 /**
  * `stripComments` の状態機械内部状態。
  * 状態ごとのハンドラ間で受け渡される、行内の文字種コンテキスト。
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 interface ScanState {
   inBlockComment: boolean;
@@ -385,6 +403,8 @@ interface ScanState {
  * 1 文字処理後の進行情報。
  * `advance` は追加で消費すべきインデックス数 (0 もしくは 1)。
  * `terminated` が true の場合、その時点で行の処理を打ち切る (行コメント検出時)。
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 interface StepResult {
   readonly advance: number;
@@ -415,6 +435,8 @@ const NO_ADVANCE: StepResult = { advance: 0, terminated: false };
  *
  * @param out **in-out**: 処理後の sanitized 文字を末尾に push する (push only)
  * @param state **in-out**: `inBlockComment` を必要に応じて mutate する
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const handleBlockComment = (
   ch: string,
@@ -438,6 +460,8 @@ const handleBlockComment = (
  * `handleStringLiteral` から閉じクォート文字を直接フィールドキーへ変換できる
  * ようにし、呼び出し側で都度 `closer` クロージャを生成していた micro-allocation
  * を排除する (Issue #621 / M2, M3)。
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 type QuoteChar = "'" | '"' | "`";
 type QuoteStateField = "inSingle" | "inDouble" | "inBacktick";
@@ -458,6 +482,8 @@ const QUOTE_FIELD: Readonly<Record<QuoteChar, QuoteStateField>> = {
  *
  * @param out **in-out**: sanitized 文字を末尾に push する (push only)
  * @param state **in-out**: 終端クォート検出時に対応する `in*` フラグを下ろす
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const handleStringLiteral = (
   ch: string,
@@ -486,6 +512,8 @@ const handleStringLiteral = (
  *
  * @param out **in-out**: sanitized 文字 / 空白を末尾に push する (push only)
  * @param state **in-out**: 検出した状態遷移に応じて `in*` フラグを mutate する
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const handleDefault = (
   ch: string,
@@ -530,6 +558,8 @@ const handleDefault = (
  *
  * @param out **in-out**: 配下ハンドラへそのまま渡される push only バッファ
  * @param state **in-out**: 配下ハンドラへそのまま渡される共有状態
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const processChar = (
   ch: string,
@@ -553,6 +583,7 @@ const processChar = (
   return handleDefault(ch, next, out, state, remainingLength);
 };
 
+/** @internal Test 専用 export. 本番コードから import しないこと */
 const stripComments = (
   line: string,
   state: CommentStripState,
@@ -584,6 +615,8 @@ const stripComments = (
  *
  * `scope: "file"` パターンの match.index (ファイル全体オフセット) から
  * 行番号 / カラム位置 / 元行 snippet を逆引きするのに使う。
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 interface SanitizedFile {
   /** コメント領域を空白に置換したファイル全体テキスト */
@@ -594,6 +627,7 @@ interface SanitizedFile {
   readonly lineStartOffsets: number[];
 }
 
+/** @internal Test 専用 export. 本番コードから import しないこと */
 const sanitizeFile = (content: string): SanitizedFile => {
   const lines = content.split(/\r?\n/);
   const sanitizedLines: string[] = [];
@@ -620,6 +654,8 @@ const sanitizeFile = (content: string): SanitizedFile => {
 /**
  * sanitized 全体オフセットから「何行目の何カラム目か」を逆引きする。
  * lineStartOffsets は昇順なので二分探索で O(log n)。
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const offsetToLineColumn = (
   offset: number,
@@ -649,6 +685,8 @@ const offsetToLineColumn = (
 /**
  * regex.exec を反復し、ヒットごとに `onMatch` を呼ぶ汎用イテレータ。
  * 0 幅マッチによる無限ループを避けるため、lastIndex を強制前進させる。
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const iterateMatches = (
   pattern: RegExp,
@@ -671,6 +709,8 @@ const iterateMatches = (
  * panda.config.ts の `bg: { "0": ... }` のような複数行構造を検出するために使う。
  *
  * @param violations **in-out**: 検出した違反を末尾に push する (Issue #621 / N1)
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const scanFileScope = (
   filePath: string,
@@ -694,6 +734,8 @@ const scanFileScope = (
 };
 
 /**
+ * @internal Test 専用 export. 本番コードから import しないこと
+ *
  * sanitized テキスト上で `lineIndex` 行目に対応する範囲を切り出す。
  * `scanLineScope` の内部ヘルパー。
  *
@@ -725,6 +767,8 @@ const extractSanitizedLine = (
  * 行ごとに sanitized 行を取り出して RegExp を実行し、行 / カラムを直接記録する。
  *
  * @param violations **in-out**: 検出した違反を末尾に push する (Issue #621 / N1)
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const scanLineScope = (
   filePath: string,
@@ -766,6 +810,8 @@ const scanLineScope = (
  *   match.index から逆引きで行 / カラムを出す。
  * - 大文字小文字は区別する (token 名は確定的にケースが決まっている)。
  * - 行コメント / ブロックコメント内は検査対象から除外する (Issue #413)。
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const scanFile = (
   filePath: string,
@@ -791,6 +837,7 @@ const formatViolation = (v: Violation): string => {
   return `${relPath}:${v.line}:${v.column}  [${v.patternName}] ${v.description}\n    ${v.snippet}`;
 };
 
+/** @internal Test 専用 export. 本番コードから import しないこと */
 interface SkipRecord {
   readonly path: string;
   readonly reason: string;
@@ -802,6 +849,8 @@ interface SkipRecord {
  * - 件数 0 の場合は何も出力しない (通常 CI ログのノイズを増やさない)
  * - 件数 > 0 の場合は件数とパス一覧 / reason を 1 行ずつ出力する
  *   ことで、CI ログで grep / scroll 時に skip 異常が一目で分かるようにする
+ *
+ * @internal Test 専用 export. 本番コードから import しないこと
  */
 const reportSkippedTargets = (skipped: readonly SkipRecord[]): void => {
   if (skipped.length === 0) {


### PR DESCRIPTION
## 概要

Issue #636 対応。`scripts/lintTokens.ts` のテスト専用 export すべてに `@internal` JSDoc を一括付与し、「テスト専用 export であり本番コードから import しないこと」を文化的に明示する（PR #621 / Issue #621 DA M-1 follow-up）。

## 変更内容

- `scripts/lintTokens.ts`: 全 export 27 件に `@internal テスト専用 export. 本番コードから import しないこと` の JSDoc を付与
  - 関数 18 個: `collectTargetFiles` / `extractSanitizedLine` / `handleBlockComment` / `handleDefault` / `handleStringLiteral` / `isAcceptableFile` / `iterateMatches` / `offsetToLineColumn` / `processChar` / `reportSkippedTargets` / `sanitizeFile` / `scanFile` / `scanFileScope` / `scanLineScope` / `shouldSkipEntry` / `stripComments` / `tryStat` / `walkDirectory`
  - 定数 1 個: `LINT_PATTERNS`
  - 型 8 個: `LintPattern` / `QuoteChar` / `SanitizedFile` / `ScanState` / `SkipCallback` / `SkipRecord` / `StepResult` / `Violation`
- 振る舞い変更なし（JSDoc 追加のみ）

## 備考

### 公開 API として残した export

なし。`scripts/lintTokens.ts` は CLI スクリプト（shebang `#!/usr/bin/env tsx` 付き）であり、CLI エントリ `main()` は非 export。import 利用者は `scripts/__tests__/lintTokens.test.ts` 1 ファイルのみ（grep 確認済み）。全 export が「テスト専用」のため全件 `@internal` 化が妥当と判断。

### JSDoc 配置と文言の統一（DA / Reviewer 指摘対応）

- 全 27 箇所で `@internal` を JSDoc ブロック末尾（説明文 → 空行 → `@internal` → `*/`）に統一配置（TSDoc 慣例準拠）
- 文言を「テスト専用 export」（カタカナ）に統一し CLAUDE.md「コメントは日本語」規約に整合

### stripInternal の扱い

本 PR は Phase 1 として JSDoc 付与のみ。`tsconfig.json` 側の `stripInternal` 有効化は別 Issue 範疇。

### 検証

- `pnpm lint` / `pnpm type-check` / `pnpm test:run` (978 件) / `pnpm build` 全 pass

Closes #636