### PR TITLE
chore: src/api/ (Vite サーバサイド) と純粋ブラウザコードの tsconfig 分離 (Closes #667)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,17 +35,18 @@ jobs:
         run: pnpm lint:tokens
 
       # Issue #580: tsc --incremental の .tsbuildinfo を cache し、
-      # type-check / type-check:test / type-check:scripts の cold ビルドを高速化する。
-      # メインキー: lockfile + tsconfig.json / tsconfig.test.json / tsconfig.scripts.json + src/scripts の hash が完全一致した場合のみ hit
+      # type-check / type-check:test / type-check:scripts / type-check:api の cold ビルドを高速化する。
+      # メインキー: lockfile + tsconfig.json / tsconfig.test.json / tsconfig.scripts.json / tsconfig.api.json + src/scripts の hash が完全一致した場合のみ hit
       # restoreKeys: lockfile + tsconfig が一致なら部分的に再利用 (src 差分のみ再計算)
       # tsconfig.scripts.json は Issue #634 で新設 (scripts/ ambient 型の attack surface 制御)
+      # tsconfig.api.json は Issue #667 で新設 (src/api/ を本体 tsc から分離し Node 型漏出を遮断)
       - name: Cache tsc incremental build info (Issue #580)
         uses: actions/cache@v5
         with:
           path: .tsbuildinfo
-          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts', 'scripts/**/*.tsx') }}
+          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json', 'tsconfig.api.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts', 'scripts/**/*.tsx') }}
           restore-keys: |
-            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-
+            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json', 'tsconfig.api.json') }}-
             tsc-${{ runner.os }}-
 
       - name: Type check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,10 +35,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # Issue #655: ci.yml (lint-and-typecheck job) と同じ cache key を共有し、
-      # deploy 時の tsc (pnpm run build 内の `tsc` / `type-check` / `type-check:scripts`) の
+      # deploy 時の tsc (pnpm run build 内の `tsc` / `type-check` / `type-check:scripts` / `type-check:api`) の
       # cold ビルドを回避する。
       # ci.yml と key を共有する理由:
-      # - ci.yml の key 構成 (tsconfig.json / tsconfig.test.json / tsconfig.scripts.json の hash + src/scripts の hash)
+      # - ci.yml の key 構成 (tsconfig.json / tsconfig.test.json / tsconfig.scripts.json / tsconfig.api.json の hash + src/scripts の hash)
       #   は deploy 時の incremental cache に対しても valid (test 用 tsconfig の hash が変わっても src の
       #   .tsbuildinfo 自体は再利用可能であり、key が変わることで再生成されても害がない)
       # - deploy 頻度は master push 時のみで頻度が低く、cache 書き込み衝突リスクは小さい
@@ -48,6 +48,9 @@ jobs:
       # NOTE: Issue #654 (PR #669) で ci.yml の cache key に追加された `'scripts/**/*.tsx'` glob と
       # 整合させるため、ここにも同 glob を含める。これにより #654 / #655 のいずれが先にマージされても
       # ci.yml と deploy.yml の cache key が drift しない。
+      # NOTE: Issue #667 で新設した tsconfig.api.json も ci.yml と揃えて hashFiles に含める
+      # (src/api/ を本体 tsc から分離し、`build:ci` 内で `tsc --project tsconfig.api.json` を踏むため、
+      # tsconfig.api.json の変更でも .tsbuildinfo の invalidation が必要になる)。
       # **重要**: 本 cache step の `key` / `restore-keys` / `path` を変更する際は ci.yml
       # (lint-and-typecheck job) 側の同 step も同期して変更すること。逆も同様。drift すると
       # ci.yml が warm にした .tsbuildinfo を deploy.yml 側が再利用できず (またはその逆)、warm cache が
@@ -56,9 +59,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .tsbuildinfo
-          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts', 'scripts/**/*.tsx') }}
+          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json', 'tsconfig.api.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts', 'scripts/**/*.tsx') }}
           restore-keys: |
-            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json') }}-
+            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json', 'tsconfig.api.json') }}-
             tsc-${{ runner.os }}-
 
       - name: Build project

--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -56,21 +56,21 @@ jobs:
         # test を二重実行しないため pnpm exec で panda / vite build を呼ぶ。
         #
         # Issue #528: hash:true build step 側は package.json の `build:ci`
-        # (= `panda && tsc && vite build`) を呼ぶ形に統一済みだが、本 step
+        # を呼ぶ形に統一済みだが (実体は `pnpm run build:ci` を参照)、本 step
         # は意図的に `build:ci` を使わない。理由は直下 (Issue #625 DA #2) の
         # とおり baseline build からは tsc を省きたいため。`build:ci` に
         # 含まれる tsc を流用すると baseline 短縮のメリットが消える。
         # 短縮を維持するため本 step は `pnpm exec panda && pnpm exec vite
         # build` を直接呼ぶ運用を継続する。
         #
-        # Issue #625 (DA #2): baseline build からは `pnpm exec tsc` を意図的に
+        # Issue #625 (DA #2): baseline build からは tsc 系コマンドを意図的に
         # 省略する。本 step の目的は bundle size 計測のみで、型チェックは
         # bundle size と直交する。後段の hash:true build step
         # (`Build project with hash:true`) で同じ tree を tsc にかけるため
         # 型 regression は引き続き検知できる。
         # tsc を省くことで baseline build を 30 秒〜数十秒短縮できる。
-        # 注意: baseline (panda + vite build) と hash:true side (build:ci =
-        # panda + tsc + vite build) は実行するコマンド列が非対称になる。
+        # 注意: baseline (panda + vite build) と hash:true side
+        # (`pnpm run build:ci` で実体定義) は実行するコマンド列が非対称になる。
         # bundle size 比較は最終 bundle に tsc が影響しないため妥当だが、
         # 所要時間比較は非対称のため不可 (baseline は tsc を含まないため
         # hash:true より速くなる)。所要時間を将来比較したくなった場合は
@@ -192,16 +192,23 @@ jobs:
         # 走らせて build regression を切り分ける。
         if: steps.tests.outcome == 'success'
         continue-on-error: true
-        # pnpm build は内部で `pnpm run lint && pnpm run test:run && pnpm run
-        # type-check && panda && tsc && vite build` を呼ぶため、上の test step
-        # と二重実行になる。さらに build 内 test 失敗が build regression として
-        # 通知されると原因切り分けが崩れるため、ここでは test / lint を含まない
-        # 専用 script `build:ci` (= `panda && tsc && vite build`) を呼ぶ。
+        # pnpm build は内部で lint / test:run / type-check 系を経た上で
+        # panda + tsc + (tsc --project tsconfig.api.json) + vite build を呼ぶため、
+        # 上の test step と二重実行になる。さらに build 内 test 失敗が
+        # build regression として通知されると原因切り分けが崩れるため、
+        # ここでは test / lint を含まない専用 script `build:ci` を呼ぶ
+        # (実体は package.json の `build:ci` を参照。本番 `build` 経路の
+        # panda / tsc / vite build と同等のコマンド列に追従させている)。
         # Issue #528: 以前は `pnpm exec panda && pnpm exec tsc && pnpm exec vite
         # build` を直接書いていたが、本番 `build` script とのコマンド列 drift
         # を防ぐため package.json 側に `build:ci` を切り出して呼ぶ形に変更
-        # した。`build:ci` は本番 build 経路 (panda + tsc + vite build) と
-        # 等価な軽量版で、test / lint / type-check:scripts は意図的に含めない。
+        # した。`build:ci` は本番 build 経路と等価な軽量版で、test / lint /
+        # type-check:scripts は意図的に含めない。
+        # Issue #667: src/api/ を本体 tsc から分離した際、`build:ci` に
+        # `tsc --project tsconfig.api.json` step が追加された。本番 `build`
+        # も同じ tsc 列を踏むため drift は無く、本 step は `pnpm run build:ci`
+        # を呼ぶだけで自動追従する。コマンド列の正確な定義は package.json の
+        # `build:ci` を一次情報源として参照すること。
         run: pnpm run build:ci
 
       - name: Report build regression

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "panda --watch & vite",
-    "build": "pnpm run lint && pnpm run test:run && pnpm run type-check && pnpm run type-check:scripts && panda && tsc && vite build",
-    "build:ci": "panda && tsc && vite build",
+    "build": "pnpm run lint && pnpm run test:run && pnpm run type-check && pnpm run type-check:api && pnpm run type-check:scripts && panda && tsc && tsc --project tsconfig.api.json && vite build",
+    "build:ci": "panda && tsc && tsc --project tsconfig.api.json && vite build",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
@@ -17,6 +17,7 @@
     "lint": "biome lint ./src ./scripts",
     "lint:tokens": "node scripts/lintTokens.ts",
     "type-check": "tsc --noEmit",
+    "type-check:api": "tsc --noEmit --project tsconfig.api.json",
     "type-check:test": "tsc --noEmit --project tsconfig.test.json",
     "type-check:scripts": "tsc --noEmit --project tsconfig.scripts.json",
     "prepare": "panda codegen",

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -1,0 +1,27 @@
+{
+  // tsconfig.json (本体, ブラウザ) を継承し、src/api/ 配下専用に Node サーバサイド向け
+  // の設定を上書きする。
+  //
+  // 本体 tsconfig は src/api/** を exclude しており、src/ の純粋ブラウザコードから
+  // @types/node の ambient globals (process / Buffer / __dirname 等) が参照できない。
+  // 一方 src/api/ は Vite dev server middleware として Node 環境で動作するため、
+  // 本ファイルで明示的に @types/node を有効化し、Node API を型付きで参照可能にする
+  // (Issue #667)。
+  //
+  // include は src/api のみだが、src/api/posts.ts は ../lib/markdownParser を import
+  // するため、moduleResolution: "bundler" によって相対 import 先の型は自動解決される。
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // src/api/ は Node サーバサイドとして実行されるため、@types/node の ambient globals
+    // (process / Buffer / __dirname 等) を有効化する。
+    // ブラウザ向け型 (vitest/globals / @testing-library/jest-dom) は不要なので含めない。
+    "types": ["node"],
+    // Incremental build (Issue #580): tsconfig.json / tsconfig.test.json /
+    // tsconfig.scripts.json と独立した .tsbuildinfo を出力する。
+    // include / types が異なるため別ファイルにしないと衝突する。
+    "tsBuildInfoFile": "./.tsbuildinfo/tsconfig.api.tsbuildinfo"
+  },
+  "include": ["src/api"],
+  // 本体 tsconfig の exclude を上書き (空配列) して、src/api 配下を確実に対象化する。
+  "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,26 @@
     /* Types */
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["src"]
+  "include": ["src"],
+  // 本体 (ブラウザ向け) の型チェックから以下を除外する (Issue #667):
+  //
+  // 1. src/api/**: Vite dev server middleware として Node 環境で動作するため、
+  //    tsconfig.api.json 側で @types/node を有効化して型付けする。
+  //
+  // 2. src/**/__tests__/**, src/**/*.test.*, src/**/*.spec.*: テストファイルは
+  //    tsconfig.test.json 側で型チェックする。一部のテスト (src/lib/__tests__ や
+  //    src/api/__tests__) は node:fs / process / __dirname 等 Node API を参照する
+  //    ため、これらを本体に含めると @types/node の ambient globals がブラウザ
+  //    コードへも漏出し、Issue #667 の防衛の意味が失われる。
+  //
+  // この exclude により src/ の純粋ブラウザコードから process / Buffer 等の Node 由来
+  // ambient 型が参照不可になる (tsc エラー化)。
+  "exclude": [
+    "src/api/**",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,10 +3,17 @@
   // include は本体の ["src"] を継承する (Issue #634 で本体から "scripts" を除外したため、
   // ここでも src 配下のテストのみが対象となる)。
   // scripts 配下の __tests__ は tsconfig.scripts.json 側で型チェックする。
+  //
+  // 本体 tsconfig は src/api/** を exclude しているが (Issue #667)、
+  // テスト側は src/api/__tests__/posts.test.ts と src/lib/__tests__/*.ts (node:fs 等を
+  // 使うもの) を含めて型チェックする必要があるため、exclude を空配列で上書きし、
+  // types に "node" を追加して Node API を型付き参照可能にする。
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    // vite/client は src 配下のテストが import.meta.env 等を参照するため必要
-    "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client"],
+    // vite/client は src 配下のテストが import.meta.env 等を参照するため必要。
+    // node は src/api/__tests__ や src/lib/__tests__ の一部が node:fs / process /
+    // __dirname 等を参照するため必要 (Issue #667)。
+    "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client", "node"],
     // テストでは setup 用の helper 変数等で意図的に未使用なものを許容する
     "noUnusedLocals": false,
     "noUnusedParameters": false,
@@ -14,5 +21,8 @@
     // 本体と test で include は同じだが、設定差分により別ビルド状態を持つため
     // ファイルを分離する。
     "tsBuildInfoFile": "./.tsbuildinfo/tsconfig.test.tsbuildinfo"
-  }
+  },
+  // 本体 tsconfig が src/api/** を exclude しているのを、テスト側では取り消す
+  // (src/api/__tests__/posts.test.ts を型チェック対象に含めるため)。
+  "exclude": []
 }


