### PR TITLE
refactor: inferPublishedAt の戻り値型を string | undefined に統一 (Closes #682)

### DIFF
--- a/scripts/newPost.ts
+++ b/scripts/newPost.ts
@@ -419,12 +419,8 @@ export const findPreviousPost = (
     return undefined;
   }
   const latest = candidates[candidates.length - 1];
-  // inferPublishedAt は外部 (src/lib/anchors.ts) の API で戻り値が
-  // `string | null` であるため、ここでの null 比較は外部 API との整合上
-  // 維持する (Issue #622)。`== null` のゆるい比較で undefined も拾える
-  // 形に揃える。
   const publishedAt = inferPublishedAt(latest);
-  if (publishedAt == null) {
+  if (publishedAt === undefined) {
     return undefined;
   }
   const filePath = join(datasourcesDir, latest);
@@ -452,12 +448,8 @@ export const computeSiteOpeningFallback = (
     return undefined;
   }
   const oldest = files[0];
-  // inferPublishedAt は外部 (src/lib/anchors.ts) の API で戻り値が
-  // `string | null` であるため、ここでの null 比較は外部 API との整合上
-  // 維持する (Issue #622)。`== null` のゆるい比較で undefined も拾える
-  // 形に揃える。
   const oldestIso = inferPublishedAt(oldest);
-  if (oldestIso == null) {
+  if (oldestIso === undefined) {
     return undefined;
   }
   return computeElapsed(publishedAt, oldestIso.slice(0, 10), "サイト開設");
@@ -566,11 +558,7 @@ const createNewPost = (): void => {
     const publishedAt = inferPublishedAt(fileName);
 
     let ignitionComment = "";
-    // inferPublishedAt は外部 (src/lib/anchors.ts) の API で戻り値が
-    // `string | null` であるため、ここでの null 比較は外部 API との整合上
-    // 維持する (Issue #622)。`== null` のゆるい比較で undefined も拾える
-    // 形に揃える。
-    if (publishedAt != null) {
+    if (publishedAt !== undefined) {
       const milestonesPath = join(datasourcesDir, "milestones.json");
       const milestones = loadMilestones(milestonesPath);
 

--- a/src/components/common/Coordinate.tsx
+++ b/src/components/common/Coordinate.tsx
@@ -10,8 +10,8 @@ interface CoordinateProps {
   /**
    * 記事の公開日時 (ISO 8601 / JST 想定)。
    *
-   * 親 (PostDetailPage) で `inferPublishedAt(post.id)` を呼び、null でない値を
-   * 渡すこと。null や不正値は本コンポーネントの責務範囲外で、上位で弾く。
+   * 親 (PostDetailPage) で `inferPublishedAt(post.id)` を呼び、undefined でない値を
+   * 渡すこと。undefined や不正値は本コンポーネントの責務範囲外で、上位で弾く。
    *
    * publishedAt 以降 (未来) の節目は `computeCoordinates` 側で除外される。
    */

--- a/src/components/common/__tests__/Coordinate.allPosts.test.tsx
+++ b/src/components/common/__tests__/Coordinate.allPosts.test.tsx
@@ -287,7 +287,7 @@ describe("Coordinate (実16記事での回帰テスト)", () => {
     it("milestones が空配列なら全 16 記事で非表示になる", () => {
       for (const postId of postIds) {
         const publishedAt = inferPublishedAt(postId);
-        if (publishedAt === null) {
+        if (publishedAt === undefined) {
           continue;
         }
 
@@ -308,7 +308,7 @@ describe("Coordinate (実16記事での回帰テスト)", () => {
 
       for (const postId of postIds) {
         const publishedAt = inferPublishedAt(postId);
-        if (publishedAt === null) {
+        if (publishedAt === undefined) {
           continue;
         }
 
@@ -329,7 +329,7 @@ describe("Coordinate (実16記事での回帰テスト)", () => {
 
       for (const postId of postIds) {
         const publishedAt = inferPublishedAt(postId);
-        if (publishedAt === null) {
+        if (publishedAt === undefined) {
           continue;
         }
 

--- a/src/components/pages/AnchorPage.tsx
+++ b/src/components/pages/AnchorPage.tsx
@@ -77,7 +77,7 @@ interface AnchorPageProps {
  * - 節目の tone は `data-tone` 属性で表現する (色だけに依存させない)
  *
  * publishedAt 推定不可なスキップ件数注記 (Issue #544):
- * - `inferPublishedAt(post.id) === null` で除外された記事の件数を、各記事の座標
+ * - `inferPublishedAt(post.id) === undefined` で除外された記事の件数を、各記事の座標
  *   section 末尾に「publishedAt 推定不可でスキップした記事: N 件」と控えめに表示する
  * - 0 件のときは注記そのものを出さない (= ノイズ削減 + 運用画面の静かなトーン維持)
  * - `role="note"` で補助情報であることを意味的に示す。件数は注記テキスト本体に
@@ -327,7 +327,7 @@ const buildPostCoordinatesEntries = (
   const entries: PostCoordinatesEntry[] = [];
   for (const post of posts) {
     const publishedAt = inferPublishedAt(post.id);
-    if (publishedAt === null) {
+    if (publishedAt === undefined) {
       continue;
     }
     const coordinates = computeCoordinates(publishedAt, milestones);

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -69,7 +69,7 @@ export const PostDetailPage = ({
 
   // Coordinate (Issue #491): post.id (= ファイル名 YYYYMMDDhhmmss) から
   // publishedAt を ISO 8601 (JST +09:00) として逆算する。タイムスタンプ形式に
-  // 適合しない id (例: テスト用 "test-post") の場合は null となり、Coordinate
+  // 適合しない id (例: テスト用 "test-post") の場合は undefined となり、Coordinate
   // は何も描画しない (= 撤退可能性の一形態として無害な早期 return が成立する)。
   const publishedAt = inferPublishedAt(post.id);
   return (
@@ -179,7 +179,7 @@ export const PostDetailPage = ({
                * milestones 空・showCoordinate=false のいずれかで何も描画
                * しない (Coordinate 内部で early return)。
                */}
-              {publishedAt !== null && (
+              {publishedAt !== undefined && (
                 <Coordinate
                   publishedAt={publishedAt}
                   milestones={milestones}

--- a/src/components/pages/__tests__/AnchorPage.test.tsx
+++ b/src/components/pages/__tests__/AnchorPage.test.tsx
@@ -177,7 +177,7 @@ describe("AnchorPage", () => {
     });
 
     it("publishedAt 推定不可な id の記事 (テスト用 id 等) はスキップして描画しない", () => {
-      // YYYYMMDDhhmmss 形式でない id は inferPublishedAt が null を返すため、
+      // YYYYMMDDhhmmss 形式でない id は inferPublishedAt が undefined を返すため、
       // 座標を計算できない。AnchorPage はそのような記事を素直にスキップする。
       const invalidPost: PostSummary = {
         id: "test-invalid-id",

--- a/src/components/pages/__tests__/PostDetailPage.test.tsx
+++ b/src/components/pages/__tests__/PostDetailPage.test.tsx
@@ -481,7 +481,7 @@ describe("PostDetailPage", () => {
 
     it("post.id がタイムスタンプ形式でない (publishedAt 推定不可) ときは Coordinate を描画しない", () => {
       // mockPost.id="test-post" は YYYYMMDDhhmmss にマッチしないため
-      // inferPublishedAt が null を返し、Coordinate は描画されない
+      // inferPublishedAt が undefined を返し、Coordinate は描画されない
       render(
         <MemoryRouter>
           <PostDetailPage
@@ -601,7 +601,7 @@ describe("PostDetailPage", () => {
 
     it("publishedAt 推定不可 (非タイムスタンプ id) の PostDetailPage 全体で axe a11y 違反が 0 件である", async () => {
       // mockPost.id="test-post" は YYYYMMDDhhmmss にマッチせず inferPublishedAt
-      // が null を返すため、PostDetailPage 側の条件分岐 (publishedAt !== null)
+      // が undefined を返すため、PostDetailPage 側の条件分岐 (publishedAt !== undefined)
       // で Coordinate 自体がレンダーされない経路。Coordinate 内部の early
       // return とは別の境界 (= 親の条件分岐) で違反が生じないことを保証する。
       const { container } = render(

--- a/src/lib/__tests__/anchors.test.ts
+++ b/src/lib/__tests__/anchors.test.ts
@@ -58,32 +58,32 @@ describe("inferPublishedAt: ファイル名からの ISO 8601 推定 (JST 固定
   });
 
   describe("異常系・境界値", () => {
-    it("ゼロ埋めの 00000000000000.md は null を返す", () => {
-      expect(inferPublishedAt("00000000000000.md")).toBeNull();
+    it("ゼロ埋めの 00000000000000.md は undefined を返す", () => {
+      expect(inferPublishedAt("00000000000000.md")).toBeUndefined();
     });
 
-    it("上限超過の 99999999999999.md は null を返す", () => {
-      expect(inferPublishedAt("99999999999999.md")).toBeNull();
+    it("上限超過の 99999999999999.md は undefined を返す", () => {
+      expect(inferPublishedAt("99999999999999.md")).toBeUndefined();
     });
 
-    it("数字以外を含む abc.md は null を返す", () => {
-      expect(inferPublishedAt("abc.md")).toBeNull();
+    it("数字以外を含む abc.md は undefined を返す", () => {
+      expect(inferPublishedAt("abc.md")).toBeUndefined();
     });
 
-    it("13 桁しか無い 2025010112000.md は null を返す", () => {
-      expect(inferPublishedAt("2025010112000.md")).toBeNull();
+    it("13 桁しか無い 2025010112000.md は undefined を返す", () => {
+      expect(inferPublishedAt("2025010112000.md")).toBeUndefined();
     });
 
-    it("15 桁の 202501011200001.md は null を返す", () => {
-      expect(inferPublishedAt("202501011200001.md")).toBeNull();
+    it("15 桁の 202501011200001.md は undefined を返す", () => {
+      expect(inferPublishedAt("202501011200001.md")).toBeUndefined();
     });
 
-    it("空文字列は null を返す", () => {
-      expect(inferPublishedAt("")).toBeNull();
+    it("空文字列は undefined を返す", () => {
+      expect(inferPublishedAt("")).toBeUndefined();
     });
 
-    it("拡張子のみの .md は null を返す", () => {
-      expect(inferPublishedAt(".md")).toBeNull();
+    it("拡張子のみの .md は undefined を返す", () => {
+      expect(inferPublishedAt(".md")).toBeUndefined();
     });
 
     /**
@@ -92,7 +92,7 @@ describe("inferPublishedAt: ファイル名からの ISO 8601 推定 (JST 固定
      * させても文字列は再構築されないため、推定値はそのまま "2025-02-29T..."
      * を返す。anchors.ts 単独の境界値仕様としてここで固定する。
      *
-     * 将来 isIso8601 側を厳密化する場合は本テストの期待値を null に反転する。
+     * 将来 isIso8601 側を厳密化する場合は本テストの期待値を undefined に反転する。
      */
     it("非閏年 2/29 ファイル名 20250229120000.md は 2025-02-29T12:00:00+09:00 を返す (実在しない日付だが文字列再構築のため許容)", () => {
       expect(inferPublishedAt("20250229120000.md")).toBe(
@@ -119,7 +119,7 @@ describe("inferPublishedAt: ファイル名からの ISO 8601 推定 (JST 固定
 
       for (const file of files) {
         const result = inferPublishedAt(file);
-        expect(result, `ファイル ${file} の推定に失敗`).not.toBeNull();
+        expect(result, `ファイル ${file} の推定に失敗`).toBeDefined();
         expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+09:00$/);
       }
     });
@@ -508,8 +508,8 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       const publishedAt = inferPublishedAt("20250229120000.md");
       expect(publishedAt).toBe("2025-02-29T12:00:00+09:00");
 
-      // null チェック: 上の expect で確定済みだが TypeScript narrowing のため
-      if (publishedAt === null) {
+      // undefined チェック: 上の expect で確定済みだが TypeScript narrowing のため
+      if (publishedAt === undefined) {
         throw new Error("unreachable");
       }
 
@@ -766,7 +766,7 @@ describe("Issue #489 AC: 実データ統合 (milestones.json × 全記事)", () 
     const isoList: string[] = [];
     for (const fileName of fileNames) {
       const iso = inferPublishedAt(fileName);
-      if (iso !== null) {
+      if (iso !== undefined) {
         isoList.push(iso);
       }
     }

--- a/src/lib/__tests__/resurface.test.ts
+++ b/src/lib/__tests__/resurface.test.ts
@@ -267,7 +267,7 @@ describe("selectResurfaced: どれも該当しないケース", () => {
   });
 
   it("posts に inferPublishedAt 解決不能な ID が含まれていても落ちず、解決可能な記事のみで判定する", () => {
-    // ID "invalid-id" は inferPublishedAt が null を返すため除外
+    // ID "invalid-id" は inferPublishedAt が undefined を返すため除外
     const posts = [makePost("20250101120000"), makePost("invalid-id")];
     const result = selectResurfaced(posts, [], "2025-02-01");
 

--- a/src/lib/anchors.ts
+++ b/src/lib/anchors.ts
@@ -121,22 +121,27 @@ const isIso8601 = (value: string): boolean => {
  *
  * - JST (+09:00) で固定する (既存記事は JST 想定)
  * - 14 桁の数字 + 任意の .md のみ受理する厳格な実装
- * - 桁数や数値が不正な場合は null を返す
+ * - 桁数や数値が不正な場合は undefined を返す
  * - 月末日や閏年の厳密判定は行わない (Date.parse がロールオーバーしても
  *   文字列自体は再構築されないため、推定値はそのまま返る)
  *
+ * 戻り値型 (Issue #682):
+ * - CLAUDE.md「null vs undefined」方針に整合させるため `string | undefined`
+ *   を採用する (「値がまだ割り当てられていない / 推定不可」のセマンティクスは
+ *   undefined 側に倒すのが本プロジェクトのスタンス)
+ *
  * @param fileName - ファイル名 (例: `20250101120000.md`)
- * @returns ISO 8601 文字列 (推定不可なら null)
+ * @returns ISO 8601 文字列 (推定不可なら undefined)
  */
-export const inferPublishedAt = (fileName: string): string | null => {
+export const inferPublishedAt = (fileName: string): string | undefined => {
   const base = fileName.replace(/\.md$/, "");
   const match = base.match(/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/);
   if (!match) {
-    return null;
+    return undefined;
   }
   const [, year, month, day, hour, minute, second] = match;
   const candidate = `${year}-${month}-${day}T${hour}:${minute}:${second}+09:00`;
-  return isIso8601(candidate) ? candidate : null;
+  return isIso8601(candidate) ? candidate : undefined;
 };
 
 /**

--- a/src/lib/resurface.ts
+++ b/src/lib/resurface.ts
@@ -187,7 +187,7 @@ const resolveAndSortPosts = (posts: readonly PostSummary[]): ResolvedPost[] => {
     // post.id がそのままファイル名のタイムスタンプ部 (例: 20260307120000) として
     // anchors.ts の inferPublishedAt に渡せる。.md 拡張子はあっても無くても良い。
     const publishedAt = inferPublishedAt(post.id);
-    if (publishedAt === null) {
+    if (publishedAt === undefined) {
       continue;
     }
     const publishedDate = isoToCalendarDate(publishedAt);


### PR DESCRIPTION
## 概要

Issue #682 対応（Issue #622 follow-up）。`src/lib/anchors.ts` の `inferPublishedAt` の戻り値型を `string | null` → `string | undefined` に変更し、CLAUDE.md「null vs undefined」方針（undefined 優先）と整合させる。呼び出し側を `=== undefined` strict 比較に揃え、PR #683 で残した暫定 `== null` コメントを撤去。

## 変更内容 (11 ファイル / +46 / -53)

### 本体
- `src/lib/anchors.ts`: 戻り値型 `string | null` → `string | undefined`、`return null;` → `return undefined;` 2 箇所、JSDoc 更新
- `src/lib/resurface.ts`: 呼び出し側 `=== null` → `=== undefined` (1 箇所)
- `scripts/newPost.ts`: ゆるい比較 (`== null` / `!= null`) を strict 比較 (`=== undefined` / `!== undefined`) に戻し、PR #683 由来の暫定コメントを撤去 (3 箇所)

### 型変更に伴う必要修正
- `src/components/pages/PostDetailPage.tsx`: 呼び出し側 + JSDoc 修正
- `src/components/pages/AnchorPage.tsx`: 呼び出し側 + JSDoc 修正
- `src/components/common/Coordinate.tsx`: JSDoc 修正

### テスト追従 (5 ファイル)
- `toBeNull()` → `toBeUndefined()`
- `=== null` → `=== undefined`
- コメント / テスト名内の文言修正

## 備考

### スコープが Issue 記述 4 箇所 → 11 ファイルに拡大した理由

戻り値型変更で TS 型推論が呼び出し側に波及し、`publishedAt === null` の narrowing が型エラーになるため、`PostDetailPage.tsx` / `AnchorPage.tsx` / `Coordinate.tsx` + テスト 5 ファイルも**物理的に不可分**な必要修正として同一 PR / 同一コミットに含めた。Issue 起票時の見落とし補完。

### 意味的等価性

- `inferPublishedAt` 内部ロジック (regex / isIso8601 / 戻り値構築) は不変
- `return null;` → `return undefined;` は呼び出し側ガード (`=== undefined`) と同時更新のため挙動同一
- `toBeNull()` → `toBeUndefined()` は旧実装で `null` を返していた地点で新実装が必ず `undefined` を返すため等価

### 残存 `=== null` パターン

`grep` で残存する `=== null` は `useTheme` (localStorage) / `useAdjacentPosts` / `Coordinate.firstChild` (DOM API) / `toMilestoneCalendarDate` (`src/lib/anchors.ts` 内の別関数) 等、いずれも `inferPublishedAt` 由来ではなく外部 API / 別関数戻り値起源。スコープ外として温存。

### 検証

- `pnpm lint` / `pnpm type-check` / `pnpm test:run` (1003 件) / `pnpm build` 全 pass

Closes #682