### PR TITLE
chore: FeaturedCard.tsx の表示文言を定数化 (Closes #691)

### DIFF
--- a/src/components/atoms/FeaturedCard.tsx
+++ b/src/components/atoms/FeaturedCard.tsx
@@ -6,6 +6,10 @@ import { buildPostHeroTransitionName } from "../../lib/viewTransition";
 import { MetaInfo } from "../common/MetaInfo";
 import { Link } from "./Link";
 
+// "FEATURED" ラベル文言 (雑誌の特集タグ表記)。Issue #691 / #630 でファイル内
+// トップレベル定数として外出しし、JSX から定数参照する。
+const FEATURED_SECTION_LABEL = "Featured" as const;
+
 interface FeaturedCardProps {
   post: PostSummary;
 }
@@ -145,7 +149,7 @@ export const FeaturedCard = memo(({ post }: FeaturedCardProps) => {
 
   return (
     <article className={featuredWrapperStyles}>
-      <span className={featuredLabelStyles}>Featured</span>
+      <span className={featuredLabelStyles}>{FEATURED_SECTION_LABEL}</span>
       <div className={featuredMetaStyles}>
         <MetaInfo
           createdAt={post.createdAt}


### PR DESCRIPTION
## 概要

Issue #630 (Anchor 系外コンポーネントの表示文言定数化ロードマップ) のファイル単位 follow-up。`FeaturedCard.tsx` の `"Featured"` ラベル文字列をファイル内トップレベル定数として外出し、将来の i18n 影響範囲を局所化する。

Closes #691

## 変更内容

- `src/components/atoms/FeaturedCard.tsx`:
  - `const FEATURED_SECTION_LABEL = "Featured" as const;` を import 直下に追加
  - JSX L152 の `"Featured"` を `{FEATURED_SECTION_LABEL}` で参照
  - 命名は PR #627 系 (`RESURFACE_SECTION_HEADING` / `ANCHOR_MILESTONES_SECTION_HEADING` 等) の `<SUBJECT>_<CONTEXT>` 形式に整合
  - `as const` でリテラル型を温存 (PR #627 DA レビュー S-2 と同方針)
  - 出力文字列が不変なため既存テスト全 pass

## ローカルレビュー結果

- 実装担当 → レビュワー (/review 相当) → DA の 3 段階レビュー実施
- DA 指摘 (M: 命名規約整合) を反映し、`FEATURED_LABEL` → `FEATURED_SECTION_LABEL` に修正
- 出力文字列不変のため Tripwire 全 pass

## 検証

- [x] `pnpm test:run` pass (55 files / 1006 tests)
- [x] `pnpm lint` pass (125 files, no fixes applied)

## 備考