### PR TITLE
chore: HomePage.tsx の表示文言を定数化 (Closes #694)

### DIFF
--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -10,6 +10,19 @@ import { EmptyState } from "../common/EmptyState";
 import { Pagination } from "../common/Pagination";
 import { Resurface } from "../common/Resurface";
 
+/**
+ * HomePage の表示文言定数 (Issue #694)。
+ *
+ * Issue #630 のロードマップに沿って、表示文言を JSX 直書きからファイル内
+ * トップレベル定数に外出しする。PR #627 (Anchor 系) と同じ方針で、リテラル
+ * 定数には `as const` を付与して literal type を温存する。
+ */
+const HOMEPAGE_EMPTY_STATE_TITLE = "新しい記事をお楽しみに" as const;
+const HOMEPAGE_EMPTY_STATE_DESCRIPTION =
+  "まもなく素晴らしい記事が公開される予定です。創造性に満ちたコンテンツをお届けします。" as const;
+const HOMEPAGE_BENTO_ARIA_LABEL = "注目の記事" as const;
+const HOMEPAGE_INDEX_HEADING = "Index" as const;
+
 interface HomePageProps {
   posts: PostSummary[];
   currentPage: number;
@@ -199,8 +212,8 @@ export const HomePage = memo(
         <div className={containerStyles}>
           <EmptyState
             icon={FileText}
-            title="新しい記事をお楽しみに"
-            description="まもなく素晴らしい記事が公開される予定です。創造性に満ちたコンテンツをお届けします。"
+            title={HOMEPAGE_EMPTY_STATE_TITLE}
+            description={HOMEPAGE_EMPTY_STATE_DESCRIPTION}
           />
         </div>
       );
@@ -214,7 +227,7 @@ export const HomePage = memo(
 
           {/* Bento: 2-7 記事目 */}
           {bentoPosts.length > 0 && (
-            <section className={bentoGridStyles} aria-label="注目の記事">
+            <section className={bentoGridStyles} aria-label={HOMEPAGE_BENTO_ARIA_LABEL}>
               {bentoPosts.map((post, idx) => (
                 <BentoCard key={post.id} post={post} size={bentoSizes[idx]} />
               ))}
@@ -228,7 +241,7 @@ export const HomePage = memo(
           {indexPosts.length > 0 && (
             <section aria-labelledby="index-section-heading">
               <h3 id="index-section-heading" className={indexHeadingStyles}>
-                Index
+                {HOMEPAGE_INDEX_HEADING}
               </h3>
               <ul className={indexListStyles} data-token-border="border.subtle">
                 {indexPosts.map((post, idx) => (


### PR DESCRIPTION
## 概要

Issue #630 (Anchor 系外コンポーネントの表示文言定数化ロードマップ) のファイル単位 follow-up。`HomePage.tsx` の 4 件の表示文言を定数化する。

Closes #694

## 変更内容

- `src/components/pages/HomePage.tsx`:
  - `HOMEPAGE_EMPTY_STATE_TITLE = "新しい記事をお楽しみに" as const` (EmptyState 経由の見出し)
  - `HOMEPAGE_EMPTY_STATE_DESCRIPTION = "まもなく素晴らしい記事が公開される予定です。..." as const` (EmptyState 経由の説明文)
  - `HOMEPAGE_BENTO_ARIA_LABEL = "注目の記事" as const` (Bento グリッド a11y ラベル)
  - `HOMEPAGE_INDEX_HEADING = "Index" as const` (Magazine 風 TOC 章タイトル)
  - JSX 4 箇所を定数参照に置換
  - 命名は PR #627 系 (AnchorPage 先例 `ANCHOR_EMPTY_MILESTONES_MESSAGE` / `ANCHOR_EMPTY_POSTS_MESSAGE`) の `_EMPTY_<TARGET>_<TYPE>` 形式に整合
  - 出力文字列が不変なため既存テスト全 pass

## ローカルレビュー結果

- 実装担当 → レビュワー (/review 相当) → DA の 3 段階レビュー実施
- DA 指摘 (M: AnchorPage 先例との命名形式統一) を反映し、`HOMEPAGE_EMPTY_TITLE` / `HOMEPAGE_EMPTY_DESCRIPTION` → `HOMEPAGE_EMPTY_STATE_TITLE` / `HOMEPAGE_EMPTY_STATE_DESCRIPTION` に修正

## 検証

- [x] `pnpm test:run` pass (55 files / 1006 tests)
- [x] `pnpm lint` pass (125 files, no fixes applied)

## 備考