### PR TITLE
refactor: calculateContrast.ts の exitOnFailure から printSummary を分離 (Closes #688)

### DIFF
--- a/scripts/__tests__/calculateContrast.test.ts
+++ b/scripts/__tests__/calculateContrast.test.ts
@@ -1,11 +1,12 @@
 /**
  * scripts/calculateContrast.ts のヘルパー単体テスト
- * (Issue #623 / S-2、Issue #651 / M-2 + M-3 対応)
+ * (Issue #623 / S-2、Issue #651 / M-2 + M-3、Issue #688 対応)
  *
  * 検証対象:
  *   - buildCsvRow: valid OKLCH ペアで CSV 行を組み立て、invalid 入力で undefined を返す
  *   - emitGithubActionsWarnings: 環境変数 GITHUB_ACTIONS の状態で出力分岐する
  *   - aggregateResults: NG / マージン僅少 / 合計件数を集計する (M-2)
+ *   - printSummary: 合計サマリ行 (空行 + 合計行) を console.log に出力する (Issue #688)
  *   - exitOnFailure: NG / --strict 違反時に exit(1)、それ以外で void 復帰する (M-2)
  *   - dispatchWarnings: aggregated.marginal を emitGithubActionsWarnings に橋渡しする (M-2)
  *   - formatReportLines: レポート行配列を純粋関数として組み立てる (M-3)
@@ -28,6 +29,7 @@ import {
   exitOnFailure,
   formatReportLines,
   type NamedColor,
+  printSummary,
 } from "../calculateContrast.ts";
 
 // =============================================================================
@@ -267,7 +269,75 @@ describe("aggregateResults", () => {
 });
 
 // =============================================================================
-// exitOnFailure (M-2)
+// printSummary (Issue #688: exitOnFailure からサマリ出力の責務を分離)
+// =============================================================================
+
+describe("printSummary", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("合計サマリ行を console.log に出力する", () => {
+    const aggregated = {
+      failed: [] as readonly ContrastResult[],
+      marginal: [buildResult("m-1", 7.05, { passed: true, marginal: true })],
+      total: 10,
+    };
+
+    printSummary(aggregated);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "合計: 10 / NG: 0 / マージン僅少: 1",
+    );
+  });
+
+  it("空行 → 合計行の順で 2 回 console.log を呼ぶ (master 出力順を維持)", () => {
+    const aggregated = {
+      failed: [] as readonly ContrastResult[],
+      marginal: [] as readonly ContrastResult[],
+      total: 3,
+    };
+
+    printSummary(aggregated);
+
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy).toHaveBeenNthCalledWith(1, "");
+    expect(logSpy).toHaveBeenNthCalledWith(
+      2,
+      "合計: 3 / NG: 0 / マージン僅少: 0",
+    );
+  });
+
+  it("failed / marginal の件数をサマリ行に反映する", () => {
+    const aggregated = {
+      failed: [
+        buildResult("f-1", 3.0, { passed: false }),
+        buildResult("f-2", 2.0, { passed: false }),
+      ],
+      marginal: [
+        buildResult("m-1", 7.05, { passed: true, marginal: true }),
+        buildResult("m-2", 4.6, { passed: true, marginal: true }),
+        buildResult("m-3", 7.1, { passed: true, marginal: true }),
+      ],
+      total: 20,
+    };
+
+    printSummary(aggregated);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "合計: 20 / NG: 2 / マージン僅少: 3",
+    );
+  });
+});
+
+// =============================================================================
+// exitOnFailure (M-2、Issue #688 でサマリ出力を分離)
 // =============================================================================
 
 describe("exitOnFailure", () => {
@@ -305,7 +375,7 @@ describe("exitOnFailure", () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
-  it("合計サマリ行を console.log に出力する", () => {
+  it("サマリ行は出力しない (printSummary に分離済み)", () => {
     const aggregated = {
       failed: [] as readonly ContrastResult[],
       marginal: [buildResult("m-1", 7.05, { passed: true, marginal: true })],
@@ -314,9 +384,7 @@ describe("exitOnFailure", () => {
 
     exitOnFailure(aggregated, false);
 
-    expect(logSpy).toHaveBeenCalledWith(
-      "合計: 10 / NG: 0 / マージン僅少: 1",
-    );
+    expect(logSpy).not.toHaveBeenCalled();
   });
 
   it("failed が 1 件以上あれば process.exit(1) する", () => {

--- a/scripts/calculateContrast.ts
+++ b/scripts/calculateContrast.ts
@@ -858,8 +858,34 @@ export const aggregateResults = (
 };
 
 /**
- * 集計結果をサマリ行として標準出力に流し込み、NG / --strict 違反があれば
- * `process.exit(1)` する (M-2 / Issue #651)。
+ * 集計結果をサマリ行 (空行 + `合計: N / NG: M / マージン僅少: K` 行) として
+ * 標準出力に流し込む (Issue #688 で `exitOnFailure` から責務分離)。
+ *
+ * `exitOnFailure` から「console.log によるサマリ表示」の副作用を切り出し、
+ * `exitOnFailure` を exit 判定 (`failed` / `strict + marginal` を見て
+ * `process.exit(1)` する) だけに痩せさせるための関数。純粋関数ではないが
+ * 副作用は `console.log` のみに単一化されている。
+ *
+ * 出力順は呼び出し側 (`runChecks`) で `printSummary` → `exitOnFailure` の順に
+ * 呼ぶ前提で master の出力 (空行 → 合計行 → (NG 時) エラーメッセージ → exit)
+ * と完全一致させる。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+export const printSummary = (aggregated: AggregatedResults): void => {
+  console.log("");
+  console.log(
+    `合計: ${aggregated.total} / NG: ${aggregated.failed.length} / マージン僅少: ${aggregated.marginal.length}`,
+  );
+};
+
+/**
+ * 集計結果から NG / --strict 違反を検知し、該当すれば
+ * `process.exit(1)` する (M-2 / Issue #651、Issue #688 でサマリ出力を分離)。
+ *
+ * サマリ行 (`合計: ...`) の出力は `printSummary` に分離済み。本関数は exit 判定
+ * のみを行う。`failed.length > 0` で必ず exit、`strict=true` かつ
+ * `marginal.length > 0` でも exit する。
  *
  * `process.exit` は型的に `never` を返しうるが、NG 0 件かつ非 strict 条件下では
  * `void` 復帰する。「`never | void`」を表現するため返り値型は付けない (= void)。
@@ -870,11 +896,6 @@ export const exitOnFailure = (
   aggregated: AggregatedResults,
   strict: boolean,
 ): void => {
-  console.log("");
-  console.log(
-    `合計: ${aggregated.total} / NG: ${aggregated.failed.length} / マージン僅少: ${aggregated.marginal.length}`,
-  );
-
   if (aggregated.failed.length > 0) {
     console.error("\nNG ペアあり: AAA / AA を満たしていません");
     process.exit(1);
@@ -904,6 +925,7 @@ const runChecks = (strict: boolean): void => {
   printReport(results, semanticResults);
 
   const aggregated = aggregateResults(results, semanticResults);
+  printSummary(aggregated);
   exitOnFailure(aggregated, strict);
   dispatchWarnings(aggregated);
 };


### PR DESCRIPTION
## 概要

Issue #688 対応（PR #689 / Issue #651 DA Minor #1 follow-up）。`scripts/calculateContrast.ts` の `exitOnFailure` の責務に「合計サマリ行の `console.log` 出力」が同居していたため、案 A 採用で `printSummary` を分離抽出し `exitOnFailure` を exit 判定のみに痩せる。

## 変更内容

### `scripts/calculateContrast.ts`

- 新規 export `printSummary(aggregated: AggregatedResults): void`: 空行 + 合計行 (`合計: N / NG: M / マージン僅少: K`) の 2 行を `console.log` に流す。`@internal テスト専用 export. 本番コードから import しないこと` JSDoc 付与（既存 7 export と統一文言）
- `exitOnFailure(aggregated, strict): void`: `console.log` 2 行を剥がし、`failed.length > 0` → exit(1) / `strict && marginal.length > 0` → exit(1) の判定のみに痩せる
- `runChecks` 内で `printReport` → `aggregateResults` → `printSummary` → `exitOnFailure` → `dispatchWarnings` の順で呼ぶ（master 出力順を厳密に維持）

### `scripts/__tests__/calculateContrast.test.ts`

- 新規 `printSummary` describe: 3 ケース
  - 合計サマリ行を console.log に出力する
  - 空行 → 合計行の順で 2 回 console.log を呼ぶ (master 出力順を維持)
  - failed / marginal の件数をサマリ行に反映する
- `exitOnFailure` 側: 「サマリ行は出力しない (printSummary に分離済み)」regression ガードに転用（責務分離の双方向 regression 検知）

## 備考

### CSV / レポート完全一致（AC）

master HEAD と md5 完全一致を実機検証:
- `--csv`: `5fd0823ce2e6c65f14ce46ff2200b106` 一致
- レポート: `c6b8dbdb425c205f2c15eeefa6f891b6` 一致
- `--strict`: `a56c1db7cb21927666145201916b6bf8` 一致 (exit=0)

### 責務分離の評価

- `printSummary` は副作用が `console.log` 2 回に閉じており、JSDoc で「純粋関数ではない」旨を明示
- `exitOnFailure` は名前と責務が一致（exit 判定のみ）
- 呼び出し箇所は `runChecks` のみで、テストでは独立に検証

### 検証

- `pnpm lint` / `pnpm type-check` / `pnpm test:run` (1006 件) / `pnpm build` 全 pass

Closes #688