### PR TITLE
chore: BackToTop.tsx の表示文言を定数化 (Closes #707)

### DIFF
--- a/src/components/common/BackToTop.tsx
+++ b/src/components/common/BackToTop.tsx
@@ -5,6 +5,25 @@ import { focusRingStyles } from "../../styles/focusRing";
 
 const SHOW_THRESHOLD = 300;
 
+/**
+ * ボタンの aria-label。スクリーンリーダ向けの操作説明として観測される単独参照の文言だが、
+ * 表示文言の散らばり防止 (Issue #534 follow-up: Issue #707) のため、PostDetailPage 等の先行 PR と
+ * 同方針で `as const` + UPPER_SNAKE_CASE で定数化する。
+ *
+ * PostDetailPage の `POST_DETAIL_BACK_TO_TOP_LABEL = "← TOPに戻る"` とは意味が異なる:
+ *   - こちらは「ページトップへ戻る」(常設の浮動ボタンの aria-label)
+ *   - PostDetailPage 側は「記事末尾から記事冒頭(= 記事タイトル/ナビ)へ戻る」インラインリンクのテキスト
+ * 共通化はしない (Issue #707 推奨アプローチに準拠)。
+ */
+const BACK_TO_TOP_ARIA_LABEL = "ページトップへ戻る" as const;
+
+/**
+ * ボタン表示文言の上矢印アイコン。Unicode 記号 1 文字の trivial な単独参照だが、JSX 内の
+ * 直接記述を避け表示文言を一箇所に集約する Issue #534 系列の方針に沿って定数化する。
+ * 将来アイコン差し替え (例: lucide-react icon 化) する際の置換点を 1 箇所に局所化する目的も兼ねる。
+ */
+const BACK_TO_TOP_ICON_LABEL = "↑" as const;
+
 // Editorial Citrus トークン (R-2b / Issue #389、Issue #421 で border/hover を改訂)
 // - 浮き上がる固定ボタンのため bg.surface を背景に使用 (親 bg.canvas より一段濃く、視認性確保)
 // - border 専用 token (border.subtle) で 1.4.11 (3:1) を確保
@@ -77,13 +96,13 @@ export const BackToTop = () => {
         type="button"
         className={`${buttonStyles} ${focusRingStyles}`}
         onClick={handleClick}
-        aria-label="ページトップへ戻る"
+        aria-label={BACK_TO_TOP_ARIA_LABEL}
         data-token-bg="bg.surface"
         data-token-border="border.subtle"
         data-token-hover-bg="bg.muted"
         data-focus-ring="default"
       >
-        ↑
+        {BACK_TO_TOP_ICON_LABEL}
       </button>
     </Transition>
   );

--- a/src/components/common/__tests__/BackToTop.test.tsx
+++ b/src/components/common/__tests__/BackToTop.test.tsx
@@ -8,6 +8,11 @@ vi.mock("../../../hooks/useScrollPosition", () => ({
 
 import { useScrollPosition } from "../../../hooks/useScrollPosition";
 
+// Issue #707: BackToTop.tsx の表示文言を定数化したが、テスト側は先行 PR (PostDetailPage 等) と
+// 同様に「ユーザに見える文言」をハードコードで保持し、文言が変わったら CI で検知できる
+// snapshot 的役割を維持する (= プロダクション定数の rename だけで通らないことを保証)。
+const BACK_TO_TOP_ARIA_LABEL = "ページトップへ戻る" as const;
+
 describe("BackToTop", () => {
   beforeEach(() => {
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
@@ -27,7 +32,7 @@ describe("BackToTop", () => {
     render(<BackToTop />);
 
     expect(
-      screen.queryByRole("button", { name: "ページトップへ戻る" }),
+      screen.queryByRole("button", { name: BACK_TO_TOP_ARIA_LABEL }),
     ).not.toBeInTheDocument();
   });
 
@@ -37,7 +42,7 @@ describe("BackToTop", () => {
     render(<BackToTop />);
 
     expect(
-      screen.getByRole("button", { name: "ページトップへ戻る" }),
+      screen.getByRole("button", { name: BACK_TO_TOP_ARIA_LABEL }),
     ).toBeInTheDocument();
   });
 
@@ -48,7 +53,7 @@ describe("BackToTop", () => {
     render(<BackToTop />);
 
     act(() => {
-      screen.getByRole("button", { name: "ページトップへ戻る" }).click();
+      screen.getByRole("button", { name: BACK_TO_TOP_ARIA_LABEL }).click();
     });
 
     expect(window.scrollTo).toHaveBeenCalledWith({
@@ -70,7 +75,7 @@ describe("BackToTop", () => {
 
       render(<BackToTop />);
 
-      const button = screen.getByRole("button", { name: "ページトップへ戻る" });
+      const button = screen.getByRole("button", { name: BACK_TO_TOP_ARIA_LABEL });
       expect(button).toHaveAttribute("data-token-border", "border.subtle");
     });
 
@@ -79,7 +84,7 @@ describe("BackToTop", () => {
 
       render(<BackToTop />);
 
-      const button = screen.getByRole("button", { name: "ページトップへ戻る" });
+      const button = screen.getByRole("button", { name: BACK_TO_TOP_ARIA_LABEL });
       expect(button).toHaveAttribute("data-token-hover-bg", "bg.muted");
     });
   });


### PR DESCRIPTION
## 概要

Issue #707 対応（Issue #630 / Issue #534 follow-up）。`src/components/common/BackToTop.tsx` の表示文言を Issue #534 方針（ファイル内トップレベル定数 + `as const` + UPPER_SNAKE_CASE）で定数化する。

## 変更内容（2 commits）

### `e94068c` プロダクション側
- `src/components/common/BackToTop.tsx`:
  - `BACK_TO_TOP_ARIA_LABEL = "ページトップへ戻る"` — 浮動ボタン aria-label
  - `BACK_TO_TOP_ICON_LABEL = "↑"` — ボタン本文の上矢印（lucide-react icon 化時の置換点局所化を JSDoc で明示）
  - PostDetailPage の `POST_DETAIL_BACK_TO_TOP_LABEL = "← TOPに戻る"` とは意味が異なるため共通化せず、局所定数として JSDoc で違いを明示

### `74848c3` テスト側
- `src/components/common/__tests__/BackToTop.test.tsx`:
  - 同名ローカル定数を追加（snapshot 役割で意図的に二重定義）
  - JSDoc で「プロダクション定数の rename だけでは通らないことを保証する」方針を明記
  - PR #627 / #710 / #711 / #712 / #713 の他コンポーネントテスト方針と整合

## 備考

### YAGNI 判断: `↑` 矢印の定数化

1 文字 Unicode のため過剰の疑いもあるが、`"Featured"` (1 単語、PR #710) / `"Index"` (1 単語、PR #712) も同方針で定数化済み。Issue #534 系列の方針が「JSX 直書き文言の集約」である以上、字数基準ではなく文言集約が目的のため、本 PR も一連と整合。

### コミット粒度 2 分割

「本体定数化」と「テスト側 snapshot 役割追加」はテスト側に独立した意図（snapshot 維持）があるため、別コミットが CLAUDE.md「対応内容ごとにコミット」に整合。bisect 容易性も向上。

### 検証

- `pnpm lint` (127 files) / `pnpm type-check` / `pnpm test:run` (1027 件) / `pnpm build` 全 pass

Closes #707