### PR TITLE
chore: IndexRow.tsx の表示文言を定数化 (Closes #692)

### DIFF
--- a/src/components/atoms/IndexRow.tsx
+++ b/src/components/atoms/IndexRow.tsx
@@ -5,6 +5,22 @@ import type { PostSummary } from "../../lib/markdown";
 import { buildPostHeroTransitionName } from "../../lib/viewTransition";
 import { Link } from "./Link";
 
+// 著者欠落時のフォールバック文言。`MetaInfo.tsx` でも同一文言を利用しており、
+// 横串共通化の余地があるが、本 Issue (#692) では IndexRow.tsx 単位の定数化に
+// スコープを絞り、`src/lib/i18nLiterals.ts` への集約は follow-up Issue 候補
+// として保留する (調査結果は Issue #692 報告に記載)。
+const INDEX_ROW_AUTHOR_FALLBACK = "匿名" as const;
+
+// 日付欠落時のフォールバック文言。`MetaInfo.tsx` でも同一文言を利用しており、
+// 横串共通化の余地があるが、本 Issue (#692) では IndexRow.tsx 単位の定数化に
+// スコープを絞る (同上)。
+const INDEX_ROW_DATE_FALLBACK = "日付未設定" as const;
+
+// メタ情報 (著者 / 日付) 間の視覚区切り。Em ダッシュ (U+2014) を使う。
+// aria-hidden の装飾要素として扱う (R-4 / Issue #395 (vi) に従い UI 用絵文字は
+// 使用しない)。
+const INDEX_ROW_META_SEPARATOR = "—" as const;
+
 interface IndexRowProps {
   post: PostSummary;
   /**
@@ -224,11 +240,11 @@ export const IndexRow = memo(({ post, index }: IndexRowProps) => {
       </span>
       <span className={indexLeaderStyles} aria-hidden="true" />
       <span className={indexMetaStyles}>
-        <span>{post.author || "匿名"}</span>
+        <span>{post.author || INDEX_ROW_AUTHOR_FALLBACK}</span>
         <span className={indexMetaSeparatorStyles} aria-hidden="true">
-          —
+          {INDEX_ROW_META_SEPARATOR}
         </span>
-        <span>{post.createdAt || "日付未設定"}</span>
+        <span>{post.createdAt || INDEX_ROW_DATE_FALLBACK}</span>
       </span>
     </li>
   );


### PR DESCRIPTION
## 概要

Issue #630 (Anchor 系外コンポーネントの表示文言定数化ロードマップ) のファイル単位 follow-up。`IndexRow.tsx` の 3 件の表示文言 (`"匿名"` / `"日付未設定"` / `"—"`) を定数化する。

Closes #692

## 変更内容

- `src/components/atoms/IndexRow.tsx`:
  - `INDEX_ROW_AUTHOR_FALLBACK = "匿名" as const` 追加 (著者欠落時のフォールバック)
  - `INDEX_ROW_DATE_FALLBACK = "日付未設定" as const` 追加 (日付欠落時のフォールバック)
  - `INDEX_ROW_META_SEPARATOR = "—" as const` 追加 (Em ダッシュメタ情報セパレータ、aria-hidden の装飾文字も grep 起点として価値ありと判断)
  - JSX 3 箇所を定数参照に置換
  - 出力文字列が不変なため既存テスト全 pass

## ローカルレビュー結果

- 実装担当 → レビュワー (/review 相当) → DA の 3 段階レビュー実施
- DA 指摘:
  - 横串共通化 (`"匿名"` / `"日付未設定"` は MetaInfo.tsx と重複) → follow-up Issue #706 として起票済み、本 PR スコープ外
  - Em ダッシュ aria-hidden の getByText アサーション矛盾 → follow-up Issue #709 として起票済み
- 上記 2 件は別 Issue で追跡し、本 PR は IndexRow.tsx 単位の機械的前進にスコープを絞る

## 関連 follow-up Issue

- #706: i18nLiterals.ts への `AUTHOR_FALLBACK` / `DATE_FALLBACK` 横串集約
- #709: aria-hidden 装飾要素を getByText でアサートする運用方針の整理

## 検証

- [x] `pnpm test:run` pass (55 files / 1006 tests)
- [x] `pnpm lint` pass (125 files, no fixes applied)

## 備考