### PR DESCRIPTION
## 概要

Issue #667 対応（PR #666 / Issue #634 follow-up）。PR #666 で `tsconfig.scripts.json` を新設し scripts/ 由来の `@types/node` ambient 型ロードを本体 tsc から遮断したが、本体 `tsconfig.json` は依然 `src/api/` 配下を含むため `@types/node/globals.d.ts` が src/ 純粋ブラウザコードからも transitively 参照可能な状態が残っていた。本 PR で `tsconfig.api.json` 新設 + 本体 tsconfig から `src/api/**` + テストファイル群を exclude し、Node ambient 型を src/ 純粋ブラウザコードから構造的に遮断する。

## 変更内容

### tsconfig 系
- `tsconfig.json` (本体, ブラウザ): `exclude` に `src/api/**` + テストファイル群 (`src/**/__tests__/**`, `*.test.{ts,tsx}`, `*.spec.{ts,tsx}`) を追加
- `tsconfig.api.json` (新規, Node サーバサイド): 本体を `extends`、`include: ["src/api"]`, `types: ["node"]`, `exclude: []`（本体 exclude をキャンセル）。独立 `.tsbuildinfo`
- `tsconfig.test.json`: `types` に `"node"` 追加、`exclude: []`（src/lib/__tests__/*.ts が `node:fs` / `process` を参照するため）

### `package.json`
- `type-check:api` script 追加（`tsc --noEmit -p tsconfig.api.json`）
- `build` / `build:ci` の tsc ステップに `tsc --project tsconfig.api.json` を組み込み

### `.github/workflows/`
- `ci.yml` / `deploy.yml` の `.tsbuildinfo` cache key (`hashFiles()` + `restore-keys`) に `'tsconfig.api.json'` を追記（drift 防止のため両 workflow 同期）
- `panda-hash-regression.yml` のコメントを一次情報源 (`pnpm run build:ci` / `package.json`) への参照に抽象化（今後 `build:ci` 構成が変わってもコメント追従が不要になる構造）

## 備考

### テスト exclude 拡張の判断

本体 `tsconfig.json` から `src/**/__tests__/**` 等を exclude しないと、`src/lib/__tests__/*.ts` が `node:fs` / `process` 等を import している経路で `@types/node` の ambient global が transitively 引き込まれ、Issue #667 の防衛 (TS2591 化) が完全に無効化される。テストは `tsconfig.test.json` 専用に責務分離する整理（`tsconfig.test.json` 側に `node` types 追加で型付き参照可能）。

### 手動検証 (process / Buffer 参照エラー化)

- `src/lib/_process_probe.ts` に `process.cwd()` を追加 → `pnpm type-check` で `TS2591: Cannot find name 'process'` エラー化を確認
- `src/lib/_buffer_probe.ts` に `Buffer.from(...)` を追加 → 同様に `TS2591: Cannot find name 'Buffer'` エラー化を確認
- `src/api/_node_probe.ts` で `node:process` / `node:buffer` 参照 → `pnpm type-check:api` で型付き参照可能を確認
- プローブはすべて削除済み（`git status` で残存なし確認）

### 検証

- `pnpm lint` / `pnpm type-check` / `pnpm type-check:api` (新規) / `pnpm type-check:test` / `pnpm type-check:scripts` / `pnpm test:run` (1006 件) / `pnpm build` 全 pass
- `actionlint` 新規エラーなし

Closes #667