### PR TITLE
chore: checkBuildCiSync の部分一致判定を word-tokenize suffix 化 + 空文字 fail 化 (Closes #701)

### DIFF
--- a/scripts/__tests__/checkBuildCiSync.test.ts
+++ b/scripts/__tests__/checkBuildCiSync.test.ts
@@ -1,25 +1,31 @@
 /**
- * scripts/checkBuildCiSync.ts の単体テスト (Issue #685)
+ * scripts/checkBuildCiSync.ts の単体テスト (Issue #685 / #701)
  *
  * 検証対象:
  *   - splitCommands: `&&` 区切りで command を取り出し、空 token を除外する
+ *   - tokenizeCommand: 空白区切りで token 列を返し、空 token を除外する
  *   - checkSync:
  *       - build に build:ci の全 command が順序を保って含まれていれば ok
  *       - 順序が崩れた / command が抜けていれば ng (reason 付き)
  *       - build:ci 側が空なら ok (検査対象なし)
- *       - 部分一致 (prefix 付き wrapper など) を許容する
+ *       - wrapper prefix (`pnpm exec tsc` 等) を許容する
+ *       - 部分一致誤検出 (`pnpm exec my-tsc-wrapper` ⊃ `tsc`) を排除する (Issue #701)
+ *       - multi-token command (`tsc --project tsconfig.api.json`) を token 列単位で扱う
  *   - loadPackageScripts: package.json から scripts.build / scripts["build:ci"] を取り出し、
  *     欠落 / 型違反は throw する
+ *   - main: buildCi が空文字列の場合に exit 1 で fail する (Issue #701)
  */
 
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   checkSync,
   loadPackageScripts,
+  main,
   splitCommands,
+  tokenizeCommand,
 } from "../checkBuildCiSync.ts";
 
 describe("splitCommands", () => {
@@ -37,6 +43,36 @@ describe("splitCommands", () => {
 
   it("空白のみの token を除外する", () => {
     expect(splitCommands("panda && && tsc")).toEqual(["panda", "tsc"]);
+  });
+});
+
+describe("tokenizeCommand", () => {
+  it("空白区切りで token 配列を返す", () => {
+    expect(tokenizeCommand("pnpm exec tsc")).toEqual(["pnpm", "exec", "tsc"]);
+  });
+
+  it("単一 token の command をそのまま 1 要素配列にする", () => {
+    expect(tokenizeCommand("tsc")).toEqual(["tsc"]);
+  });
+
+  it("連続する空白を 1 つの区切りとして扱う", () => {
+    expect(tokenizeCommand("pnpm   exec   tsc")).toEqual([
+      "pnpm",
+      "exec",
+      "tsc",
+    ]);
+  });
+
+  it("flag 付き command を token に展開する", () => {
+    expect(tokenizeCommand("tsc --project tsconfig.api.json")).toEqual([
+      "tsc",
+      "--project",
+      "tsconfig.api.json",
+    ]);
+  });
+
+  it("空文字列に対して空配列を返す", () => {
+    expect(tokenizeCommand("")).toEqual([]);
   });
 });
 
@@ -73,11 +109,49 @@ describe("checkSync", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("部分一致 (wrapper prefix 付き) を許容する", () => {
+  it("wrapper prefix (`pnpm exec` 等) 付き build token を末尾完全一致で許容する", () => {
     const buildScript =
       "pnpm exec panda && pnpm exec tsc && pnpm exec vite build";
     const buildCiScript = "panda && tsc && vite build";
     expect(checkSync(buildScript, buildCiScript).ok).toBe(true);
+  });
+
+  it("build 側に `my-tsc-wrapper` のような別 command が含まれていても `tsc` を誤検出しない (Issue #701)", () => {
+    // 旧実装は `String#includes` の部分一致で `my-tsc-wrapper` が `tsc` に
+    // マッチしてしまっていた。word-tokenize 末尾完全一致では別 token として
+    // 区別されるため、build:ci の `tsc` は build に存在しないと判定される。
+    const buildScript = "panda && pnpm exec my-tsc-wrapper && vite build";
+    const buildCiScript = "panda && tsc && vite build";
+    const result = checkSync(buildScript, buildCiScript);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("tsc");
+  });
+
+  it("multi-token command (`tsc --project tsconfig.api.json`) を token 列単位で完全一致判定する", () => {
+    const buildScript =
+      "panda && tsc && tsc --project tsconfig.api.json && vite build";
+    const buildCiScript =
+      "panda && tsc && tsc --project tsconfig.api.json && vite build";
+    expect(checkSync(buildScript, buildCiScript).ok).toBe(true);
+  });
+
+  it("multi-token command の flag が欠けていれば ng (token 列の完全一致が崩れる)", () => {
+    const buildScript =
+      "panda && tsc && tsc --project tsconfig.app.json && vite build";
+    const buildCiScript =
+      "panda && tsc && tsc --project tsconfig.api.json && vite build";
+    const result = checkSync(buildScript, buildCiScript);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("tsc --project tsconfig.api.json");
+  });
+
+  it("build 側 token が `tscx` のような prefix 拡張でも `tsc` を誤検出しない", () => {
+    // 末尾完全一致なので `tscx` !== `tsc` で別 token と判定される。
+    const buildScript = "panda && tscx && vite build";
+    const buildCiScript = "panda && tsc && vite build";
+    const result = checkSync(buildScript, buildCiScript);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("tsc");
   });
 
   it("build が空かつ build:ci が非空なら ng", () => {
@@ -146,5 +220,131 @@ describe("loadPackageScripts", () => {
       }),
     );
     expect(() => loadPackageScripts(packagePath)).toThrow(/build:ci/);
+  });
+});
+
+describe("main", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "check-build-ci-sync-main-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * `process.exit(code)` を呼び出されたら同期的に throw する spy を仕込む。
+   * これにより main 内の早期 return ロジック (exit 後にコードが続かない前提)
+   * をテスト側でも担保できる。
+   */
+  const installExitSpy = (): void => {
+    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+  };
+
+  it("buildCi が空文字列なら exit 1 で fail する (Issue #701)", () => {
+    const packagePath = join(tempDir, "package.json");
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        scripts: {
+          build: "panda && tsc && vite build",
+          "build:ci": "",
+        },
+      }),
+    );
+    installExitSpy();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => main(packagePath)).toThrow(/process\.exit\(1\)/);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("build:ci"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/空文字列|構成不備/),
+    );
+  });
+
+  it("buildCi が空白のみでも exit 1 で fail する (Issue #701)", () => {
+    const packagePath = join(tempDir, "package.json");
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        scripts: {
+          build: "panda && tsc && vite build",
+          "build:ci": "   ",
+        },
+      }),
+    );
+    installExitSpy();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => main(packagePath)).toThrow(/process\.exit\(1\)/);
+  });
+
+  it("build / build:ci が同期していれば exit せず stdout に OK を出す", () => {
+    const packagePath = join(tempDir, "package.json");
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        scripts: {
+          build: "panda && tsc && vite build",
+          "build:ci": "panda && tsc && vite build",
+        },
+      }),
+    );
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit(${code ?? 0})`);
+      }) as never);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    expect(() => main(packagePath)).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("checkBuildCiSync OK"),
+    );
+  });
+
+  it("build に build:ci の command が欠落していれば exit 1 で fail する", () => {
+    const packagePath = join(tempDir, "package.json");
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        scripts: {
+          build: "panda && vite build",
+          "build:ci": "panda && tsc && vite build",
+        },
+      }),
+    );
+    installExitSpy();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => main(packagePath)).toThrow(/process\.exit\(1\)/);
+  });
+
+  it("Issue #701 誤検出シナリオ: build に my-tsc-wrapper があり tsc が無いと exit 1 で fail する", () => {
+    const packagePath = join(tempDir, "package.json");
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        scripts: {
+          build: "panda && pnpm exec my-tsc-wrapper && vite build",
+          "build:ci": "panda && tsc && vite build",
+        },
+      }),
+    );
+    installExitSpy();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => main(packagePath)).toThrow(/process\.exit\(1\)/);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("tsc"),
+    );
   });
 });

--- a/scripts/checkBuildCiSync.ts
+++ b/scripts/checkBuildCiSync.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Issue #685: `package.json` の `build` script と `build:ci` script の
+ * Issue #685 / #701: `package.json` の `build` script と `build:ci` script の
  * drift を CI で機械的に検知するためのガードスクリプト。
  *
  * 背景:
@@ -10,9 +10,9 @@
  *   - 過去 (Issue #528) は CLAUDE.md 散文で「`build` 変更時は `build:ci`
  *     も同期させること」と運用ルール化していたが、散文ルールは時間経過で
  *     形骸化する。
- *   - 本スクリプトは `build` 文字列に `build:ci` の各 command (`panda` /
- *     `tsc` / `vite build`) が **順序を保って** 含まれているかを部分一致で
- *     判定し、ずれていれば exit 1 で fail-fast する。
+ *   - 本スクリプトは `build` 文字列に `build:ci` の各 command が
+ *     **順序を保って** 含まれているかを word-tokenize ベースで判定し、
+ *     ずれていれば exit 1 で fail-fast する。
  *
  * 設計方針:
  *   - 本リポの `build` / `build:ci` 構造に絞った最小実装。汎用的な script
@@ -20,6 +20,14 @@
  *   - 外部依存追加禁止 (`node:fs` / `node:path` のみ)。
  *   - 純粋関数 `checkSync(buildScript, buildCiScript)` をテスト用に export
  *     する。CLI エントリ (`main`) は副作用 (file IO / process.exit) に集約。
+ *
+ * Issue #701 (DA Major 指摘対応): 旧実装は `String#includes` の部分一致で
+ *   command を判定していたため、`build:ci` の `tsc` が `build` 側の
+ *   `pnpm exec my-tsc-wrapper` のような別 command にマッチしてしまう
+ *   誤検出があった。`tokenizeCommand` で空白分割し、build:ci の token 列が
+ *   build token の **末尾と完全一致** するかで判定するよう変更した。
+ *   これにより `pnpm exec tsc` (= 末尾 `[tsc]`) は OK のまま、
+ *   `pnpm exec my-tsc-wrapper` (= 末尾 `[my-tsc-wrapper]`) は NG になる。
  *
  * 使い方:
  *   - `pnpm exec tsx scripts/checkBuildCiSync.ts`
