### PR TITLE
chore: MetaInfo.tsx の "分で読了" 文言を関数定数化 (Closes #721)

### DIFF
--- a/src/components/common/MetaInfo.tsx
+++ b/src/components/common/MetaInfo.tsx
@@ -10,6 +10,15 @@ interface MetaInfoProps {
   variant?: "card" | "header" | "featured" | "bento";
 }
 
+// Issue #721 (PR #715 follow-up): 表示文言テンプレートを定数として外出し。
+// `"分で読了"` は単一ファイル内で完結する文言のため `i18nLiterals.ts` への
+// 横串集約はせず、ファイル内ローカル定数に留める (Issue #534 / #630 方針、
+// CLAUDE.md「ファイル内局所定数」と「横串共通定数」の使い分け基準に準拠)。
+// テンプレート関数形式は `Coordinate.tsx` の `COORDINATE_LABEL_TEMPLATE` /
+// `Resurface.tsx` の `RESURFACE_REASON_LABEL_*_TEMPLATE` に倣う。
+const READING_TIME_LABEL_TEMPLATE = (minutes: number): string =>
+  `${minutes}分で読了`;
+
 // スタイルをコンポーネント外に定数として定義
 const containerStyles = css({
   display: "flex",
@@ -208,7 +217,7 @@ export const MetaInfo = memo(
         {readingTimeMinutes !== undefined && (
           <div className={itemClassName} data-token-bg={styles.itemBg}>
             <Clock aria-hidden="true" size={styles.iconSize} />
-            <span>{readingTimeMinutes}分で読了</span>
+            <span>{READING_TIME_LABEL_TEMPLATE(readingTimeMinutes)}</span>
           </div>
         )}
       </div>


### PR DESCRIPTION
## 概要

Issue #721 対応（PR #715 / Issue #706 follow-up）。`src/components/common/MetaInfo.tsx` の `"分で読了"` を Issue #534 / Issue #630 方針で局所定数化する。

## 変更内容

- `src/components/common/MetaInfo.tsx`:
  - `READING_TIME_LABEL_TEMPLATE = (minutes: number): string => \`\${minutes}分で読了\`` 関数定数を追加
  - JSX 内の直書きテンプレートを定数参照に置換
  - 横串性なしのため `i18nLiterals.ts` には集約せず、ファイル内ローカル定数で維持（理由を JSDoc 明記）

## 備考

### 関数定数（`*_TEMPLATE`）採用根拠

数値補間ありのため単純文字列ではなく関数形式を採用:
- `Coordinate.tsx` の `COORDINATE_LABEL_TEMPLATE`
- `Resurface.tsx` の `RESURFACE_REASON_LABEL_CALENDAR_TEMPLATE` / `RESURFACE_REASON_LABEL_MILESTONE_ANNIVERSARY_TEMPLATE`

と命名・形式が完全一致。将来の語順依存 i18n (`{minutes} minutes to read` 等) でも suffix 連結方式より関数形式の方が耐性が高い。

### テスト維持

`MetaInfo.test.tsx` / `BentoCard.test.tsx` / `FeaturedCard.test.tsx` の期待値リテラル (`"5分で読了"` 等) は変更なし。`i18nLiterals.ts` 方針（「テストファイルから import しない、期待値リテラルは直書き」）と整合。

### 検証

- `pnpm lint` / `pnpm type-check` / `pnpm test:run` (1042 件) / `pnpm build` 全 pass

Closes #721