### PR TITLE
chore: checkBuildCiSync.ts の word boundary 化 + 空文字 fail 化 (Closes #701)

### DIFF
--- a/scripts/__tests__/checkBuildCiSync.test.ts
+++ b/scripts/__tests__/checkBuildCiSync.test.ts
@@ -1,25 +1,34 @@
 /**
- * scripts/checkBuildCiSync.ts の単体テスト (Issue #685)
+ * scripts/checkBuildCiSync.ts の単体テスト (Issue #685 / #701)
  *
  * 検証対象:
  *   - splitCommands: `&&` 区切りで command を取り出し、空 token を除外する
+ *   - tokenizeWords: command 文字列を空白区切りの word 配列に分解する (Issue #701)
+ *   - isSuffixMatch: word 配列の suffix (末尾揃え) 完全一致判定 (Issue #701)
  *   - checkSync:
  *       - build に build:ci の全 command が順序を保って含まれていれば ok
  *       - 順序が崩れた / command が抜けていれば ng (reason 付き)
  *       - build:ci 側が空なら ok (検査対象なし)
- *       - 部分一致 (prefix 付き wrapper など) を許容する
+ *       - 部分一致 (wrapper prefix など) を word boundary 単位で許容する
+ *       - 単語境界を跨ぐ偶発混入 (`tsc` ⊂ `my-tsc-wrapper` 等) は ng (Issue #701)
+ *   - isBuildCiMisconfigured: build:ci が空文字 / 空白のみなら true (Issue #701)
  *   - loadPackageScripts: package.json から scripts.build / scripts["build:ci"] を取り出し、
  *     欠落 / 型違反は throw する
+ *   - main: build:ci が空文字なら exit 1 (構成不備として fail) (Issue #701)
  */
 
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   checkSync,
+  isBuildCiMisconfigured,
+  isSuffixMatch,
   loadPackageScripts,
+  main,
   splitCommands,
+  tokenizeWords,
 } from "../checkBuildCiSync.ts";
 
 describe("splitCommands", () => {
@@ -37,6 +46,85 @@ describe("splitCommands", () => {
 
   it("空白のみの token を除外する", () => {
     expect(splitCommands("panda && && tsc")).toEqual(["panda", "tsc"]);
+  });
+});
+
+describe("tokenizeWords", () => {
+  it("空白区切りで word 配列を返す", () => {
+    expect(tokenizeWords("tsc --project tsconfig.api.json")).toEqual([
+      "tsc",
+      "--project",
+      "tsconfig.api.json",
+    ]);
+  });
+
+  it("単独 word でも word 配列として返す", () => {
+    expect(tokenizeWords("tsc")).toEqual(["tsc"]);
+  });
+
+  it("連続する空白を単一 separator として扱う", () => {
+    expect(tokenizeWords("pnpm   exec    tsc")).toEqual([
+      "pnpm",
+      "exec",
+      "tsc",
+    ]);
+  });
+
+  it("タブ区切りも単一 separator として扱う", () => {
+    expect(tokenizeWords("pnpm\texec\ttsc")).toEqual(["pnpm", "exec", "tsc"]);
+  });
+
+  it("空文字列に対して空配列を返す", () => {
+    expect(tokenizeWords("")).toEqual([]);
+  });
+
+  it("空白のみの文字列に対して空配列を返す", () => {
+    expect(tokenizeWords("   ")).toEqual([]);
+  });
+});
+
+describe("isSuffixMatch", () => {
+  it("完全一致なら true", () => {
+    expect(isSuffixMatch(["tsc"], ["tsc"])).toBe(true);
+  });
+
+  it("ciWords が buildWords の suffix なら true (wrapper prefix 許容)", () => {
+    expect(isSuffixMatch(["tsc"], ["pnpm", "exec", "tsc"])).toBe(true);
+    expect(isSuffixMatch(["vite", "build"], ["pnpm", "exec", "vite", "build"]))
+      .toBe(true);
+  });
+
+  it("複数 word の ciWords が build 側 suffix と一致するなら true", () => {
+    expect(
+      isSuffixMatch(
+        ["tsc", "--project", "tsconfig.api.json"],
+        ["pnpm", "exec", "tsc", "--project", "tsconfig.api.json"],
+      ),
+    ).toBe(true);
+  });
+
+  it("word 境界が一致しない (substring混入) なら false", () => {
+    // `tsc` が `my-tsc-wrapper` のサブストリングだが word としては別 → false
+    expect(isSuffixMatch(["tsc"], ["my-tsc-wrapper"])).toBe(false);
+    expect(isSuffixMatch(["tsc"], ["pnpm", "exec", "my-tsc-wrapper"])).toBe(
+      false,
+    );
+  });
+
+  it("ciWords が buildWords より長ければ false", () => {
+    expect(isSuffixMatch(["pnpm", "exec", "tsc"], ["tsc"])).toBe(false);
+  });
+
+  it("ciWords が空なら false (空はマッチ対象外として扱う)", () => {
+    expect(isSuffixMatch([], ["tsc"])).toBe(false);
+  });
+
+  it("buildWords が prefix で一致しても suffix が一致しなければ false", () => {
+    // ciWords=["tsc"] vs buildWords=["tsc", "--project", "tsconfig.api.json"]
+    // → suffix は "tsconfig.api.json" であり "tsc" と一致しない
+    expect(
+      isSuffixMatch(["tsc"], ["tsc", "--project", "tsconfig.api.json"]),
+    ).toBe(false);
   });
 });
 
@@ -73,7 +161,7 @@ describe("checkSync", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("部分一致 (wrapper prefix 付き) を許容する", () => {
+  it("部分一致 (wrapper prefix 付き) を word boundary 単位で許容する", () => {
     const buildScript =
       "pnpm exec panda && pnpm exec tsc && pnpm exec vite build";
     const buildCiScript = "panda && tsc && vite build";
@@ -90,6 +178,59 @@ describe("checkSync", () => {
     const result = checkSync("panda && tsc", "panda && tsc && vite build");
     expect(result.ok).toBe(false);
     expect(result.reason).toContain("vite build");
+  });
+
+  it("複数 word の command (tsc --project ...) も word boundary 単位で match できる", () => {
+    // 本リポ実態と一致する build:ci 構成
+    const buildScript =
+      "pnpm run lint && pnpm run test:run && panda && tsc && tsc --project tsconfig.api.json && vite build";
+    const buildCiScript =
+      "panda && tsc && tsc --project tsconfig.api.json && vite build";
+    expect(checkSync(buildScript, buildCiScript).ok).toBe(true);
+  });
+
+  // Issue #701 Major #1: 短い token の誤検出回避テスト
+  it("build 側に `my-tsc-wrapper` 等のサブストリング混入がある場合は ng になる", () => {
+    // `tsc` (build:ci 側) が `my-tsc-wrapper` (build 側) の substring として
+    // 含まれるが、word boundary 判定では別単語として扱われるため ng となる
+    const buildScript = "panda && my-tsc-wrapper && vite build";
+    const buildCiScript = "panda && tsc && vite build";
+    const result = checkSync(buildScript, buildCiScript);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("tsc");
+  });
+
+  it("build 側が `tsc-wrapper` (suffix 違い) でも word boundary で ng", () => {
+    const buildScript = "panda && tsc-wrapper && vite build";
+    const buildCiScript = "panda && tsc && vite build";
+    expect(checkSync(buildScript, buildCiScript).ok).toBe(false);
+  });
+
+  it("build 側が `wrapper-tsc` (prefix 違い) でも word boundary で ng", () => {
+    const buildScript = "panda && wrapper-tsc && vite build";
+    const buildCiScript = "panda && tsc && vite build";
+    expect(checkSync(buildScript, buildCiScript).ok).toBe(false);
+  });
+});
+
+describe("isBuildCiMisconfigured", () => {
+  it("空文字なら true", () => {
+    expect(isBuildCiMisconfigured("")).toBe(true);
+  });
+
+  it("空白のみなら true", () => {
+    expect(isBuildCiMisconfigured("   ")).toBe(true);
+    expect(isBuildCiMisconfigured("\t\n")).toBe(true);
+  });
+
+  it("非空 command なら false", () => {
+    expect(isBuildCiMisconfigured("panda && tsc && vite build")).toBe(false);
+  });
+
+  it("`&&` のみでも (= splitCommands で空になるが) false 扱い (構成不備検査は文字列の空を見るのみ)", () => {
+    // 本関数は「文字列として空 / 空白のみか」のみを判定する。
+    // command 配列としての空 (例: `&& &&`) は checkSync 側の責務として ok を返す。
+    expect(isBuildCiMisconfigured("&&")).toBe(false);
   });
 });
 
@@ -146,5 +287,99 @@ describe("loadPackageScripts", () => {
       }),
     );
     expect(() => loadPackageScripts(packagePath)).toThrow(/build:ci/);
+  });
+});
+
+describe("main (build:ci 空文字 fail) (Issue #701 Major #2)", () => {
+  let tempDir: string;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "check-build-ci-sync-main-"));
+    // process.exit を throw に差し替え、後続コードの実行を止めつつ exit code を検証する
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`process.exit:${code ?? 0}`);
+      // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
+    }) as any);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it("build:ci が空文字の package.json を渡すと exit 1 で fail する", () => {
+    const packagePath = join(tempDir, "package.json");
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        scripts: {
+          build: "panda && tsc && vite build",
+          "build:ci": "",
+        },
+      }),
+    );
+    expect(() => main(packagePath)).toThrow("process.exit:1");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const messages = errorSpy.mock.calls
+      .map((args: unknown[]) => args.join(" "))
+      .join("\n");
+    expect(messages).toContain('scripts["build:ci"] が空文字');
+  });
+
+  it("build:ci が空白のみの package.json を渡すと exit 1 で fail する", () => {
+    const packagePath = join(tempDir, "package.json");
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        scripts: {
+          build: "panda && tsc && vite build",
+          "build:ci": "   ",
+        },
+      }),
+    );
+    expect(() => main(packagePath)).toThrow("process.exit:1");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("正常系 (build:ci が非空 + build に含まれる) では exit が呼ばれない", () => {
+    const packagePath = join(tempDir, "package.json");
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        scripts: {
+          build:
+            "pnpm run lint && panda && tsc && tsc --project tsconfig.api.json && vite build",
+          "build:ci":
+            "panda && tsc && tsc --project tsconfig.api.json && vite build",
+        },
+      }),
+    );
+    main(packagePath);
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it("build に my-tsc-wrapper のような誤検出ケースが含まれていれば exit 1 で fail する (Issue #701 Major #1)", () => {
+    const packagePath = join(tempDir, "package.json");
+    writeFileSync(
+      packagePath,
+      JSON.stringify({
+        scripts: {
+          build: "panda && my-tsc-wrapper && vite build",
+          "build:ci": "panda && tsc && vite build",
+        },
+      }),
+    );
+    expect(() => main(packagePath)).toThrow("process.exit:1");
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });

