### PR TITLE
chore: BackToTop.tsx の表示文言を定数化 (Closes #707)

### DIFF
--- a/src/components/common/BackToTop.tsx
+++ b/src/components/common/BackToTop.tsx
@@ -3,6 +3,23 @@ import { css } from "../../../styled-system/css";
 import { useScrollPosition } from "../../hooks/useScrollPosition";
 import { focusRingStyles } from "../../styles/focusRing";
 
+/**
+ * BackToTop の表示文言定数 (Issue #707)。
+ *
+ * Issue #630 のロードマップに沿って、表示文言を JSX 直書きからファイル内
+ * トップレベル定数に外出しする。PR #627 (Anchor 系) と同じ方針で、リテラル
+ * 定数には `as const` を付与して literal type を温存する。
+ *
+ * `BACK_TO_TOP_ARROW` は button 内の装飾矢印 (Unicode 文字 `↑`) を表す。
+ * SVG / アイコンフォントではなく純粋な glyph のため `ICON` ではなく
+ * `ARROW` と命名する。button には `aria-label={BACK_TO_TOP_ARIA_LABEL}`
+ * で SR 向けラベルを付与しており、矢印自体は視覚装飾扱い。JSX 側では
+ * `<span aria-hidden="true">` で wrap し、accessible name 計算で
+ * textContent が二重発話されないようにする (Issue #707 本文要件)。
+ */
+const BACK_TO_TOP_ARIA_LABEL = "ページトップへ戻る" as const;
+const BACK_TO_TOP_ARROW = "↑" as const;
+
 const SHOW_THRESHOLD = 300;
 
 // Editorial Citrus トークン (R-2b / Issue #389、Issue #421 で border/hover を改訂)
@@ -77,13 +94,13 @@ export const BackToTop = () => {
         type="button"
         className={`${buttonStyles} ${focusRingStyles}`}
         onClick={handleClick}
-        aria-label="ページトップへ戻る"
+        aria-label={BACK_TO_TOP_ARIA_LABEL}
         data-token-bg="bg.surface"
         data-token-border="border.subtle"
         data-token-hover-bg="bg.muted"
         data-focus-ring="default"
       >
-        ↑
+        <span aria-hidden="true">{BACK_TO_TOP_ARROW}</span>
       </button>
     </Transition>
   );


### PR DESCRIPTION
## 概要

Issue #630 (Anchor 系外コンポーネントの表示文言定数化ロードマップ) の後出し follow-up。`BackToTop.tsx` の表示文言を定数化する。

Closes #707

## 変更内容

- `src/components/common/BackToTop.tsx`:
  - `BACK_TO_TOP_ARIA_LABEL = "ページトップへ戻る" as const` (SR 向け aria-label)
  - `BACK_TO_TOP_ARROW = "↑" as const` (上矢印 glyph)
  - JSX 構造変更: 上矢印を \`<span aria-hidden="true">{BACK_TO_TOP_ARROW}</span>\` で wrap し、accessible name は button の aria-label のみから計算される構造に整理
  - 命名は PR #710-#713 系 (`POST_DETAIL_BACK_TO_TOP_LABEL` 等) の `<DOMAIN>_<CONTEXT>` 形式に整合
  - 出力文字列が不変、Tripwire アサート (`data-token-*`) は button 直下属性のみ参照のため span 追加で破綻しない

## ローカルレビュー結果

- 実装担当 → レビュワー (/review 相当) → DA の 3 段階レビュー
- DA M-1 指摘 (aria-hidden 明示 wrap) と M-2 指摘 (命名 `ICON` → `ARROW`) を反映
- 修正後の再レビューで両 DA 指摘の対応が承認

## 横串集約見送り判断

`PostDetailPage` の `← TOPに戻る` (PR #713) との横串集約は、用途が異なるため見送り:
- BackToTop: ページ内スクロール上端へ戻る (`window.scrollTo`)
- PostDetailPage 戻るリンク: ホーム/記事一覧へ遷移 (`to="/"`)

## 検証

- [x] `pnpm test:run` pass (55 files / 1006 tests)
- [x] `pnpm lint` pass (125 files, no fixes applied)

## 備考