@@ -65,20 +73,73 @@ const splitCommands = (script: string): string[] => {
 };
 
 /**
- * `build` script 文字列の中に `build:ci` の各 command が「順序を保って」
- * 部分一致で出現するかを判定する。
+ * command 文字列を空白で分割し、空 token を除外した token 配列を返す。
  *
- * アルゴリズム:
- *   - `build` を `splitCommands` で token 配列化する。
- *   - `build:ci` の各 command を順に走査し、`build` token 列の中から
- *     部分一致 (`String#includes`) する次の token を線形検索する。
+ * 例:
+ *   - `"tsc"` → `["tsc"]`
+ *   - `"pnpm exec tsc"` → `["pnpm", "exec", "tsc"]`
+ *   - `"tsc --project tsconfig.api.json"`
+ *     → `["tsc", "--project", "tsconfig.api.json"]`
+ *
+ * シェルの quoting / escape は scope 外 (`build` / `build:ci` は単純な
+ * 空白区切りの command 列にしか使われていないため、最小実装で十分)。
+ * 将来 quoting が必要になったら本関数を拡張する。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+const tokenizeCommand = (command: string): readonly string[] => {
+  return command
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+};
+
+/**
+ * `buildTokens` (build 側 token の word-tokenize 結果) の末尾が
+ * `ciTokens` (build:ci 側 command の word-tokenize 結果) と完全一致するか
+ * を判定する。
+ *
+ * 「末尾完全一致」を採用するのは、`pnpm exec tsc` のような wrapper prefix
+ * を許容しつつ、`pnpm exec my-tsc-wrapper` ⊃ `tsc` のような部分一致誤検出
+ * を排除するため (Issue #701)。
+ */
+const matchesAsSuffix = (
+  buildTokens: readonly string[],
+  ciTokens: readonly string[],
+): boolean => {
+  if (ciTokens.length === 0 || ciTokens.length > buildTokens.length) {
+    return false;
+  }
+  const offset = buildTokens.length - ciTokens.length;
+  for (let i = 0; i < ciTokens.length; i += 1) {
+    if (buildTokens[offset + i] !== ciTokens[i]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * `build` script 文字列の中に `build:ci` の各 command が「順序を保って」
+ * 出現するかを word-tokenize ベースで判定する。
+ *
+ * アルゴリズム (Issue #701 で部分一致 → word-tokenize 末尾一致へ変更):
+ *   - `build` / `build:ci` をそれぞれ `splitCommands` で `&&` 区切りの
+ *     command 配列にする。
+ *   - 各 command を `tokenizeCommand` で空白分割し、token 列に展開する。
+ *   - `build:ci` の各 command (token 列) を順に走査し、`build` 側の
+ *     command (token 列) の **末尾と完全一致** するものを線形検索する。
  *   - 全 `build:ci` command を順序を崩さず消費できれば ok。
  *   - 途中で見つからなくなった時点で reason 付き ng を返す。
  *
- * 部分一致 (`includes`) を採用する理由:
- *   - `build` 側に `pnpm run lint && ... && panda && tsc && vite build`
- *     のように prefix (`pnpm run`) や追加 flag が付くケースを許容するため。
- *   - 完全一致では `pnpm run build:ci` のような wrapper にも対応できない。
+ * 末尾完全一致を採用する理由 (Issue #701 DA Major 指摘対応):
+ *   - 旧実装は `String#includes` の部分一致で、`build:ci` の短い token
+ *     (例 `tsc`) が `build` 側の `pnpm exec my-tsc-wrapper` のような別
+ *     command にもマッチして誤検出していた。
+ *   - 末尾完全一致なら `pnpm exec tsc` (suffix = `[tsc]`) は OK のまま、
+ *     `pnpm exec my-tsc-wrapper` (suffix = `[my-tsc-wrapper]`) を NG に
+ *     できる。multi-token command (`tsc --project tsconfig.api.json` 等)
+ *     も token 列単位の完全一致として自然に扱える。
  *
  * 空配列ケース:
  *   - `buildCiScript` が空 (token 0 件): 検査する command が無いので ok。
@@ -98,20 +159,27 @@ const checkSync = (
     return { ok: true };
   }
 
-  const buildTokens = splitCommands(buildScript);
+  const buildTokenLists = splitCommands(buildScript).map((cmd) =>
+    tokenizeCommand(cmd),
+  );
   let cursor = 0;
   for (const ciCommand of ciCommands) {
+    const ciTokens = tokenizeCommand(ciCommand);
+    if (ciTokens.length === 0) {
+      // splitCommands で空 token は除外しているため通常到達しないが、
+      // tokenizeCommand 単独の戻り値型を信頼するためのガード。
+      continue;
+    }
     let matchedIndex = -1;
-    for (let i = cursor; i < buildTokens.length; i += 1) {
-      const token = buildTokens[i] ?? "";
-      if (token.includes(ciCommand)) {
+    for (let i = cursor; i < buildTokenLists.length; i += 1) {
+      const buildTokens = buildTokenLists[i] ?? [];
+      if (matchesAsSuffix(buildTokens, ciTokens)) {
         matchedIndex = i;
         break;
       }
     }
     if (matchedIndex === -1) {
-      const position =
-        cursor === 0 ? "" : " (前 command 以降の位置で)";
+      const position = cursor === 0 ? "" : " (前 command 以降の位置で)";
       return {
         ok: false,
         reason: `build:ci の command "${ciCommand}" が build script 内${position}に見つかりません。`,
@@ -171,13 +239,33 @@ const HINT_MESSAGE = [
   "     セクションの記述を併せて更新する",
 ].join("\n");
 
-const main = (): void => {
+/**
+ * CLI エントリポイント。`package.json` を読み、`checkSync` の結果に応じて
+ * stdout / stderr に出力し、drift / 構成不備時は `process.exit(1)` する。
+ *
+ * Issue #701 で `buildCiScript === ""` (構成不備) を明示的に fail させる
+ * 分岐を追加した。`checkSync` 自体は「空 build:ci なら ok」を返す純粋関数
+ * だが、CLI ガードとしての契約は「build:ci が定義されており非空」を要求する。
+ *
+ * @param packageJsonPath - 通常は `PACKAGE_JSON_PATH`。テスト時のみ別 path
+ *   を渡せるよう optional 引数として公開する (既存呼び出しの互換性維持)。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+const main = (packageJsonPath: string = PACKAGE_JSON_PATH): void => {
   let scripts: PackageScripts;
   try {
-    scripts = loadPackageScripts(PACKAGE_JSON_PATH);
+    scripts = loadPackageScripts(packageJsonPath);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`checkBuildCiSync FATAL: ${message}`);
+    process.exit(1);
+  }
+
+  if (scripts.buildCi.trim().length === 0) {
+    console.error(
+      'checkBuildCiSync FATAL: package.json の scripts["build:ci"] が空文字列です (構成不備)。',
+    );
     process.exit(1);
   }
 
@@ -214,4 +302,10 @@ if (isDirectInvocation()) {
 }
 
 export type { CheckResult, PackageScripts };
-export { checkSync, loadPackageScripts, splitCommands };
+export {
+  checkSync,
+  loadPackageScripts,
+  main,
+  splitCommands,
+  tokenizeCommand,
+};


### PR DESCRIPTION
## 概要

Issue #701 対応（PR #702 / Issue #685 DA Major #1 follow-up）。`scripts/checkBuildCiSync.ts` の `checkSync` で使用していた `String#includes` 部分一致は、`tsc` のような短い token が `my-tsc-wrapper` のサブストリングに含まれる誤検出リスクがあった。本 PR で **word-tokenize による末尾完全一致** に変更し、誤検出を解消。加えて `buildCi` 空文字列を構成不備として `main` で fail させる。

## 変更内容

### `scripts/checkBuildCiSync.ts`

- `tokenizeCommand(command: string): readonly string[]` 純粋関数を追加（空白で split + trim + 空除外）
- `matchesAsSuffix(buildTokens, ciTokens): boolean` 追加: build token 列の**末尾**が ciTokens と完全一致するか判定
  - `pnpm exec tsc` の suffix `[tsc]` → OK
  - `pnpm exec my-tsc-wrapper` の suffix `[my-tsc-wrapper]` → NG
  - `tsc --pretty` の suffix `[--pretty]` → 厳密に区別
- `checkSync` を `String#includes` から `matchesAsSuffix(tokenize(build), tokenize(ciCommand))` の線形検索に置換
- `main` に `buildCi.trim().length === 0` ガード追加（構成不備として exit 1）
- `main` を optional `packageJsonPath` 引数付きで export 化（`lintTokens.ts` / `calculateContrast.ts` と同パターン）

### `scripts/__tests__/checkBuildCiSync.test.ts`

13 → 29 件 (+16):
- `tokenizeCommand` 単体 5 件（基本 / 単一 / 連続空白 / flag / 空）
- `checkSync` 新規 4 件（`my-tsc-wrapper` 誤検出排除 / multi-token 完全一致 / multi-token flag 欠落 NG / `tscx` prefix 拡張誤検出排除）
- `main` 新規 5 件（空文字列 / 空白のみ / 同期時 OK log / drift NG / Issue #701 誤検出シナリオ）

## 備考

### `matchesAsSuffix` 設計根拠

- `pnpm exec tsc` / `node tsc` / `tsx tsc` のような wrapper 経由呼び出しは「コマンド名が末尾に来る」慣行
- 「完全一致」では wrapper 経由をすべて drift と誤判定してしまう
- 「prefix 一致」は wrapper 意味論と逆
- suffix matching が実プロジェクト構造と最も自然に整合

### flag 厳密一致 semantics

`tsc --pretty` と `tsc --noEmit` は本実装で別 token 列として区別される。`build:ci` 側に flag を含めて書けば pass するため運用負荷は小さく、むしろ「flag 違いの 2 つの `tsc` を区別したい」というニーズに自動応答する。

### scope 外

- 環境変数 prefix (`FOO=bar tsc`) / シェルクオート (`'foo bar'`) / `;` / `|` 区切りは scope 外（JSDoc 明記、本リポの script では発生しない）

### 検証

- `pnpm lint` / `pnpm type-check` / `pnpm test:run` (1041 件) / `pnpm build` / `pnpm check:build-ci-sync` 全 pass
- 手動破壊検証: `pnpm exec my-tsc-wrapper` 含む build / `build:ci` 空文字列 で正しく exit 1

### 既存契約維持

- `splitCommands` / `checkSync` / `loadPackageScripts` シグネチャ不変
- `tokenizeCommand` / `main` を追加 export（additive only）
- `@internal` JSDoc 統一文言を新規 export も踏襲

Closes #701