### PR TITLE
chore: panda-hash-regression workflow と本番 build の drift 防止に build:ci script を追加 (Closes #528)

### DIFF
--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -54,9 +54,14 @@ jobs:
         continue-on-error: true
         # 既存 hash:true build step (`Build project with hash:true`) と同じく
         # test を二重実行しないため pnpm exec で panda / vite build を呼ぶ。
-        # Issue #528 で議論中の package.json build スクリプトとの drift 問題
-        # は本 issue のスコープ外。両 step で同じコマンド列を使うことで本
-        # workflow 内では一貫性を保つ。
+        #
+        # Issue #528: hash:true build step 側は package.json の `build:ci`
+        # (= `panda && tsc && vite build`) を呼ぶ形に統一済みだが、本 step
+        # は意図的に `build:ci` を使わない。理由は直下 (Issue #625 DA #2) の
+        # とおり baseline build からは tsc を省きたいため。`build:ci` に
+        # 含まれる tsc を流用すると baseline 短縮のメリットが消える。
+        # 短縮を維持するため本 step は `pnpm exec panda && pnpm exec vite
+        # build` を直接呼ぶ運用を継続する。
         #
         # Issue #625 (DA #2): baseline build からは `pnpm exec tsc` を意図的に
         # 省略する。本 step の目的は bundle size 計測のみで、型チェックは
@@ -184,9 +189,14 @@ jobs:
         # pnpm build は内部で `pnpm run lint && pnpm run test:run && pnpm run
         # type-check && panda && tsc && vite build` を呼ぶため、上の test step
         # と二重実行になる。さらに build 内 test 失敗が build regression として
-        # 通知されると原因切り分けが崩れるため、ここでは pnpm exec で生成 /
-        # 型チェック / バンドルだけを 1 回ずつ実行する。
-        run: pnpm exec panda && pnpm exec tsc && pnpm exec vite build
+        # 通知されると原因切り分けが崩れるため、ここでは test / lint を含まない
+        # 専用 script `build:ci` (= `panda && tsc && vite build`) を呼ぶ。
+        # Issue #528: 以前は `pnpm exec panda && pnpm exec tsc && pnpm exec vite
+        # build` を直接書いていたが、本番 `build` script とのコマンド列 drift
+        # を防ぐため package.json 側に `build:ci` を切り出して呼ぶ形に変更
+        # した。`build:ci` は本番 build 経路 (panda + tsc + vite build) と
+        # 等価な軽量版で、test / lint / type-check:scripts は意図的に含めない。
+        run: pnpm run build:ci
 
       - name: Report build regression
         if: steps.tests.outcome == 'success' && steps.build.outcome == 'failure'

--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -69,6 +69,12 @@ jobs:
         # (`Build project with hash:true`) で同じ tree を tsc にかけるため
         # 型 regression は引き続き検知できる。
         # tsc を省くことで baseline build を 30 秒〜数十秒短縮できる。
+        # 注意: baseline (panda + vite build) と hash:true side (build:ci =
+        # panda + tsc + vite build) は実行するコマンド列が非対称になる。
+        # bundle size 比較は最終 bundle に tsc が影響しないため妥当だが、
+        # 所要時間比較は非対称のため不可 (baseline は tsc を含まないため
+        # hash:true より速くなる)。所要時間を将来比較したくなった場合は
+        # 両 step を同一コマンド列に揃えるところから設計し直すこと。
         run: |
           set -euo pipefail
           pnpm exec panda

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,8 @@ Tripwire テスト用に吐く data-* 属性の命名は以下を指針とする
   - CI で `hash:true` 実機検証を回すための workflow は `.github/workflows/panda-hash-regression.yml`（Issue #496 で追加済み）
   - GitHub Actions の "Panda hash:true regression check" workflow から手動 (workflow_dispatch) で実行できる
   - 実行内容: `pnpm test:run` と `panda + tsc + vite build` を `hash: true` で 1 回ずつ実行し、Tripwire 耐性の regression を検知する
+- **`build:ci` script と workflow の整合性メモ（Issue #528）**: hash:true build step は `package.json` の `build:ci` (= `panda && tsc && vite build`, test/lint/type-check:scripts を含まない軽量版) を呼ぶ。`build` script (本番経路) のコマンド列 (`panda && tsc && vite build` 部分) を変更する場合は `build:ci` も同期させること
+  - baseline (hash:false) build step は bundle size 計測専用で tsc を意図的に省く運用 (Issue #625 DA #2) のため `build:ci` ではなく `pnpm exec panda && pnpm exec vite build` を直接呼ぶ非対称運用とする
 
 ### 設定ファイル
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "panda --watch & vite",
     "build": "pnpm run lint && pnpm run test:run && pnpm run type-check && pnpm run type-check:scripts && panda && tsc && vite build",
+    "build:ci": "panda && tsc && vite build",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",


### PR DESCRIPTION
## 概要

Issue #528 対応（案 A 採用）。`.github/workflows/panda-hash-regression.yml` の build step が `pnpm exec panda && pnpm exec tsc && pnpm exec vite build` を直接呼んでおり、将来 `package.json` の `build` script 末尾が変更されると workflow 側が手動同期しないと drift する懸念があった（DA 指摘）。

本 PR で `build:ci` script を `package.json` に追加し、workflow から `pnpm run build:ci` を呼ぶ形に切り替えることで drift を解消する。

## 変更内容

- `package.json`: `build:ci` script を新規追加（`panda && tsc && vite build`）。本番 `build` 末尾と同等の軽量版（lint/test/type-check:scripts 抜き）
- `.github/workflows/panda-hash-regression.yml`:
  - hash:true build step（`Build project with hash:true`）を `pnpm run build:ci` 呼び出しに変更
  - baseline build step（`Build baseline (hash:false)`）は `build:ci` を採用せず `panda + vite build` のまま維持。Issue #625 DA #2 で確立された「bundle size 計測専用なので tsc を意図的に省略」運用を保つため
  - baseline step コメントに「非対称運用の意味論的整合」根拠を追記（bundle size 比較は妥当 / 所要時間比較は不可）
- `CLAUDE.md`: 「Panda `hash:true` の運用判断」セクション末尾に `build:ci` 整合性メモと baseline 非対称運用根拠を 2 行で追記

## 備考

### 案 A 採用根拠

- 案 B（CLAUDE.md 散文ルール）は時間経過で形骸化する公算が高い
- 案 C（何もしない）は drift 検知の手段がゼロのまま

### baseline 非対称運用の根拠

- baseline (hash:false) build は bundle size 計測**のみ**が目的（型チェックは bundle size と直交）
- `build:ci` (tsc 含む) に置換すると tsc 省略による baseline 短縮 (30 秒〜数十秒) のメリットが失われる
- 後段 hash:true build step が同じ tree を tsc にかけるため型 regression 検知は維持される
- bundle size 比較は最終 bundle に tsc が影響しないため妥当（所要時間比較は不可）

### 追従ガード自動化（DA Major #1）

CLAUDE.md 散文記述では drift 再発を半年〜1 年スパンで防げない懸念は残るため、追従ガード自動化を Issue #685 として別途起票済み（軽量 Node スクリプト案 / vitest snapshot 案を比較検討予定）。

### 検証

- `pnpm lint` / `pnpm type-check` / `pnpm test:run` (978 件) / `pnpm run build:ci` / `pnpm build` 全 pass

Closes #528
Related #685 (drift 自動検出 follow-up)