### PR TITLE
chore: build / build:ci の drift 自動検出ガードを追加 (Closes #685)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Lint design tokens (R-5 / Issue #393)
         run: pnpm lint:tokens
 
+      - name: Check build / build:ci sync (Issue #685)
+        run: pnpm check:build-ci-sync
+
       # Issue #580: tsc --incremental の .tsbuildinfo を cache し、
       # type-check / type-check:test / type-check:scripts の cold ビルドを高速化する。
       # メインキー: lockfile + tsconfig.json / tsconfig.test.json / tsconfig.scripts.json + src/scripts の hash が完全一致した場合のみ hit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Tripwire テスト用に吐く data-* 属性の命名は以下を指針とする
   - CI で `hash:true` 実機検証を回すための workflow は `.github/workflows/panda-hash-regression.yml`（Issue #496 で追加済み）
   - GitHub Actions の "Panda hash:true regression check" workflow から手動 (workflow_dispatch) で実行できる
   - 実行内容: `pnpm test:run` と `panda + tsc + vite build` を `hash: true` で 1 回ずつ実行し、Tripwire 耐性の regression を検知する
-- **`build:ci` script と workflow の整合性メモ（Issue #528）**: hash:true build step は `package.json` の `build:ci` (= `panda && tsc && vite build`, test/lint/type-check:scripts を含まない軽量版) を呼ぶ。`build` script (本番経路) のコマンド列 (`panda && tsc && vite build` 部分) を変更する場合は `build:ci` も同期させること
+- **`build:ci` script と workflow の整合性メモ（Issue #528）**: hash:true build step は `package.json` の `build:ci` (= `panda && tsc && vite build`, test/lint/type-check:scripts を含まない軽量版) を呼ぶ。`build` script (本番経路) のコマンド列 (`panda && tsc && vite build` 部分) を変更する場合は `build:ci` も同期させること。**同期の有無は `scripts/checkBuildCiSync.ts` で自動検出される（Issue #685、`.github/workflows/ci.yml` の lint-and-typecheck job で実行）** ので、散文ルールが形骸化しても CI が drift を検知して fail する
   - baseline (hash:false) build step は bundle size 計測専用で tsc を意図的に省く運用 (Issue #625 DA #2) のため `build:ci` ではなく `pnpm exec panda && pnpm exec vite build` を直接呼ぶ非対称運用とする
 
 ### 設定ファイル

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "fmt": "biome check --write --unsafe ./src ./scripts",
     "lint": "biome lint ./src ./scripts",
     "lint:tokens": "node scripts/lintTokens.ts",
+    "check:build-ci-sync": "node scripts/checkBuildCiSync.ts",
     "type-check": "tsc --noEmit",
     "type-check:test": "tsc --noEmit --project tsconfig.test.json",
     "type-check:scripts": "tsc --noEmit --project tsconfig.scripts.json",

--- a/scripts/__tests__/checkBuildCiSync.test.ts
+++ b/scripts/__tests__/checkBuildCiSync.test.ts
@@ -1,0 +1,150 @@
+/**
+ * scripts/checkBuildCiSync.ts の単体テスト (Issue #685)
+ *
+ * 検証対象:
+ *   - splitCommands: `&&` 区切りで command を取り出し、空 token を除外する
+ *   - checkSync:
+ *       - build に build:ci の全 command が順序を保って含まれていれば ok
+ *       - 順序が崩れた / command が抜けていれば ng (reason 付き)
+ *       - build:ci 側が空なら ok (検査対象なし)
+ *       - 部分一致 (prefix 付き wrapper など) を許容する
+ *   - loadPackageScripts: package.json から scripts.build / scripts["build:ci"] を取り出し、
+ *     欠落 / 型違反は throw する
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  checkSync,
+  loadPackageScripts,
+  splitCommands,
+} from "../checkBuildCiSync.ts";
+
+describe("splitCommands", () => {
+  it("`&&` 区切りで各 command を trim した配列を返す", () => {
+    expect(splitCommands("panda && tsc && vite build")).toEqual([
+      "panda",
+      "tsc",
+      "vite build",
+    ]);
+  });
+
+  it("空文字列に対して空配列を返す", () => {
+    expect(splitCommands("")).toEqual([]);
+  });
+
+  it("空白のみの token を除外する", () => {
+    expect(splitCommands("panda && && tsc")).toEqual(["panda", "tsc"]);
+  });
+});
+
+describe("checkSync", () => {
+  it("build:ci の全 command が build に順序を保って含まれていれば ok", () => {
+    const buildScript =
+      "pnpm run lint && pnpm run test:run && pnpm run type-check && panda && tsc && vite build";
+    const buildCiScript = "panda && tsc && vite build";
+    const result = checkSync(buildScript, buildCiScript);
+    expect(result.ok).toBe(true);
+  });
+
+  it("build と build:ci が完全一致でも ok", () => {
+    const script = "panda && tsc && vite build";
+    expect(checkSync(script, script).ok).toBe(true);
+  });
+
+  it("build:ci が空なら ok (検査対象なし)", () => {
+    expect(checkSync("panda && tsc && vite build", "").ok).toBe(true);
+  });
+
+  it("build から build:ci の command が欠落していれば ng", () => {
+    const buildScript = "panda && vite build";
+    const buildCiScript = "panda && tsc && vite build";
+    const result = checkSync(buildScript, buildCiScript);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("tsc");
+  });
+
+  it("build:ci の command が build と逆順なら ng", () => {
+    const buildScript = "vite build && tsc && panda";
+    const buildCiScript = "panda && tsc && vite build";
+    const result = checkSync(buildScript, buildCiScript);
+    expect(result.ok).toBe(false);
+  });
+
+  it("部分一致 (wrapper prefix 付き) を許容する", () => {
+    const buildScript =
+      "pnpm exec panda && pnpm exec tsc && pnpm exec vite build";
+    const buildCiScript = "panda && tsc && vite build";
+    expect(checkSync(buildScript, buildCiScript).ok).toBe(true);
+  });
+
+  it("build が空かつ build:ci が非空なら ng", () => {
+    const result = checkSync("", "panda && tsc && vite build");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("panda");
+  });
+
+  it("ng 時に reason に欠落 command 名が含まれる", () => {
+    const result = checkSync("panda && tsc", "panda && tsc && vite build");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("vite build");
+  });
+});
+
+describe("loadPackageScripts", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "check-build-ci-sync-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("scripts.build / scripts['build:ci'] を取り出せる", () => {
+    const packagePath = join(tempDir, "package.json");
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        scripts: {
+          build: "panda && tsc && vite build",
+          "build:ci": "panda && tsc && vite build",
+        },
+      }),
+    );
+    const result = loadPackageScripts(packagePath);
+    expect(result.build).toBe("panda && tsc && vite build");
+    expect(result.buildCi).toBe("panda && tsc && vite build");
+  });
+
+  it("scripts フィールドが無いと throw する", () => {
+    const packagePath = join(tempDir, "package.json");
+    writeFileSync(packagePath, JSON.stringify({ name: "foo" }));
+    expect(() => loadPackageScripts(packagePath)).toThrow(/scripts/);
+  });
+
+  it("scripts.build が無いと throw する", () => {
+    const packagePath = join(tempDir, "package.json");
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        scripts: { "build:ci": "panda && tsc && vite build" },
+      }),
+    );
+    expect(() => loadPackageScripts(packagePath)).toThrow(/scripts\.build/);
+  });
+
+  it("scripts['build:ci'] が無いと throw する", () => {
+    const packagePath = join(tempDir, "package.json");
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        scripts: { build: "panda && tsc && vite build" },
+      }),
+    );
+    expect(() => loadPackageScripts(packagePath)).toThrow(/build:ci/);
+  });
+});

--- a/scripts/checkBuildCiSync.ts
+++ b/scripts/checkBuildCiSync.ts
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+
+/**
+ * Issue #685: `package.json` の `build` script と `build:ci` script の
+ * drift を CI で機械的に検知するためのガードスクリプト。
+ *
+ * 背景:
+ *   - `build:ci` (= `panda && tsc && vite build`) は hash:true regression
+ *     workflow 等で `build` の代用として呼ばれるサブセット。
+ *   - 過去 (Issue #528) は CLAUDE.md 散文で「`build` 変更時は `build:ci`
+ *     も同期させること」と運用ルール化していたが、散文ルールは時間経過で
+ *     形骸化する。
+ *   - 本スクリプトは `build` 文字列に `build:ci` の各 command (`panda` /
+ *     `tsc` / `vite build`) が **順序を保って** 含まれているかを部分一致で
+ *     判定し、ずれていれば exit 1 で fail-fast する。
+ *
+ * 設計方針:
+ *   - 本リポの `build` / `build:ci` 構造に絞った最小実装。汎用的な script
+ *     依存解析は行わない。
+ *   - 外部依存追加禁止 (`node:fs` / `node:path` のみ)。
+ *   - 純粋関数 `checkSync(buildScript, buildCiScript)` をテスト用に export
+ *     する。CLI エントリ (`main`) は副作用 (file IO / process.exit) に集約。
+ *
+ * 使い方:
+ *   - `pnpm exec tsx scripts/checkBuildCiSync.ts`
+ *   - 成功時: exit 0
+ *   - drift 検知時 / 構成不備時: exit 1 (stderr にヒントを出力)
+ */
+
+import { readFileSync } from "node:fs";
+import { basename, resolve } from "node:path";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..");
+const PACKAGE_JSON_PATH = resolve(PROJECT_ROOT, "package.json");
+
+/**
+ * `checkSync` の戻り値。
+ * - `ok`: true なら drift なし、false なら drift あり。
+ * - `reason`: ok=false のときのみ設定する違反理由 (human readable)。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+interface CheckResult {
+  readonly ok: boolean;
+  readonly reason?: string;
+}
+
+/**
+ * script 文字列を `&&` 区切りで分割し、各 command を trim した配列にする。
+ *
+ * `build:ci` は `panda && tsc && vite build` のような単純な直列 chain を
+ * 前提とする。`|` / `;` / `&` 等の他の shell 演算子は本スクリプトの対象外
+ * (将来 `build:ci` がそうした構造に変わった場合は本ガードも見直す)。
+ *
+ * 空 / 空白のみの token は除外する (例: `panda && && tsc` のような
+ * 異常入力に対する防御)。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+const splitCommands = (script: string): string[] => {
+  return script
+    .split("&&")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+};
+
+/**
+ * `build` script 文字列の中に `build:ci` の各 command が「順序を保って」
+ * 部分一致で出現するかを判定する。
+ *
+ * アルゴリズム:
+ *   - `build` を `splitCommands` で token 配列化する。
+ *   - `build:ci` の各 command を順に走査し、`build` token 列の中から
+ *     部分一致 (`String#includes`) する次の token を線形検索する。
+ *   - 全 `build:ci` command を順序を崩さず消費できれば ok。
+ *   - 途中で見つからなくなった時点で reason 付き ng を返す。
+ *
+ * 部分一致 (`includes`) を採用する理由:
+ *   - `build` 側に `pnpm run lint && ... && panda && tsc && vite build`
+ *     のように prefix (`pnpm run`) や追加 flag が付くケースを許容するため。
+ *   - 完全一致では `pnpm run build:ci` のような wrapper にも対応できない。
+ *
+ * 空配列ケース:
+ *   - `buildCiScript` が空 (token 0 件): 検査する command が無いので ok。
+ *     ただし呼び出し側 (`main`) では「`build:ci` 自体が未定義 / 空」を
+ *     構成不備として別途扱う (本関数は文字列入力に対する純粋関数のため、
+ *     未定義との区別は呼び出し側に委ねる)。
+ *   - `buildScript` が空かつ `buildCiScript` が非空: ng (drift)。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+const checkSync = (
+  buildScript: string,
+  buildCiScript: string,
+): CheckResult => {
+  const ciCommands = splitCommands(buildCiScript);
+  if (ciCommands.length === 0) {
+    return { ok: true };
+  }
+
+  const buildTokens = splitCommands(buildScript);
+  let cursor = 0;
+  for (const ciCommand of ciCommands) {
+    let matchedIndex = -1;
+    for (let i = cursor; i < buildTokens.length; i += 1) {
+      const token = buildTokens[i] ?? "";
+      if (token.includes(ciCommand)) {
+        matchedIndex = i;
+        break;
+      }
+    }
+    if (matchedIndex === -1) {
+      const position =
+        cursor === 0 ? "" : " (前 command 以降の位置で)";
+      return {
+        ok: false,
+        reason: `build:ci の command "${ciCommand}" が build script 内${position}に見つかりません。`,
+      };
+    }
+    cursor = matchedIndex + 1;
+  }
+
+  return { ok: true };
+};
+
+/**
+ * `package.json` を読み、`scripts.build` / `scripts.build:ci` を取り出す。
+ *
+ * 構成不備 (フィールド欠落 / 型違反) は throw する。`main` 側で
+ * catch し exit 1 にする。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+interface PackageScripts {
+  readonly build: string;
+  readonly buildCi: string;
+}
+
+/** @internal テスト専用 export. 本番コードから import しないこと */
+const loadPackageScripts = (packageJsonPath: string): PackageScripts => {
+  const raw = readFileSync(packageJsonPath, "utf8");
+  const parsed: unknown = JSON.parse(raw);
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("package.json のトップレベルがオブジェクトではありません");
+  }
+  const scriptsField = (parsed as Record<string, unknown>).scripts;
+  if (typeof scriptsField !== "object" || scriptsField === null) {
+    throw new Error("package.json に scripts フィールドがありません");
+  }
+  const scripts = scriptsField as Record<string, unknown>;
+  const build = scripts.build;
+  const buildCi = scripts["build:ci"];
+  if (typeof build !== "string") {
+    throw new Error("package.json の scripts.build が文字列ではありません");
+  }
+  if (typeof buildCi !== "string") {
+    throw new Error(
+      'package.json の scripts["build:ci"] が文字列ではありません',
+    );
+  }
+  return { build, buildCi };
+};
+
+const HINT_MESSAGE = [
+  "",
+  "Issue #685: build / build:ci の drift を検知しました。",
+  "対処方針はいずれか:",
+  "  1. build:ci を build に合わせて更新する (panda / tsc / vite build の順を維持)",
+  "  2. build から該当 command を削除した意図的変更であれば、本検査スクリプト",
+  "     (scripts/checkBuildCiSync.ts) と CLAUDE.md「Panda hash:true の運用判断」",
+  "     セクションの記述を併せて更新する",
+].join("\n");
+
+const main = (): void => {
+  let scripts: PackageScripts;
+  try {
+    scripts = loadPackageScripts(PACKAGE_JSON_PATH);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`checkBuildCiSync FATAL: ${message}`);
+    process.exit(1);
+  }
+
+  const result = checkSync(scripts.build, scripts.buildCi);
+  if (result.ok) {
+    console.log(
+      "checkBuildCiSync OK - build script に build:ci の全 command が順序を保って含まれています。",
+    );
+    return;
+  }
+
+  console.error(`checkBuildCiSync NG - ${result.reason ?? "理由不明"}`);
+  console.error(`  build    = ${scripts.build}`);
+  console.error(`  build:ci = ${scripts.buildCi}`);
+  console.error(HINT_MESSAGE);
+  process.exit(1);
+};
+
+/**
+ * CLI として直接起動された場合のみ `main()` を実行する。
+ * テストから import した際に副作用 (file IO / process.exit) が走らないよう
+ * にするためのエントリポイントガード (scripts/lintTokens.ts / calculateContrast.ts と同パターン)。
+ */
+const isDirectInvocation = (): boolean => {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return basename(entry) === "checkBuildCiSync.ts";
+};
+
+if (isDirectInvocation()) {
+  main();
+}
+
+export type { CheckResult, PackageScripts };
+export { checkSync, loadPackageScripts, splitCommands };


### PR DESCRIPTION
## 概要

Issue #685 対応（PR #686 / Issue #528 follow-up）。`package.json` の `build` と `build:ci` の drift を CI で機械的に検出するガードを導入。CLAUDE.md 散文ルールでは形骸化する懸念を解消する（案 A 採用）。

## 変更内容

- `scripts/checkBuildCiSync.ts` (新規): `checkSync(buildScript, buildCiScript)` 純粋関数 + CLI エントリ
  - `build:ci` を `&&` で tokenize 後、`build` 内で順序を保って部分一致 (`String#includes`) で消費できれば ok
  - 失敗時は exit 1 + 対処方針ヒント (stderr)
- `scripts/__tests__/checkBuildCiSync.test.ts` (新規): 15 ケース (`splitCommands` 3 / `checkSync` 8 / `loadPackageScripts` 4)
- `package.json`: `check:build-ci-sync` script 追加 (`node scripts/checkBuildCiSync.ts`)
- `.github/workflows/ci.yml`: `lint-and-typecheck` job に `pnpm check:build-ci-sync` step を追加
- `CLAUDE.md`: 「Panda hash:true の運用判断」セクションの「build:ci 同期義務」記述を「自動検出される」に更新

## 備考

### 設計判断: `tsx` 不要

`pnpm exec tsx` ではなく `node scripts/checkBuildCiSync.ts` 直接実行を採用。Node 24 の type stripping で TS ファイルを直接実行可能なため `tsx` 依存を回避できる。リポ全体で既存スクリプト (`lint:tokens` / `new-post` / `contrast:check`) と統一パターン。

### `@internal` JSDoc 統一

`checkSync` / `splitCommands` / `loadPackageScripts` 等のテスト用 export に `@internal テスト専用 export. 本番コードから import しないこと` 文言を付与（既存 `lintTokens.ts` / `calculateContrast.ts` と統一）。

### 手動破壊検証

`package.json` の `build` を一時的に `tsc` 抜きに書き換え → `node scripts/checkBuildCiSync.ts` が exit 1 で `build:ci の command "tsc" が build script 内に見つかりません。` と stderr 出力することを確認。

### 既知の限界（follow-up）

DA 指摘: `String#includes` 部分一致は短い token (`tsc` 等) の誤検出リスクと `buildCiScript = ""` での沈黙リスクが残る。本 PR スコープ外として Issue #701 (word boundary 化 + 空文字 fail 化) を別途起票済み。

### 検証

- `pnpm lint` / `pnpm type-check` / `pnpm test:run` (1021 件) / `pnpm build` / `pnpm check:build-ci-sync` 全 pass

Closes #685
Related #701 (word boundary 化 + 空文字 fail 化 follow-up)