### PR TITLE
chore: i18nLiterals.ts に AUTHOR_FALLBACK / DATE_FALLBACK を横串集約 (Closes #706)

### DIFF
--- a/src/components/atoms/IndexRow.tsx
+++ b/src/components/atoms/IndexRow.tsx
@@ -1,24 +1,17 @@
 import { type CSSProperties, memo } from "react";
 import { css } from "../../../styled-system/css";
-import { UNTITLED_POST } from "../../lib/i18nLiterals";
+import {
+  AUTHOR_FALLBACK,
+  DATE_FALLBACK,
+  UNTITLED_POST,
+} from "../../lib/i18nLiterals";
 import type { PostSummary } from "../../lib/markdown";
 import { buildPostHeroTransitionName } from "../../lib/viewTransition";
 import { Link } from "./Link";
 
-// 著者欠落時のフォールバック文言。`MetaInfo.tsx` でも同一文言を利用しており、
-// 横串共通化の余地があるが、本 Issue (#692) では IndexRow.tsx 単位の定数化に
-// スコープを絞り、`src/lib/i18nLiterals.ts` への集約は follow-up Issue 候補
-// として保留する (調査結果は Issue #692 報告に記載)。
-const INDEX_ROW_AUTHOR_FALLBACK = "匿名" as const;
-
-// 日付欠落時のフォールバック文言。`MetaInfo.tsx` でも同一文言を利用しており、
-// 横串共通化の余地があるが、本 Issue (#692) では IndexRow.tsx 単位の定数化に
-// スコープを絞る (同上)。
-const INDEX_ROW_DATE_FALLBACK = "日付未設定" as const;
-
 // メタ情報 (著者 / 日付) 間の視覚区切り。Em ダッシュ (U+2014) を使う。
 // aria-hidden の装飾要素として扱う (R-4 / Issue #395 (vi) に従い UI 用絵文字は
-// 使用しない)。
+// 使用しない)。装飾文字のため横串集約 (i18nLiterals.ts) の対象外。
 const INDEX_ROW_META_SEPARATOR = "—" as const;
 
 interface IndexRowProps {
@@ -240,11 +233,11 @@ export const IndexRow = memo(({ post, index }: IndexRowProps) => {
       </span>
       <span className={indexLeaderStyles} aria-hidden="true" />
       <span className={indexMetaStyles}>
-        <span>{post.author || INDEX_ROW_AUTHOR_FALLBACK}</span>
+        <span>{post.author || AUTHOR_FALLBACK}</span>
         <span className={indexMetaSeparatorStyles} aria-hidden="true">
           {INDEX_ROW_META_SEPARATOR}
         </span>
-        <span>{post.createdAt || INDEX_ROW_DATE_FALLBACK}</span>
+        <span>{post.createdAt || DATE_FALLBACK}</span>
       </span>
     </li>
   );

--- a/src/components/common/MetaInfo.tsx
+++ b/src/components/common/MetaInfo.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import { css } from "../../../styled-system/css";
+import { AUTHOR_FALLBACK, DATE_FALLBACK } from "../../lib/i18nLiterals";
 import { Calendar, Clock, PenLine } from "../atoms/icons";
 
 interface MetaInfoProps {
@@ -198,11 +199,11 @@ export const MetaInfo = memo(
       >
         <div className={itemClassName} data-token-bg={styles.itemBg}>
           <Calendar aria-hidden="true" size={styles.iconSize} />
-          <span>{createdAt || "日付未設定"}</span>
+          <span>{createdAt || DATE_FALLBACK}</span>
         </div>
         <div className={itemClassName} data-token-bg={styles.itemBg}>
           <PenLine aria-hidden="true" size={styles.iconSize} />
-          <span>{author || "匿名"}</span>
+          <span>{author || AUTHOR_FALLBACK}</span>
         </div>
         {readingTimeMinutes !== undefined && (
           <div className={itemClassName} data-token-bg={styles.itemBg}>

--- a/src/lib/i18nLiterals.ts
+++ b/src/lib/i18nLiterals.ts
@@ -38,3 +38,35 @@
  * 同義反復になり、文言変更時の regression を検知できなくなるため)。
  */
 export const UNTITLED_POST = "無題の記事" as const;
+
+/**
+ * 著者欠落時のフォールバック文言。
+ *
+ * 参照元 (2 箇所):
+ * - `src/components/atoms/IndexRow.tsx`
+ * - `src/components/common/MetaInfo.tsx`
+ *
+ * 当初 PR #711 (Issue #692) で IndexRow.tsx の局所定数として導入したが、
+ * MetaInfo.tsx でも同一文言を利用していたため、本モジュールへ横串集約
+ * (Issue #706 / Issue #629 follow-up)。
+ *
+ * テストファイルからは **import しない** (期待値リテラルを共有すると
+ * 同義反復になり、文言変更時の regression を検知できなくなるため)。
+ */
+export const AUTHOR_FALLBACK = "匿名" as const;
+
+/**
+ * 日付欠落時のフォールバック文言。
+ *
+ * 参照元 (2 箇所):
+ * - `src/components/atoms/IndexRow.tsx`
+ * - `src/components/common/MetaInfo.tsx`
+ *
+ * 当初 PR #711 (Issue #692) で IndexRow.tsx の局所定数として導入したが、
+ * MetaInfo.tsx でも同一文言を利用していたため、本モジュールへ横串集約
+ * (Issue #706 / Issue #629 follow-up)。
+ *
+ * テストファイルからは **import しない** (期待値リテラルを共有すると
+ * 同義反復になり、文言変更時の regression を検知できなくなるため)。
+ */
+export const DATE_FALLBACK = "日付未設定" as const;


### PR DESCRIPTION
## 概要

PR #711 (Closes #692) で `INDEX_ROW_AUTHOR_FALLBACK = "匿名"` / `INDEX_ROW_DATE_FALLBACK = "日付未設定"` を IndexRow.tsx 内の局所定数として導入したが、grep 調査で同じ文言が `MetaInfo.tsx` (L201, L205) でもハードコードされていることが判明。`i18nLiterals.ts` 方針「複数ファイル参照される文言は横串集約」(Issue #629) に従って本 PR で横串集約する。

Closes #706

## 変更内容

- `src/lib/i18nLiterals.ts`:
  - `AUTHOR_FALLBACK = "匿名" as const` 追加
  - `DATE_FALLBACK = "日付未設定" as const` 追加
  - JSDoc に参照元 2 箇所と PR #711 follow-up 経緯を明記
- `src/components/atoms/IndexRow.tsx`:
  - 局所定数 `INDEX_ROW_AUTHOR_FALLBACK` / `INDEX_ROW_DATE_FALLBACK` を削除
  - `i18nLiterals.ts` から `AUTHOR_FALLBACK` / `DATE_FALLBACK` を import 参照に置換
  - `INDEX_ROW_META_SEPARATOR` は装飾文字 (Em ダッシュ) のため集約対象外、現状維持
- `src/components/common/MetaInfo.tsx`:
  - L201 / L205 のハードコード `"日付未設定"` / `"匿名"` を i18nLiterals.ts からの import 参照に置換

## ローカルレビュー結果

- 実装担当 → レビュワー → DA の 3 段階レビュー実施
- レビュワー: ✅ 承認 (AC 全項目達成)
- DA: マージ可、軽微指摘 (命名/scope/JSDoc 保守) は follow-up で追跡

## 検証

- [x] `pnpm test:run` pass (56 files / 1027 tests)
- [x] `pnpm lint` pass (127 files, no fixes)
- [x] `pnpm build` pass (panda + tsc + tsc:api + tsc:scripts + vite build)
- [x] `git grep -nE '"匿名"|"日付未設定"' src/` 残ハードコード 0 件 (i18nLiterals.ts 定義行除く / テスト直書きは方針上維持)

## 備考