--- a/scripts/checkBuildCiSync.ts
+++ b/scripts/checkBuildCiSync.ts
@@ -1,18 +1,18 @@
 #!/usr/bin/env node
 
 /**
- * Issue #685: `package.json` の `build` script と `build:ci` script の
+ * Issue #685 / #701: `package.json` の `build` script と `build:ci` script の
  * drift を CI で機械的に検知するためのガードスクリプト。
  *
  * 背景:
- *   - `build:ci` (= `panda && tsc && vite build`) は hash:true regression
+ *   - `build:ci` (= `panda && tsc && vite build` の派生) は hash:true regression
  *     workflow 等で `build` の代用として呼ばれるサブセット。
  *   - 過去 (Issue #528) は CLAUDE.md 散文で「`build` 変更時は `build:ci`
  *     も同期させること」と運用ルール化していたが、散文ルールは時間経過で
  *     形骸化する。
- *   - 本スクリプトは `build` 文字列に `build:ci` の各 command (`panda` /
- *     `tsc` / `vite build`) が **順序を保って** 含まれているかを部分一致で
- *     判定し、ずれていれば exit 1 で fail-fast する。
+ *   - 本スクリプトは `build` script の各 command に `build:ci` の各 command が
+ *     **順序を保って** 含まれているかを word boundary 単位で判定し、ずれて
+ *     いれば exit 1 で fail-fast する。
  *
  * 設計方針:
  *   - 本リポの `build` / `build:ci` 構造に絞った最小実装。汎用的な script
@@ -20,6 +20,19 @@
  *   - 外部依存追加禁止 (`node:fs` / `node:path` のみ)。
  *   - 純粋関数 `checkSync(buildScript, buildCiScript)` をテスト用に export
  *     する。CLI エントリ (`main`) は副作用 (file IO / process.exit) に集約。
+ *
+ * Issue #701 follow-up (PR #702 DA レビュー):
+ *   - Major #1: 短い token の誤検出リスク。`String#includes` の部分一致では
+ *     `tsc` が `my-tsc-wrapper` 等のサブストリングに偶発混入する。
+ *     → command を空白区切りで word 配列化し、`build:ci` 側 command の word
+ *       列が `build` 側 command の word 列の **suffix (末尾揃え)** として
+ *       完全一致するかを判定する方式 (案 A) に変更。
+ *       wrapper prefix (`pnpm exec tsc` 等) は許容しつつ、`my-tsc-wrapper`
+ *       のような単語境界を跨ぐ偶発混入を排除する。
+ *   - Major #2: `build:ci` が空文字の場合に沈黙する。
+ *     → `main` で `buildCiScript === ""` を構成不備として扱い exit 1 + メッセージ。
+ *       (`checkSync` 自体は文字列入力の純粋関数として「検査対象なし → ok」を
+ *        維持し、構成不備の判定は呼び出し側に集約する。)
  *
  * 使い方:
  *   - `pnpm exec tsx scripts/checkBuildCiSync.ts`
@@ -65,26 +78,89 @@ const splitCommands = (script: string): string[] => {
 };
 
 /**
+ * command 文字列を空白区切りの word 配列に分解する。
+ *
+ * 例: `"tsc --project tsconfig.api.json"` → `["tsc", "--project", "tsconfig.api.json"]`
+ * 例: `"pnpm exec tsc"` → `["pnpm", "exec", "tsc"]`
+ *
+ * 連続する空白 (タブ・複数スペース) は単一 separator として扱う。
+ * 空 word は除外する。
+ *
+ * Issue #701: 本関数は `checkSync` の word boundary 判定で使用する。
+ * `String#includes` による部分一致では `tsc` が `my-tsc-wrapper` の
+ * サブストリングに偶発混入するため、word 単位での比較に切り替える。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+const tokenizeWords = (command: string): string[] => {
+  return command
+    .split(/\s+/)
+    .map((word) => word.trim())
+    .filter((word) => word.length > 0);
+};
+
+/**
+ * `ciWords` が `buildWords` の **suffix (末尾揃え)** として完全一致するかを判定する。
+ *
+ * 例 (match):
+ *   - `["tsc"]` vs `["tsc"]` → match
+ *   - `["tsc"]` vs `["pnpm", "exec", "tsc"]` → match (wrapper prefix 許容)
+ *   - `["vite", "build"]` vs `["pnpm", "exec", "vite", "build"]` → match
+ *   - `["tsc", "--project", "tsconfig.api.json"]` vs
+ *     `["pnpm", "exec", "tsc", "--project", "tsconfig.api.json"]` → match
+ *
+ * 例 (no match):
+ *   - `["tsc"]` vs `["my-tsc-wrapper"]` → no match (word 境界で `tsc` !== `my-tsc-wrapper`)
+ *   - `["tsc"]` vs `["tsc", "--project", "tsconfig.api.json"]` → no match
+ *     (suffix が `tsconfig.api.json` であり `tsc` と一致しない。`build` 側に
+ *      flag 付き token と flag 無し token の両方が並ぶケースは、command 単位で
+ *      別 token として並んでいる前提なので、別 token として独立に suffix match させる)
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+const isSuffixMatch = (
+  ciWords: readonly string[],
+  buildWords: readonly string[],
+): boolean => {
+  if (ciWords.length === 0) {
+    return false;
+  }
+  if (ciWords.length > buildWords.length) {
+    return false;
+  }
+  const offset = buildWords.length - ciWords.length;
+  for (let i = 0; i < ciWords.length; i += 1) {
+    if (buildWords[offset + i] !== ciWords[i]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
  * `build` script 文字列の中に `build:ci` の各 command が「順序を保って」
- * 部分一致で出現するかを判定する。
+ * word boundary 単位で出現するかを判定する。
  *
  * アルゴリズム:
- *   - `build` を `splitCommands` で token 配列化する。
- *   - `build:ci` の各 command を順に走査し、`build` token 列の中から
- *     部分一致 (`String#includes`) する次の token を線形検索する。
+ *   - `build` / `build:ci` を `splitCommands` で command 配列化する。
+ *   - 各 command を `tokenizeWords` で空白区切りの word 配列に分解する。
+ *   - `build:ci` の各 command の word 列を順に走査し、`build` command 配列の
+ *     中から **suffix match** する次の command を線形検索する。
  *   - 全 `build:ci` command を順序を崩さず消費できれば ok。
  *   - 途中で見つからなくなった時点で reason 付き ng を返す。
  *
- * 部分一致 (`includes`) を採用する理由:
- *   - `build` 側に `pnpm run lint && ... && panda && tsc && vite build`
- *     のように prefix (`pnpm run`) や追加 flag が付くケースを許容するため。
- *   - 完全一致では `pnpm run build:ci` のような wrapper にも対応できない。
+ * Word boundary 判定 (suffix match) を採用する理由 (Issue #701 Major #1):
+ *   - `String#includes` による部分一致では `tsc` (CI 側) が `my-tsc-wrapper`
+ *     (build 側) のサブストリングに偶発混入する誤検出が発生する。
+ *   - 各 command を空白で分解した word 列の suffix 比較に切り替えることで、
+ *     `pnpm exec tsc` のような wrapper prefix を許容しつつ、`my-tsc-wrapper`
+ *     のような単語境界を跨ぐ混入を排除する。
  *
  * 空配列ケース:
- *   - `buildCiScript` が空 (token 0 件): 検査する command が無いので ok。
- *     ただし呼び出し側 (`main`) では「`build:ci` 自体が未定義 / 空」を
- *     構成不備として別途扱う (本関数は文字列入力に対する純粋関数のため、
- *     未定義との区別は呼び出し側に委ねる)。
+ *   - `buildCiScript` が空 (command 0 件): 検査する command が無いので ok。
+ *     ただし呼び出し側 (`main`) では「`build:ci` 自体が空文字」を構成不備
+ *     として別途扱う (Issue #701 Major #2)。本関数は文字列入力に対する純粋
+ *     関数のため、空文字判定は呼び出し側に委ねる。
  *   - `buildScript` が空かつ `buildCiScript` が非空: ng (drift)。
  *
  * @internal テスト専用 export. 本番コードから import しないこと
@@ -98,23 +174,25 @@ const checkSync = (
     return { ok: true };
   }
 
-  const buildTokens = splitCommands(buildScript);
+  const buildCommands = splitCommands(buildScript);
+  const buildWordLists = buildCommands.map((command) => tokenizeWords(command));
+
   let cursor = 0;
   for (const ciCommand of ciCommands) {
+    const ciWords = tokenizeWords(ciCommand);
     let matchedIndex = -1;
-    for (let i = cursor; i < buildTokens.length; i += 1) {
-      const token = buildTokens[i] ?? "";
-      if (token.includes(ciCommand)) {
+    for (let i = cursor; i < buildWordLists.length; i += 1) {
+      const buildWords = buildWordLists[i] ?? [];
+      if (isSuffixMatch(ciWords, buildWords)) {
         matchedIndex = i;
         break;
       }
     }
     if (matchedIndex === -1) {
-      const position =
-        cursor === 0 ? "" : " (前 command 以降の位置で)";
+      const position = cursor === 0 ? "" : " (前 command 以降の位置で)";
       return {
         ok: false,
-        reason: `build:ci の command "${ciCommand}" が build script 内${position}に見つかりません。`,
+        reason: `build:ci の command "${ciCommand}" が build script 内${position}に word boundary 単位で見つかりません。`,
       };
     }
     cursor = matchedIndex + 1;
@@ -171,13 +249,47 @@ const HINT_MESSAGE = [
   "     セクションの記述を併せて更新する",
 ].join("\n");
 
-const main = (): void => {
+/**
+ * `scripts["build:ci"]` の文字列が「構成不備 (空 / 空白のみ)」かどうかを判定する。
+ *
+ * Issue #701 Major #2: `build:ci = ""` で `checkSync` が ok を返してしまう問題に
+ * 対応。`checkSync` 自体は文字列入力に対する純粋関数として「検査対象なし → ok」を
+ * 維持し、構成不備の判定は本関数 + 呼び出し側 (`main`) に集約する。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+const isBuildCiMisconfigured = (buildCiScript: string): boolean => {
+  return buildCiScript.trim() === "";
+};
+
+/**
+ * CLI エントリ。`package.json` を読み、`build` / `build:ci` の sync を検査する。
+ *
+ * Issue #701: 引数 `packageJsonPath` でテスト時に任意の package.json path を
+ * 注入できるようにする (デフォルトは PROJECT_ROOT/package.json)。テストでは
+ * `process.exit` を mock し、空文字 fail の振る舞いを直接検証する。
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+const main = (packageJsonPath: string = PACKAGE_JSON_PATH): void => {
   let scripts: PackageScripts;
   try {
-    scripts = loadPackageScripts(PACKAGE_JSON_PATH);
+    scripts = loadPackageScripts(packageJsonPath);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`checkBuildCiSync FATAL: ${message}`);
+    process.exit(1);
+  }
+
+  // Issue #701 Major #2: build:ci が空文字なら構成不備として fail させる。
+  // checkSync 自体は「検査対象なし → ok」のままにし、構成不備判定は CLI 側に集約する。
+  if (isBuildCiMisconfigured(scripts.buildCi)) {
+    console.error(
+      'checkBuildCiSync NG - package.json の scripts["build:ci"] が空文字です。',
+    );
+    console.error(`  build    = ${scripts.build}`);
+    console.error(`  build:ci = ${scripts.buildCi}`);
+    console.error(HINT_MESSAGE);
     process.exit(1);
   }
 
@@ -214,4 +326,12 @@ if (isDirectInvocation()) {
 }
 
 export type { CheckResult, PackageScripts };
-export { checkSync, loadPackageScripts, splitCommands };
+export {
+  checkSync,
+  isBuildCiMisconfigured,
+  isSuffixMatch,
+  loadPackageScripts,
+  main,
+  splitCommands,
+  tokenizeWords,
+};


### PR DESCRIPTION
## 概要

PR #702 (Closes #685) の DA レビュー Major 指摘 2 件への対応。

Closes #701

## 変更内容

- `scripts/checkBuildCiSync.ts`:
  - **Major #1 対応**: `String#includes` 部分一致を **word 単位 suffix match** (案 A) に変更
    - `tokenizeWords` (空白で split + trim + 空 filter) を追加
    - `isSuffixMatch` (build 側 word 配列の末尾と build:ci 側 word 配列が要素単位で一致するか判定) を追加
    - `checkSync` で各 build:ci command を word 配列化して build 側の suffix と比較
    - wrapper prefix 許容 (`pnpm exec tsc` build → `tsc` build:ci で match) と word boundary 誤検出排除 (`my-tsc-wrapper` ≠ `tsc`) を両立
  - **Major #2 対応**: `isBuildCiMisconfigured` を追加し `main` で `buildCiScript === "" || .trim() === ""` を構成不備として `exit 1`
  - `main(packageJsonPath = PACKAGE_JSON_PATH)` のオプショナル引数化 (テスト用 fixture 注入、本番経路は無引数で副作用なし)
- `scripts/__tests__/checkBuildCiSync.test.ts`:
  - 新規 25 件追加 (`tokenizeWords` 6 / `isSuffixMatch` 7 / `checkSync` 誤検出回避 3 + 複数 word 1 / `isBuildCiMisconfigured` 4 / `main` 統合 4)
  - 既存 15 件 + 新規 25 件 = 計 40 件全 pass

## 採用案と判断根拠

**案 A (word 単位 suffix match)** を採用:
- 既存 `splitCommands` の戻り値を活かしつつ、各 command を空白で word 配列化し suffix match で判定
- 案 B (regex `\b`) は word boundary の単純化はできるが、wrapper prefix 許容 (`pnpm exec tsc` → `tsc` への簡略化) を実現するには結局 word 単位の比較が必要なため、案 A の方が直接的

## ローカルレビュー結果

- 実装担当 → レビュワー → DA の 3 段階レビュー実施
- レビュワー: ✅ 承認 (アルゴリズム / 既存挙動互換 / テスト網羅性 / refactor 影響 / commit すべて整合)
- DA: マージ可、軽微指摘 (JSDoc に案 B 比較記録 / シェルクォート非対応明記 / scope 過剰) は follow-up で追跡

## 検証

- [x] `pnpm test:run` pass (1052 tests / 56 files)
- [x] `pnpm lint` pass (127 files, no fixes)
- [x] `pnpm type-check:scripts` pass
- [x] 意図的破壊シナリオ手動検証: `my-tsc-wrapper` 混入 → exit 1, `build:ci` 空文字 → exit 1, `tsc-wrapper` (suffix違い) → exit 1

## 備考