### PR TITLE
chore: lintTokens.ts walkDirectory に symlink ループ防止を追加 (Closes #658)

### DIFF
--- a/scripts/__tests__/lintTokens.test.ts
+++ b/scripts/__tests__/lintTokens.test.ts
@@ -246,6 +246,138 @@ describe("walkDirectory", () => {
     expect(() => walkDirectory(tmpDir, results)).not.toThrow();
     expect(results).toContain(join(tmpDir, "real.ts"));
   });
+
+  // ====================================================================
+  // symlink ループ防止 (Issue #658)
+  //
+  // PR #635 (Issue #621) で broken symlink は `tryStat` 経由で握り潰す
+  // ようになったが、symlink ループ (`a -> b`, `b -> a` 等) は `tryStat`
+  // が Stats を返すため `isDirectory()` 判定後に再帰呼び出しで無限ループに
+  // 陥る潜在リスクがあった。
+  //
+  // 案 1: `realpathSync` で正規化したパスを `Set<string>` で記録し、
+  // 重複したら skip + `onSkip` 通知。本テスト群は以下を担保する:
+  //   - シンプル symlink ループで無限ループせず skip される
+  //   - `onSkip` が想定通り呼ばれる (件数集計可能)
+  //   - 非ループ symlink (`a -> b`, `b` は通常ディレクトリ) は通常通り走査
+  //   - broken symlink は既存挙動 (skip) を維持する
+  // ====================================================================
+  describe("symlink ループ防止 (Issue #658)", () => {
+    it("シンプル symlink ループ (`a -> b`, `b -> a`) で無限ループせず skip できる", () => {
+      // tmpDir/
+      //   real.ts            # 通常ファイル (走査対象)
+      //   a -> b             # symlink ループ
+      //   b -> a             # symlink ループ
+      writeFileSync(join(tmpDir, "real.ts"), "x", "utf8");
+      symlinkSync(join(tmpDir, "b"), join(tmpDir, "a"));
+      symlinkSync(join(tmpDir, "a"), join(tmpDir, "b"));
+      const results: string[] = [];
+      // 無限ループに陥らず正常終了することを担保する
+      // (vitest デフォルトの testTimeout 5s 内に完了)。
+      expect(() => walkDirectory(tmpDir, results)).not.toThrow();
+      expect(results).toContain(join(tmpDir, "real.ts"));
+    });
+
+    it("symlink ループで onSkip が呼ばれ件数集計できる", () => {
+      // 自己参照 symlink (`self -> self`) を作成。
+      // `realpathSync` は ELOOP を投げるため `tryRealpath` で skip + 通知される。
+      symlinkSync(join(tmpDir, "self"), join(tmpDir, "self"));
+      const results: string[] = [];
+      const onSkip = vi.fn();
+      expect(() =>
+        walkDirectory(tmpDir, results, onSkip),
+      ).not.toThrow();
+      // 自己参照 symlink について `onSkip` が少なくとも 1 回呼ばれる
+      // (realpath 失敗 or symlink ループ判定で)。
+      expect(onSkip).toHaveBeenCalled();
+      const skippedPaths = onSkip.mock.calls.map((c) => c[0] as string);
+      expect(skippedPaths).toContain(join(tmpDir, "self"));
+    });
+
+    it("ディレクトリ間 symlink ループ (`dir-a -> dir-b`, `dir-b -> dir-a`) で skip できる", () => {
+      // tmpDir/
+      //   real.ts
+      //   loop/
+      //     dir-a -> ../loop/dir-b
+      //     dir-b -> ../loop/dir-a
+      const loopDir = join(tmpDir, "loop");
+      mkdirSync(loopDir);
+      writeFileSync(join(tmpDir, "real.ts"), "x", "utf8");
+      symlinkSync(join(loopDir, "dir-b"), join(loopDir, "dir-a"));
+      symlinkSync(join(loopDir, "dir-a"), join(loopDir, "dir-b"));
+      const results: string[] = [];
+      const onSkip = vi.fn();
+      expect(() =>
+        walkDirectory(tmpDir, results, onSkip),
+      ).not.toThrow();
+      expect(results).toContain(join(tmpDir, "real.ts"));
+      // ループ symlink が onSkip 通知される (realpath 失敗 or 訪問済み判定)。
+      expect(onSkip).toHaveBeenCalled();
+    });
+
+    it("非ループ symlink (`link -> normalDir`) は通常通り走査できる", () => {
+      // tmpDir/
+      //   normal/
+      //     deep.ts          # 通常ファイル
+      //   link -> normal     # 非ループ symlink
+      //
+      // 期待挙動: 同一実体を指す経路 (`normal/deep.ts` / `link/deep.ts`) は
+      // visited で重複排除され、**いずれか 1 経路で 1 回だけ** results に
+      // 入る。どちらの経路が先に走査されるかは `readdirSync` の OS 依存の
+      // 順序に依存するため、ここでは「1 件含まれる」ことだけを担保する。
+      const normalDir = join(tmpDir, "normal");
+      mkdirSync(normalDir);
+      writeFileSync(join(normalDir, "deep.ts"), "x", "utf8");
+      symlinkSync(normalDir, join(tmpDir, "link"));
+      const results: string[] = [];
+      walkDirectory(tmpDir, results);
+      // 経路に依らず `deep.ts` が 1 件だけ集まる (= 二重カウントされない)。
+      const deepHits = results.filter((p) => p.endsWith("deep.ts"));
+      expect(deepHits).toHaveLength(1);
+      // 集まった経路は実体パス or symlink 経路のどちらかで、basename は
+      // `deep.ts`。`normal` または `link` 配下のいずれかであること。
+      const hit = deepHits[0] ?? "";
+      expect(
+        hit === join(normalDir, "deep.ts") ||
+          hit === join(tmpDir, "link", "deep.ts"),
+      ).toBe(true);
+    });
+
+    it("broken symlink (実体なし) は既存挙動通り skip される", () => {
+      // 回帰テスト: PR #635 (Issue #621) で導入した broken symlink skip
+      // 挙動を Issue #658 の実装が壊していないことを確認する。
+      writeFileSync(join(tmpDir, "real.ts"), "x", "utf8");
+      symlinkSync(join(tmpDir, "missing-target"), join(tmpDir, "dangling"));
+      const results: string[] = [];
+      expect(() => walkDirectory(tmpDir, results)).not.toThrow();
+      expect(results).toContain(join(tmpDir, "real.ts"));
+    });
+
+    it("visited Set を呼び出し間で再利用しない (各 collectTargetFiles 呼び出しが独立)", () => {
+      // tmpDir/
+      //   t1/
+      //     real.ts
+      //   t2 -> t1            # t2 は t1 への symlink
+      // 連続して walkDirectory(t1) と walkDirectory(t2) を呼んだとき、
+      // visited のスコープが呼び出し単位なので両方とも走査される
+      // (= 「symlink で同じ実体を指す独立ターゲットを別々に集計したい」
+      //   要件を担保する)。
+      const t1 = join(tmpDir, "t1");
+      mkdirSync(t1);
+      writeFileSync(join(t1, "real.ts"), "x", "utf8");
+      symlinkSync(t1, join(tmpDir, "t2"));
+
+      const r1: string[] = [];
+      walkDirectory(t1, r1);
+      expect(r1).toContain(join(t1, "real.ts"));
+
+      const r2: string[] = [];
+      walkDirectory(join(tmpDir, "t2"), r2);
+      // t2 経由でも実体ファイルを集められる (= visited が呼び出し間で
+      // 共有されていない)。
+      expect(r2.length).toBeGreaterThan(0);
+    });
+  });
 });
 
 describe("collectTargetFiles", () => {

--- a/scripts/lintTokens.ts
+++ b/scripts/lintTokens.ts
@@ -44,7 +44,13 @@
  * - false positive が出た場合は `EXCLUDED_FILE_SUFFIXES` 経由で除外する。
  */
 
-import { readdirSync, readFileSync, type Stats, statSync } from "node:fs";
+import {
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  type Stats,
+  statSync,
+} from "node:fs";
 import { basename, extname, join, relative, resolve } from "node:path";
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "..");
@@ -252,6 +258,43 @@ const tryStat = (
 };
 
 /**
+ * `realpathSync` を try/catch でラップし、失敗時は undefined を返す補助関数。
+ *
+ * 用途 (Issue #658 / 案 1):
+ *   `walkDirectory` の symlink ループ防止 (`a -> b`, `b -> a` のような循環) に
+ *   使う。訪問済みパス管理 (`Set<string>`) のキーは「実体パス」に正規化された
+ *   ものを使う必要があり、`realpathSync` で symlink を辿り切って絶対パスに変換する。
+ *
+ * 例外ポリシー (`tryStat` と同じ理由で全例外を握り潰す):
+ *   - ENOENT (broken symlink で実体が存在しない) → undefined を返し、呼び出し側
+ *     で安全側 skip させる。Tripwire スクリプトの責務は「読める範囲を走査
+ *     する」ことなので、realpath 失敗で CI を落とすより skip するほうが妥当
+ *   - ELOOP (symlink ループ深度上限到達) / EACCES (権限不足) 等も同様に undefined
+ *   - `onSkip` callback が渡されていれば errno code を reason として通知する
+ *
+ * CLAUDE.md「null vs undefined」方針に従い、戻り値型は `string | undefined`。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+const tryRealpath = (
+  target: string,
+  onSkip?: SkipCallback,
+): string | undefined => {
+  try {
+    return realpathSync(target);
+  } catch (error) {
+    if (onSkip) {
+      const reason =
+        error && typeof error === "object" && "code" in error
+          ? String((error as NodeJS.ErrnoException).code ?? "unknown")
+          : "unknown";
+      onSkip(target, reason);
+    }
+    return undefined;
+  }
+};
+
+/**
  * 走査対象ファイルとして受理可能か判定する。
  * - 拡張子が `TARGET_EXTENSIONS` に含まれること
  * - `EXCLUDED_FILE_SUFFIXES` のいずれにも該当しないこと
@@ -291,10 +334,28 @@ const shouldSkipEntry = (entry: string): boolean => {
  * `tryStat` 経由で取得し、stat 失敗エントリは静かにスキップする
  * (Issue #621 / M1)。
  *
+ * symlink ループ防止 (Issue #658):
+ *   `a -> b`, `b -> a` のような symlink 循環下では `tryStat` が Stats を返す
+ *   ため `isDirectory()` 判定後に再帰呼び出しで無限ループに陥る潜在リスクが
+ *   ある。そこで `realpathSync` で正規化したディレクトリ実体パスを
+ *   `visited: Set<string>` に記録し、既訪問なら skip する (案 1)。
+ *
+ *   - `visited` のスコープは `walkDirectory` 呼び出し単位 (= `collectTargetFiles`
+ *     1 回分)。呼び出し間で再利用しないことで、`TARGET_PATHS` の各ターゲット
+ *     が独立した走査を行えるようにする (例: `src/` と `scripts/` の両方が
+ *     `tmp/cache` を symlink で指していても両方を走査対象にする)
+ *   - `realpathSync` が失敗 (broken symlink / ELOOP 等) した場合は安全側 skip
+ *     + `onSkip` 通知 (`tryRealpath` 経由)
+ *   - ファイルは再帰呼び出しを伴わないため visited 記録対象外 (= ループ
+ *     リスクなし)。記録すると同一実体ファイルを複数の symlink 経由で参照
+ *     しているケースで片方が落ちる副作用が出るため、ディレクトリのみ管理する
+ *
  * @param results **in-out**: 検出した受理可能ファイルのパスを末尾に push する
  *   (Issue #621 / N1)
- * @param onSkip 省略可。stat 失敗で skip した場合に呼ばれるコールバック
- *   (Issue #637)。`main()` が件数集計用に渡す
+ * @param onSkip 省略可。stat / realpath 失敗 / symlink ループで skip した場合に
+ *   呼ばれるコールバック (Issue #637 / Issue #658)。`main()` が件数集計用に渡す
+ * @param visited 省略可。訪問済みディレクトリ実体パスの `Set` (Issue #658)。
+ *   省略時は呼び出しごとに新規生成され、当該呼び出し内でのみ共有される
  *
  * @internal テスト専用 export. 本番コードから import しないこと
  */
@@ -302,7 +363,22 @@ const walkDirectory = (
   current: string,
   results: string[],
   onSkip?: SkipCallback,
+  visited: Set<string> = new Set<string>(),
 ): void => {
+  // 現在ディレクトリを訪問済みに記録する。`current` 自身も symlink 経由で
+  // 渡された可能性があるため、`realpathSync` で実体パスに正規化する。
+  // realpath 失敗時は安全側 skip (broken symlink / 権限不足等)。
+  const currentReal = tryRealpath(current, onSkip);
+  if (currentReal === undefined) {
+    return;
+  }
+  if (visited.has(currentReal)) {
+    // symlink ループ等で既訪問パスに再到達した場合は skip + 通知。
+    onSkip?.(current, "ELOOP");
+    return;
+  }
+  visited.add(currentReal);
+
   const entries = readdirSync(current);
   for (const entry of entries) {
     if (shouldSkipEntry(entry)) {
@@ -314,7 +390,7 @@ const walkDirectory = (
       continue;
     }
     if (entryStats.isDirectory()) {
-      walkDirectory(fullPath, results, onSkip);
+      walkDirectory(fullPath, results, onSkip, visited);
       continue;
     }
     if (entryStats.isFile() && isAcceptableFile(fullPath)) {
@@ -984,6 +1060,7 @@ export {
   scanLineScope,
   shouldSkipEntry,
   stripComments,
+  tryRealpath,
   tryStat,
   walkDirectory,
 };


### PR DESCRIPTION
## 概要

Issue #658 対応（PR #635 / Issue #621 follow-up）。`scripts/lintTokens.ts` の `walkDirectory` は `tryStat` で broken symlink を回避しているが、**symlink ループ** (`a -> b`, `b -> a` 等) は `tryStat` が Stats を返してしまうため `isDirectory()` 判定後に再帰呼び出しで無限ループに陥る潜在 DoS リスクがある。案 1 採用で訪問済みパス管理 (`Set<string>` + `realpathSync` 正規化) を導入。

## 変更内容

### `scripts/lintTokens.ts` (+81 / -4)

- `tryRealpath(target: string, onSkip?: SkipCallback): string | undefined` ヘルパー新設
  - `tryStat` と同じ例外握り潰しポリシー（全例外 catch → errno code 化して `onSkip` 通知）
  - `@internal テスト専用 export. 本番コードから import しないこと` 文言付与（既存統一）
- `walkDirectory` シグネチャ拡張: `(current, results, onSkip?, visited?: Set<string> = new Set()) => void`
  - 引数追加は optional、既存 caller は影響なし
  - `realpathSync` で正規化したディレクトリ実体パスを Set に記録、既訪問なら `onSkip("ELOOP")` で skip
  - スコープは呼び出し単位（`collectTargetFiles` 1 回分）
  - ファイルは再帰呼び出しなしのため visited 対象外（同一実体ファイルを別 symlink から参照するケースで片方が落ちる副作用を回避）

### `scripts/__tests__/lintTokens.test.ts` (+132 / -0)

新規 describe `walkDirectory > symlink ループ防止 (Issue #658)` で 6 ケース:
1. シンプル symlink ループ (`a -> b`, `b -> a`) で無限ループせず skip できる
2. 自己参照 symlink で `onSkip` 通知される
3. ディレクトリ間 symlink ループでも他ファイル収集を継続できる
4. 非ループ symlink を visited で重複排除できる（二重カウント禁止）
5. broken symlink は既存挙動（skip）が維持される（回帰テスト）
6. `visited` Set が呼び出し間で共有されない（独立走査）

## 備考

### 案 1 採用根拠

- 案 2 (再帰深度上限) は深度仮定が要件依存で不採用
- 案 3 (`lstatSync` で symlink 自体判定) は本来 lint 対象になるべき symlink 配下を見落とすリスクで不採用
- `realpathSync` 正規化は実体パス基準なので、攻撃者が異なる symlink 経路から同じ実体を指す手口にも耐性あり

### Minor follow-up

DA レビューで指摘された Minor 3 件（`visited` 明示渡し / ELOOP 通知回数アサート / ファイル symlink 重複 scan テスト）は Issue #703 として別途起票。

### 検証

- `pnpm lint` / `pnpm type-check` / `pnpm test:run` (1012 件) / `pnpm build` / `pnpm lint:tokens` 全 pass
- macOS / Ubuntu CI 双方で動作確認（`/tmp -> /private/tmp` symlink も `realpathSync` 正規化で吸収）

Closes #658
Related #703 (Minor 改善 follow-up)