### PR TITLE
chore: PostDetailPage.tsx の表示文言を定数化 (Closes #695)

### DIFF
--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -15,6 +15,20 @@ import { MetaInfo } from "../common/MetaInfo";
 import { PostNavigation } from "../common/PostNavigation";
 import { TableOfContents } from "../common/TableOfContents";
 
+// Issue #695: 表示文言テンプレートを定数として外出し。将来の i18n 化や
+// 文言調整の影響範囲をファイル内 1 箇所に局所化する。
+// (i18n フレームワークは導入しない方針 — 単純な template リテラルに留める)
+//
+// 矢印「←」はテキストの一部として 1 定数に連結したまま保持する。理由:
+// - 現状 JSX は `<Link>← TOPに戻る</Link>` の単一テキストノードで構成されており、
+//   矢印を別 span で装飾扱いしていない (= aria-hidden で SR から隠す構造ではない)。
+// - 連結のまま 1 定数化する方が JSX 側の変更を最小化でき、テンプレート文字列
+//   としての可読性も保たれる。
+// - 将来矢印をアイコンコンポーネント化する等の構造変更が入る場合は、その時点で
+//   再度分離を検討する (現時点では YAGNI)。
+const POST_DETAIL_NAV_ARIA_LABEL = "ページナビゲーション" as const;
+const POST_DETAIL_BACK_TO_TOP_LABEL = "← TOPに戻る" as const;
+
 interface PostDetailPageProps {
   post: Post;
   olderPost: PostSummary | null;
@@ -76,7 +90,7 @@ export const PostDetailPage = ({
     <>
       {/* Navigation */}
       <nav
-        aria-label="ページナビゲーション"
+        aria-label={POST_DETAIL_NAV_ARIA_LABEL}
         data-token-border="border.subtle"
         className={css({
           background: "bg.surface",
@@ -102,7 +116,7 @@ export const PostDetailPage = ({
           })}
         >
           <Link to="/" variant="navigation">
-            ← TOPに戻る
+            {POST_DETAIL_BACK_TO_TOP_LABEL}
           </Link>
         </div>
       </nav>


### PR DESCRIPTION
## 概要

Issue #630 (Anchor 系外コンポーネントの表示文言定数化ロードマップ) のファイル単位 follow-up。`PostDetailPage.tsx` の 2 件の表示文言を定数化する。

Closes #695

## 変更内容

- `src/components/pages/PostDetailPage.tsx`:
  - `POST_DETAIL_NAV_ARIA_LABEL = "ページナビゲーション" as const` (戻る nav の a11y ラベル)
  - `POST_DETAIL_BACK_TO_TOP_LABEL = "← TOPに戻る" as const` (戻るリンク表示文字列)
  - JSX 2 箇所を定数参照に置換
  - 矢印分離は YAGNI 観点で連結 1 定数を採用 (現状 JSX が単一テキストノード構成のため装飾分離不要)
  - 出力文字列が不変なため既存テスト全 pass

## ローカルレビュー結果

- 実装担当 → レビュワー (/review 相当) → DA の 3 段階レビュー実施
- DA はマージ可と判定。follow-up 観点を別 Issue で追跡

## 関連 follow-up Issue

- #708: PostDetailPage 戻るリンクの矢印分離 i18n / RTL 対応の再評価

## 検証

- [x] `pnpm test:run` pass (55 files / 1006 tests)
- [x] `pnpm lint` pass (125 files, no fixes applied)

## 備考