### PR TITLE
refactor: calculateContrast.ts の runChecks 4 責務分割と printReport 純粋関数化 (Closes #651)

### DIFF
--- a/scripts/__tests__/calculateContrast.test.ts
+++ b/scripts/__tests__/calculateContrast.test.ts
@@ -1,24 +1,64 @@
 /**
- * scripts/calculateContrast.ts のヘルパー単体テスト (Issue #623 / S-2 対応)
+ * scripts/calculateContrast.ts のヘルパー単体テスト
+ * (Issue #623 / S-2、Issue #651 / M-2 + M-3 対応)
  *
  * 検証対象:
  *   - buildCsvRow: valid OKLCH ペアで CSV 行を組み立て、invalid 入力で undefined を返す
  *   - emitGithubActionsWarnings: 環境変数 GITHUB_ACTIONS の状態で出力分岐する
+ *   - aggregateResults: NG / マージン僅少 / 合計件数を集計する (M-2)
+ *   - exitOnFailure: NG / --strict 違反時に exit(1)、それ以外で void 復帰する (M-2)
+ *   - dispatchWarnings: aggregated.marginal を emitGithubActionsWarnings に橋渡しする (M-2)
+ *   - formatReportLines: レポート行配列を純粋関数として組み立てる (M-3)
  *
  * 方針:
  *   - 振る舞い単位で 1 ケースずつ書く (TDD)
  *   - 環境変数判定は dead code 化を防ぐため true / false 両ケース検証
  *   - console.log は vi.spyOn で捕獲する
+ *   - process.exit は vi.spyOn で throw に差し替え、捕捉する
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  aggregateResults,
   buildCsvRow,
   type ContrastPair,
   type ContrastResult,
+  dispatchWarnings,
   emitGithubActionsWarnings,
+  exitOnFailure,
+  formatReportLines,
   type NamedColor,
 } from "../calculateContrast.ts";
+
+// =============================================================================
+// ContrastResult ファクトリ (テスト共通)
+// =============================================================================
+
+const buildResult = (
+  name: string,
+  ratio: number,
+  options: { passed?: boolean; marginal?: boolean } = {},
+): ContrastResult => {
+  const passed = options.passed ?? true;
+  const marginal = options.marginal ?? false;
+  const pair: ContrastPair = {
+    name,
+    fg: "oklch(20% 0.02 90)",
+    bg: "oklch(98% 0.02 90)",
+    minRatio: 4.5,
+    category: "body",
+  };
+  return {
+    pair,
+    ratio,
+    fgLuminance: 0.1,
+    bgLuminance: 0.9,
+    aaa: ratio >= 7,
+    aa: ratio >= 4.5,
+    passed,
+    marginal,
+  };
+};
 
 // =============================================================================
 // buildCsvRow
@@ -97,30 +137,6 @@ describe("buildCsvRow", () => {
 // =============================================================================
 
 describe("emitGithubActionsWarnings", () => {
-  const buildResult = (
-    name: string,
-    ratio: number,
-    marginal: boolean,
-  ): ContrastResult => {
-    const pair: ContrastPair = {
-      name,
-      fg: "oklch(20% 0.02 90)",
-      bg: "oklch(98% 0.02 90)",
-      minRatio: 4.5,
-      category: "body",
-    };
-    return {
-      pair,
-      ratio,
-      fgLuminance: 0.1,
-      bgLuminance: 0.9,
-      aaa: ratio >= 7,
-      aa: ratio >= 4.5,
-      passed: ratio >= pair.minRatio,
-      marginal,
-    };
-  };
-
   let logSpy: ReturnType<typeof vi.spyOn>;
   const originalEnv = process.env.GITHUB_ACTIONS;
 
@@ -140,8 +156,8 @@ describe("emitGithubActionsWarnings", () => {
   it("GITHUB_ACTIONS=true でマージン僅少ペアごとに ::warning:: を出力できる", () => {
     process.env.GITHUB_ACTIONS = "true";
     const marginal = [
-      buildResult("pair-a", 7.05, true),
-      buildResult("pair-b", 4.6, true),
+      buildResult("pair-a", 7.05, { marginal: true }),
+      buildResult("pair-b", 4.6, { marginal: true }),
     ];
 
     emitGithubActionsWarnings(marginal);
@@ -159,7 +175,7 @@ describe("emitGithubActionsWarnings", () => {
 
   it("GITHUB_ACTIONS 未設定では何も出力しない", () => {
     delete process.env.GITHUB_ACTIONS;
-    const marginal = [buildResult("pair-a", 7.05, true)];
+    const marginal = [buildResult("pair-a", 7.05, { marginal: true })];
 
     emitGithubActionsWarnings(marginal);
 
@@ -168,7 +184,7 @@ describe("emitGithubActionsWarnings", () => {
 
   it("GITHUB_ACTIONS=false (true 以外の値) では何も出力しない", () => {
     process.env.GITHUB_ACTIONS = "false";
-    const marginal = [buildResult("pair-a", 7.05, true)];
+    const marginal = [buildResult("pair-a", 7.05, { marginal: true })];
 
     emitGithubActionsWarnings(marginal);
 
@@ -181,5 +197,283 @@ describe("emitGithubActionsWarnings", () => {
     emitGithubActionsWarnings([]);
 
     expect(logSpy).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// aggregateResults (M-2)
+// =============================================================================
+
+describe("aggregateResults", () => {
+  it("NG (passed=false) を failed に振り分けられる", () => {
+    const results = [
+      buildResult("p-1", 8.0, { passed: true }),
+      buildResult("p-2", 3.0, { passed: false }),
+    ];
+    const semanticResults = [buildResult("s-1", 2.0, { passed: false })];
+
+    const aggregated = aggregateResults(results, semanticResults);
+
+    expect(aggregated.failed).toHaveLength(2);
+    expect(aggregated.failed.map((r) => r.pair.name)).toEqual(["p-2", "s-1"]);
+  });
+
+  it("passed かつ marginal を marginal に振り分けられる", () => {
+    const results = [
+      buildResult("p-1", 7.05, { passed: true, marginal: true }),
+      buildResult("p-2", 8.0, { passed: true, marginal: false }),
+    ];
+    const semanticResults = [
+      buildResult("s-1", 4.6, { passed: true, marginal: true }),
+    ];
+
+    const aggregated = aggregateResults(results, semanticResults);
+
+    expect(aggregated.marginal).toHaveLength(2);
+    expect(aggregated.marginal.map((r) => r.pair.name)).toEqual(["p-1", "s-1"]);
+  });
+
+  it("passed=false かつ marginal=true は marginal に含めない (NG が優先)", () => {
+    const results = [
+      buildResult("p-1", 4.0, { passed: false, marginal: true }),
+    ];
+
+    const aggregated = aggregateResults(results, []);
+
+    expect(aggregated.failed).toHaveLength(1);
+    expect(aggregated.marginal).toHaveLength(0);
+  });
+
+  it("primitive と semantic を連結した合計件数を total に返す", () => {
+    const results = [
+      buildResult("p-1", 8.0),
+      buildResult("p-2", 8.0),
+      buildResult("p-3", 8.0),
+    ];
+    const semanticResults = [buildResult("s-1", 8.0), buildResult("s-2", 8.0)];
+
+    const aggregated = aggregateResults(results, semanticResults);
+
+    expect(aggregated.total).toBe(5);
+  });
+
+  it("空配列を渡すと failed / marginal が空・total=0 になる", () => {
+    const aggregated = aggregateResults([], []);
+
+    expect(aggregated.failed).toEqual([]);
+    expect(aggregated.marginal).toEqual([]);
+    expect(aggregated.total).toBe(0);
+  });
+});
+
+// =============================================================================
+// exitOnFailure (M-2)
+// =============================================================================
+
+describe("exitOnFailure", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // process.exit を throw に差し替えて、後続コードを止めつつ呼び出しを検証する
+    const mockExit = (code?: number): never => {
+      throw new Error(`process.exit(${code})`);
+    };
+    exitSpy = vi
+      .spyOn(process, "exit")
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+      .mockImplementation(mockExit as any);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("failed が 0 件かつ strict=false なら exit せず void 復帰する", () => {
+    const aggregated = {
+      failed: [] as readonly ContrastResult[],
+      marginal: [] as readonly ContrastResult[],
+      total: 3,
+    };
+
+    expect(() => exitOnFailure(aggregated, false)).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("合計サマリ行を console.log に出力する", () => {
+    const aggregated = {
+      failed: [] as readonly ContrastResult[],
+      marginal: [buildResult("m-1", 7.05, { passed: true, marginal: true })],
+      total: 10,
+    };
+
+    exitOnFailure(aggregated, false);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "合計: 10 / NG: 0 / マージン僅少: 1",
+    );
+  });
+
+  it("failed が 1 件以上あれば process.exit(1) する", () => {
+    const aggregated = {
+      failed: [buildResult("f-1", 3.0, { passed: false })],
+      marginal: [] as readonly ContrastResult[],
+      total: 1,
+    };
+
+    expect(() => exitOnFailure(aggregated, false)).toThrow(
+      "process.exit(1)",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "\nNG ペアあり: AAA / AA を満たしていません",
+    );
+  });
+
+  it("strict=true かつ marginal がある場合は process.exit(1) する", () => {
+    const aggregated = {
+      failed: [] as readonly ContrastResult[],
+      marginal: [buildResult("m-1", 7.05, { passed: true, marginal: true })],
+      total: 1,
+    };
+
+    expect(() => exitOnFailure(aggregated, true)).toThrow("process.exit(1)");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "\n--strict 指定: マージン僅少ペアあり",
+    );
+  });
+
+  it("strict=true でも marginal が空なら exit しない", () => {
+    const aggregated = {
+      failed: [] as readonly ContrastResult[],
+      marginal: [] as readonly ContrastResult[],
+      total: 1,
+    };
+
+    expect(() => exitOnFailure(aggregated, true)).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// dispatchWarnings (M-2)
+// =============================================================================
+
+describe("dispatchWarnings", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  const originalEnv = process.env.GITHUB_ACTIONS;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    if (originalEnv === undefined) {
+      delete process.env.GITHUB_ACTIONS;
+    } else {
+      process.env.GITHUB_ACTIONS = originalEnv;
+    }
+  });
+
+  it("aggregated.marginal を emitGithubActionsWarnings に橋渡しできる", () => {
+    process.env.GITHUB_ACTIONS = "true";
+    const aggregated = {
+      failed: [] as readonly ContrastResult[],
+      marginal: [buildResult("m-1", 7.05, { passed: true, marginal: true })],
+      total: 1,
+    };
+
+    dispatchWarnings(aggregated);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      "::warning::マージン僅少 ratio=7.05 m-1",
+    );
+  });
+
+  it("GITHUB_ACTIONS 未設定なら何も出力しない", () => {
+    delete process.env.GITHUB_ACTIONS;
+    const aggregated = {
+      failed: [] as readonly ContrastResult[],
+      marginal: [buildResult("m-1", 7.05, { passed: true, marginal: true })],
+      total: 1,
+    };
+
+    dispatchWarnings(aggregated);
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// formatReportLines (M-3)
+// =============================================================================
+
+describe("formatReportLines", () => {
+  it("ヘッダ行 / 閾値行 / セクション見出しの順で行を組み立てる", () => {
+    const lines = formatReportLines([], []);
+
+    expect(lines[0]).toBe("== Editorial Citrus AAA コントラスト実測 ==");
+    expect(lines[1]).toMatch(/^本文閾値: .* \/ 大文字: .*$/);
+    expect(lines[2]).toBe("");
+    expect(lines[3]).toBe("[primitive ペア]");
+    expect(lines[4]).toBe("");
+    expect(lines[5]).toBe("[semantic トークン整合性]");
+  });
+
+  it("primitive / semantic ペア各 1 件で 8 行を返す (header4 + p1 + blank + sem-header + s1)", () => {
+    const results = [buildResult("p-1", 8.0, { passed: true })];
+    const semanticResults = [buildResult("s-1", 8.0, { passed: true })];
+
+    const lines = formatReportLines(results, semanticResults);
+
+    // header(1) + threshold(1) + blank(1) + section(1) + p1(1) + blank(1) + section(1) + s1(1)
+    expect(lines).toHaveLength(8);
+    expect(lines[4]).toContain("p-1");
+    expect(lines[7]).toContain("s-1");
+  });
+
+  it("純粋関数として副作用を持たない (console.log を呼ばない)", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      formatReportLines(
+        [buildResult("p-1", 8.0)],
+        [buildResult("s-1", 8.0)],
+      );
+      expect(logSpy).not.toHaveBeenCalled();
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("passed=true で OK マーカ、passed=false で NG マーカを行に含める", () => {
+    const results = [
+      buildResult("ok-pair", 8.0, { passed: true }),
+      buildResult("ng-pair", 2.0, { passed: false }),
+    ];
+
+    const lines = formatReportLines(results, []);
+
+    const okLine = lines.find((l) => l.includes("ok-pair"));
+    const ngLine = lines.find((l) => l.includes("ng-pair"));
+    expect(okLine).toMatch(/OK /);
+    expect(ngLine).toMatch(/NG /);
+  });
+
+  it("marginal=true のペアには (margin<5%) サフィックスを付与する", () => {
+    const results = [
+      buildResult("marginal-pair", 7.05, { passed: true, marginal: true }),
+    ];
+
+    const lines = formatReportLines(results, []);
+
+    const marginalLine = lines.find((l) => l.includes("marginal-pair"));
+    expect(marginalLine).toContain("(margin<5%)");
   });
 });

--- a/scripts/calculateContrast.ts
+++ b/scripts/calculateContrast.ts
@@ -391,6 +391,28 @@ const getContrastPairs = (): readonly ContrastPair[] => {
 // =============================================================================
 
 /**
+ * WCAG 2.x 仕様値の AAA / AA / AA-large 閾値。
+ *
+ * `contrastThresholds.bodyText` (= 7.20) はプロジェクト独自の本文運用閾値
+ * (AAA 7.00 + 1〜2% マージン) であり、WCAG 規定値そのものではない。
+ * CSV 出力の `verdict` / `aaa` / `aa` 列および `computeContrast` の
+ * `aaa` / `aa` フラグは **WCAG 規定値** での判定が必要なため、運用閾値とは
+ * 別の定数として保持する (Issue #651 / N-1)。
+ *
+ * `contrastThresholds.largeText` (= 4.50) は WCAG AA 値と一致するため
+ * 同じ値を再利用する。由来 (運用閾値 vs WCAG 規定) を区別するため別シンボル
+ * を用意し、`WCAG_AA_RATIO` だけは `contrastThresholds.largeText` を経由する
+ * (= 値の一意性を保証する)。AAA / AA-large は WCAG 規定値そのままを置く。
+ *
+ * これらの値を変更すると `docs/contrast-matrix.csv` の `verdict` / `aaa` /
+ * `aa` 列が変わるため、CSV ベースの regression テストが壊れる。値の変更は
+ * WCAG 仕様改定時のみに限ること。
+ */
+const WCAG_AAA_RATIO = 7.0;
+const WCAG_AA_RATIO = contrastThresholds.largeText;
+const WCAG_AA_LARGE_RATIO = 3.0;
+
+/**
  * 単一ペアのコントラスト比を WCAG 2.x 仕様で計算する。
  *
  * 実体は culori の `wcagContrast` で、(L1 + 0.05) / (L2 + 0.05)
@@ -412,8 +434,8 @@ const computeContrast = (pair: ContrastPair): ContrastResult => {
   const fgLuminance = wcagLuminance(fgColor);
   const bgLuminance = wcagLuminance(bgColor);
 
-  const aaa = ratio >= 7.0;
-  const aa = ratio >= 4.5;
+  const aaa = ratio >= WCAG_AAA_RATIO;
+  const aa = ratio >= WCAG_AA_RATIO;
   const passed = ratio >= pair.minRatio;
   const marginal =
     pair.minRatio > 0 &&
@@ -507,13 +529,13 @@ const collectMatrixColors = (): {
 };
 
 const verdict = (ratio: number): string => {
-  if (ratio >= 7.0) {
+  if (ratio >= WCAG_AAA_RATIO) {
     return "AAA";
   }
-  if (ratio >= 4.5) {
+  if (ratio >= WCAG_AA_RATIO) {
     return "AA";
   }
-  if (ratio >= 3.0) {
+  if (ratio >= WCAG_AA_LARGE_RATIO) {
     return "AA-large";
   }
   return "FAIL";
@@ -527,8 +549,8 @@ const formatCsvRow = (
   fg: NamedColor,
   ratio: number,
 ): string => {
-  const aaa = ratio >= 7.0 ? "yes" : "no";
-  const aa = ratio >= 4.5 ? "yes" : "no";
+  const aaa = ratio >= WCAG_AAA_RATIO ? "yes" : "no";
+  const aa = ratio >= WCAG_AA_RATIO ? "yes" : "no";
   return [
     surface.label,
     fg.label,
@@ -548,6 +570,8 @@ const formatCsvRow = (
  * では sentinel として `undefined` を返し、行をスキップさせる。
  *
  * テストから import するため export する (S-2 / Issue #623)。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 export const buildCsvRow = (
   surface: NamedColor,
@@ -731,23 +755,46 @@ const formatRow = (result: ContrastResult): string => {
   return `  ${marker}[${verdictTag}] ${ratioStr}:1 (>= ${minStr}) ${result.pair.name}${marginalTag}`;
 };
 
+/**
+ * レポート出力に流し込む行配列を構築する純粋関数 (M-3 / Issue #651)。
+ *
+ * `printReport` を I/O (console.log) と整形ロジックに分離するための中核関数。
+ * 戻り値を 1 行ずつ `console.log` に流し込むと従来の `printReport` と同じ
+ * 出力になる (= レポート出力の master 完全一致を保証する)。
+ *
+ * 純粋関数であるため副作用 (console.log / 環境変数参照) を持たず、行配列を
+ * そのまま assert できる。レポート整形の単体テストはこの関数を対象に書く。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+export const formatReportLines = (
+  results: readonly ContrastResult[],
+  semanticResults: readonly ContrastResult[],
+): readonly string[] => {
+  const lines: string[] = [];
+  lines.push("== Editorial Citrus AAA コントラスト実測 ==");
+  lines.push(
+    `本文閾値: ${contrastThresholds.bodyText} / 大文字: ${contrastThresholds.largeText}`,
+  );
+  lines.push("");
+  lines.push("[primitive ペア]");
+  for (const result of results) {
+    lines.push(formatRow(result));
+  }
+  lines.push("");
+  lines.push("[semantic トークン整合性]");
+  for (const result of semanticResults) {
+    lines.push(formatRow(result));
+  }
+  return lines;
+};
+
 const printReport = (
   results: readonly ContrastResult[],
   semanticResults: readonly ContrastResult[],
 ): void => {
-  console.log("== Editorial Citrus AAA コントラスト実測 ==");
-  console.log(
-    `本文閾値: ${contrastThresholds.bodyText} / 大文字: ${contrastThresholds.largeText}`,
-  );
-  console.log("");
-  console.log("[primitive ペア]");
-  for (const result of results) {
-    console.log(formatRow(result));
-  }
-  console.log("");
-  console.log("[semantic トークン整合性]");
-  for (const result of semanticResults) {
-    console.log(formatRow(result));
+  for (const line of formatReportLines(results, semanticResults)) {
+    console.log(line);
   }
 };
 
@@ -761,6 +808,8 @@ const printReport = (
  * テストから import するため export する (S-2 / Issue #623)。
  * 環境変数で挙動分岐するため、両ケース (true / false) を単体テストで担保し
  * 環境変数判定の dead code 化を防ぐ。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
  */
 export const emitGithubActionsWarnings = (
   marginal: readonly ContrastResult[],
@@ -775,29 +824,88 @@ export const emitGithubActionsWarnings = (
   }
 };
 
+/**
+ * 集計結果。primitive ペアと semantic ペアを連結した allResults を
+ * NG / マージン僅少 / 全件配列に分解した形で保持する。
+ *
+ * 集計ロジックを純粋関数化することで、exit 判定や warning dispatch から
+ * 切り離してテスト可能にする (M-2 / Issue #651)。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+export interface AggregatedResults {
+  readonly failed: readonly ContrastResult[];
+  readonly marginal: readonly ContrastResult[];
+  readonly total: number;
+}
+
+/**
+ * primitive ペアと semantic ペアを連結し、NG / マージン僅少を集計する
+ * 純粋関数 (M-2 / Issue #651)。
+ *
+ * 副作用なし。同じ入力に対して常に同じ出力を返す。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+export const aggregateResults = (
+  results: readonly ContrastResult[],
+  semanticResults: readonly ContrastResult[],
+): AggregatedResults => {
+  const allResults = [...results, ...semanticResults];
+  const failed = allResults.filter((r) => !r.passed);
+  const marginal = allResults.filter((r) => r.passed && r.marginal);
+  return { failed, marginal, total: allResults.length };
+};
+
+/**
+ * 集計結果をサマリ行として標準出力に流し込み、NG / --strict 違反があれば
+ * `process.exit(1)` する (M-2 / Issue #651)。
+ *
+ * `process.exit` は型的に `never` を返しうるが、NG 0 件かつ非 strict 条件下では
+ * `void` 復帰する。「`never | void`」を表現するため返り値型は付けない (= void)。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+export const exitOnFailure = (
+  aggregated: AggregatedResults,
+  strict: boolean,
+): void => {
+  console.log("");
+  console.log(
+    `合計: ${aggregated.total} / NG: ${aggregated.failed.length} / マージン僅少: ${aggregated.marginal.length}`,
+  );
+
+  if (aggregated.failed.length > 0) {
+    console.error("\nNG ペアあり: AAA / AA を満たしていません");
+    process.exit(1);
+  }
+  if (strict && aggregated.marginal.length > 0) {
+    console.error("\n--strict 指定: マージン僅少ペアあり");
+    process.exit(1);
+  }
+};
+
+/**
+ * マージン僅少ペアを `emitGithubActionsWarnings` 経由で
+ * GitHub Actions の `::warning::` 行として出力する (M-2 / Issue #651)。
+ *
+ * 単純な薄ラッパーだが、`runChecks` から「warning dispatch 責務」を明示的に
+ * 切り出すことで、計算 / 集計 / exit / warning の各責務を 1 関数 = 1 責務に揃える。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+export const dispatchWarnings = (aggregated: AggregatedResults): void => {
+  emitGithubActionsWarnings(aggregated.marginal);
+};
+
 const runChecks = (strict: boolean): void => {
   const results = getContrastPairs().map(computeContrast);
   const semanticResults = verifySemanticPairs();
   printReport(results, semanticResults);
 
-  const allResults = [...results, ...semanticResults];
-  const failed = allResults.filter((r) => !r.passed);
-  const marginal = allResults.filter((r) => r.passed && r.marginal);
-
-  console.log("");
-  console.log(
-    `合計: ${allResults.length} / NG: ${failed.length} / マージン僅少: ${marginal.length}`,
-  );
-
-  if (failed.length > 0) {
-    console.error("\nNG ペアあり: AAA / AA を満たしていません");
-    process.exit(1);
-  }
-  if (strict && marginal.length > 0) {
-    console.error("\n--strict 指定: マージン僅少ペアあり");
-    process.exit(1);
-  }
-  emitGithubActionsWarnings(marginal);
+  const aggregated = aggregateResults(results, semanticResults);
+  exitOnFailure(aggregated, strict);
+  dispatchWarnings(aggregated);
 };
 
 const main = (): void => {


### PR DESCRIPTION
## 概要

Issue #651 対応（PR #623 / Issue #623 follow-up）。`scripts/calculateContrast.ts` の `runChecks` が「compute + report 呼び出し + 集計 + exit 判定 + warning dispatch」の 4 責務を持っていたため、責務分割と純粋関数化を実施。CSV / レポート / --strict 出力は master と完全一致（md5 検証済み）。

## 変更内容

### 抽出した新規 export （`scripts/calculateContrast.ts`）

- `aggregateResults(results, semanticResults): AggregatedResults` (M-2): 集計のみ、純粋関数
- `exitOnFailure(aggregated, strict): void` (M-2): exit 判定 + サマリ出力
- `dispatchWarnings(aggregated): void` (M-2): GitHub Actions warning dispatch
- `formatReportLines(results, semanticResults): readonly string[]` (M-3): レポート文字列を組み立てる純粋関数
- `interface AggregatedResults { failed, marginal, total }` (M-2 型)
- `printReport` は `formatReportLines(...).forEach(console.log)` の薄ラッパーへ縮退
- `runChecks` は compute → printReport → 3 ヘルパー呼び出しのみに痩せた（8 行）

すべての新規 + 既存テスト用 export に `@internal テスト専用 export. 本番コードから import しないこと` を付与（PR #684 の `lintTokens.ts` 方針と統一）。

### 閾値定数の一元化 (N-1)

Issue 本文は「`formatCsvRow` 内の 7.0 / 4.5 を `contrastThresholds.bodyText` (7.2) / `contrastThresholds.largeText` (4.5) から import」と書かれていたが、`bodyText = 7.2` は**運用閾値**で WCAG 規定値 7.0 と乖離。文字通り実装すると CSV の `aaa` 列が変わり受け入れ基準（CSV 完全一致）違反になるため、**WCAG 規定値定数 `WCAG_AAA_RATIO` / `WCAG_AA_RATIO` / `WCAG_AA_LARGE_RATIO` を `calculateContrast.ts` 内に新設**して一元化（`WCAG_AA_RATIO` は `contrastThresholds.largeText` を再利用、`WCAG_AAA_RATIO = 7.0` は WCAG 規定値）。判断根拠は当該定数の JSDoc に記載。

結果: 運用閾値 (`contrastThresholds`) と WCAG 規定値 (`WCAG_*_RATIO`) が**意図的に二系統共存**する形になった。これは「一元化の半達成」だが、二系統の理由を JSDoc で追跡可能にした。

### テスト追加（`scripts/__tests__/calculateContrast.test.ts`）

7 件 → 24 件 (+17 件):
- `aggregateResults`: 5 ケース
- `exitOnFailure`: 5 ケース（`process.exit` を throw 差し替え mock で捕捉）
- `dispatchWarnings`: 2 ケース
- `formatReportLines`: 5 ケース（純粋関数性も観測）

## 備考

### CSV / レポート完全一致（AC）

master baseline と md5 完全一致を実機検証:
- report: `c6b8dbdb425c205f2c15eeefa6f891b6`
- csv: `5fd0823ce2e6c65f14ce46ff2200b106`
- --strict: `a56c1db7cb21927666145201916b6bf8` (exit 1, 仕様通り)

### follow-up

- DA Minor #1 (`exitOnFailure` の二重責務 = exit 判定 + サマリ出力) は Issue #688 として別途起票済み

### 検証

- `pnpm lint` / `pnpm type-check` / `pnpm test:run` (995 件) / `pnpm build` 全 pass

Closes #651
Related #688 (exitOnFailure 二重責務分離 follow-up)