### PR TITLE
chore: tsc incremental cache を本体と test で entry 分離 (Closes #640)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,18 +39,56 @@ jobs:
 
       # Issue #580: tsc --incremental の .tsbuildinfo を cache し、
       # type-check / type-check:test / type-check:scripts / type-check:api の cold ビルドを高速化する。
-      # メインキー: lockfile + tsconfig.json / tsconfig.test.json / tsconfig.scripts.json / tsconfig.api.json + src/scripts の hash が完全一致した場合のみ hit
-      # restoreKeys: lockfile + tsconfig が一致なら部分的に再利用 (src 差分のみ再計算)
-      # tsconfig.scripts.json は Issue #634 で新設 (scripts/ ambient 型の attack surface 制御)
-      # tsconfig.api.json は Issue #667 で新設 (src/api/ を本体 tsc から分離し Node 型漏出を遮断)
-      - name: Cache tsc incremental build info (Issue #580)
+      # Issue #640: PR #580 では 4 つの .tsbuildinfo を `.tsbuildinfo/` 1 entry でまとめていたため、
+      # test ファイル変更で本体 buildinfo の cache key まで invalidate される過剰 invalidation が
+      # 発生していた。これを cache entry を「本体 / test / scripts / api」の 4 つに分離することで、
+      # それぞれ独立した cache key で部分 invalidate を効かせる構造に変更する。
+      # **重要**: 本 cache step 群を変更する際は deploy.yml の同 cache step 群も同期して変更すること。
+      # 逆も同様。drift すると ci.yml が warm にした .tsbuildinfo を deploy.yml 側が再利用できず
+      # (またはその逆) warm cache が無駄になる。
+      #
+      # 本体 cache の hashFiles から `src/**/*.{test,spec}.{ts,tsx}` を negation pattern で除外する
+      # ことで、test 専用ファイルの変更が本体 cache key に波及しないようにする (Issue #640 の主目的)。
+      - name: Cache tsc main build info (Issue #640)
         uses: actions/cache@v5
         with:
-          path: .tsbuildinfo
-          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json', 'tsconfig.api.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts', 'scripts/**/*.tsx') }}
+          path: .tsbuildinfo/tsconfig.tsbuildinfo
+          key: tsc-main-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', '!src/**/*.test.ts', '!src/**/*.test.tsx', '!src/**/*.spec.ts', '!src/**/*.spec.tsx', '!src/api/**') }}
           restore-keys: |
-            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json', 'tsconfig.api.json') }}-
-            tsc-${{ runner.os }}-
+            tsc-main-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-
+            tsc-main-${{ runner.os }}-
+
+      # test 側 cache: tsconfig.test.json は tsconfig.json を継承するため、本体ソースの変更でも
+      # invalidate する必要がある (本体 + テストファイル両方を hash 対象に含める)。
+      - name: Cache tsc test build info (Issue #640)
+        uses: actions/cache@v5
+        with:
+          path: .tsbuildinfo/tsconfig.test.tsbuildinfo
+          key: tsc-test-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx') }}
+          restore-keys: |
+            tsc-test-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json') }}-
+            tsc-test-${{ runner.os }}-
+
+      # scripts 側 cache: tsconfig.scripts.json は scripts/ のみを対象 (Issue #634)。
+      - name: Cache tsc scripts build info (Issue #640)
+        uses: actions/cache@v5
+        with:
+          path: .tsbuildinfo/tsconfig.scripts.tsbuildinfo
+          key: tsc-scripts-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.scripts.json') }}-${{ hashFiles('scripts/**/*.ts', 'scripts/**/*.tsx') }}
+          restore-keys: |
+            tsc-scripts-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.scripts.json') }}-
+            tsc-scripts-${{ runner.os }}-
+
+      # api 側 cache: tsconfig.api.json は src/api/ のみを対象 (Issue #667)。
+      # ただし src/api/posts.ts は ../lib/markdownParser を import するため、src/lib も hash 対象に含める。
+      - name: Cache tsc api build info (Issue #640)
+        uses: actions/cache@v5
+        with:
+          path: .tsbuildinfo/tsconfig.api.tsbuildinfo
+          key: tsc-api-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.api.json') }}-${{ hashFiles('src/api/**/*.ts', 'src/api/**/*.tsx', 'src/lib/**/*.ts', 'src/lib/**/*.tsx', '!src/**/*.test.ts', '!src/**/*.test.tsx', '!src/**/*.spec.ts', '!src/**/*.spec.tsx') }}
+          restore-keys: |
+            tsc-api-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.api.json') }}-
+            tsc-api-${{ runner.os }}-
 
       - name: Type check
         run: pnpm type-check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,32 +37,62 @@ jobs:
       # Issue #655: ci.yml (lint-and-typecheck job) と同じ cache key を共有し、
       # deploy 時の tsc (pnpm run build 内の `tsc` / `type-check` / `type-check:scripts` / `type-check:api`) の
       # cold ビルドを回避する。
+      # Issue #640: PR #580 では 4 つの .tsbuildinfo を `.tsbuildinfo/` 1 entry でまとめていたため、
+      # test ファイル変更で本体 buildinfo の cache key まで invalidate される過剰 invalidation が
+      # 発生していた。これを cache entry を「本体 / test / scripts / api」の 4 つに分離することで、
+      # それぞれ独立した cache key で部分 invalidate を効かせる構造に変更する。
       # ci.yml と key を共有する理由:
-      # - ci.yml の key 構成 (tsconfig.json / tsconfig.test.json / tsconfig.scripts.json / tsconfig.api.json の hash + src/scripts の hash)
-      #   は deploy 時の incremental cache に対しても valid (test 用 tsconfig の hash が変わっても src の
-      #   .tsbuildinfo 自体は再利用可能であり、key が変わることで再生成されても害がない)
+      # - ci.yml の key 構成は deploy 時の incremental cache に対しても valid
       # - deploy 頻度は master push 時のみで頻度が低く、cache 書き込み衝突リスクは小さい
       #   (最悪ケース: ci.yml の同 key 書き込みと同時刻実行が衝突した際に片方の cache 書き込みが失われるが、
       #   `actions/cache` は cache miss → 再生成に degrade するだけで build correctness には影響しない)
       # - 別 key にすると ci.yml の build 成果を再利用できず deploy 時に毎回 cold ビルドになる
-      # NOTE: Issue #654 (PR #669) で ci.yml の cache key に追加された `'scripts/**/*.tsx'` glob と
-      # 整合させるため、ここにも同 glob を含める。これにより #654 / #655 のいずれが先にマージされても
-      # ci.yml と deploy.yml の cache key が drift しない。
-      # NOTE: Issue #667 で新設した tsconfig.api.json も ci.yml と揃えて hashFiles に含める
-      # (src/api/ を本体 tsc から分離し、`build:ci` 内で `tsc --project tsconfig.api.json` を踏むため、
-      # tsconfig.api.json の変更でも .tsbuildinfo の invalidation が必要になる)。
-      # **重要**: 本 cache step の `key` / `restore-keys` / `path` を変更する際は ci.yml
-      # (lint-and-typecheck job) 側の同 step も同期して変更すること。逆も同様。drift すると
-      # ci.yml が warm にした .tsbuildinfo を deploy.yml 側が再利用できず (またはその逆)、warm cache が
-      # 無駄になる。
-      - name: Cache tsc incremental build info (Issue #655)
+      # **重要**: 本 cache step 群を変更する際は ci.yml (lint-and-typecheck job) 側の同 step 群も
+      # 同期して変更すること。逆も同様。drift すると ci.yml が warm にした .tsbuildinfo を deploy.yml 側が
+      # 再利用できず (またはその逆) warm cache が無駄になる。
+      #
+      # 本体 cache の hashFiles から `src/**/*.{test,spec}.{ts,tsx}` を negation pattern で除外する
+      # ことで、test 専用ファイルの変更が本体 cache key に波及しないようにする (Issue #640 の主目的)。
+      - name: Cache tsc main build info (Issue #640)
         uses: actions/cache@v5
         with:
-          path: .tsbuildinfo
-          key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json', 'tsconfig.api.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts', 'scripts/**/*.tsx') }}
+          path: .tsbuildinfo/tsconfig.tsbuildinfo
+          key: tsc-main-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', '!src/**/*.test.ts', '!src/**/*.test.tsx', '!src/**/*.spec.ts', '!src/**/*.spec.tsx', '!src/api/**') }}
           restore-keys: |
-            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json', 'tsconfig.api.json') }}-
-            tsc-${{ runner.os }}-
+            tsc-main-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-
+            tsc-main-${{ runner.os }}-
+
+      # test 側 cache: tsconfig.test.json は tsconfig.json を継承するため、本体ソースの変更でも
+      # invalidate する必要がある (本体 + テストファイル両方を hash 対象に含める)。
+      - name: Cache tsc test build info (Issue #640)
+        uses: actions/cache@v5
+        with:
+          path: .tsbuildinfo/tsconfig.test.tsbuildinfo
+          key: tsc-test-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx') }}
+          restore-keys: |
+            tsc-test-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json') }}-
+            tsc-test-${{ runner.os }}-
+
+      # scripts 側 cache: tsconfig.scripts.json は scripts/ のみを対象 (Issue #634)。
+      - name: Cache tsc scripts build info (Issue #640)
+        uses: actions/cache@v5
+        with:
+          path: .tsbuildinfo/tsconfig.scripts.tsbuildinfo
+          key: tsc-scripts-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.scripts.json') }}-${{ hashFiles('scripts/**/*.ts', 'scripts/**/*.tsx') }}
+          restore-keys: |
+            tsc-scripts-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.scripts.json') }}-
+            tsc-scripts-${{ runner.os }}-
+
+      # api 側 cache: tsconfig.api.json は src/api/ のみを対象 (Issue #667)。
+      # ただし src/api/posts.ts は ../lib/markdownParser を import するため、src/lib も hash 対象に含める。
+      - name: Cache tsc api build info (Issue #640)
+        uses: actions/cache@v5
+        with:
+          path: .tsbuildinfo/tsconfig.api.tsbuildinfo
+          key: tsc-api-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.api.json') }}-${{ hashFiles('src/api/**/*.ts', 'src/api/**/*.tsx', 'src/lib/**/*.ts', 'src/lib/**/*.tsx', '!src/**/*.test.ts', '!src/**/*.test.tsx', '!src/**/*.spec.ts', '!src/**/*.spec.tsx') }}
+          restore-keys: |
+            tsc-api-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.api.json') }}-
+            tsc-api-${{ runner.os }}-
 
       - name: Build project
         run: pnpm run build


### PR DESCRIPTION
## 概要

PR #580 で本体と test の `.tsbuildinfo` を同じ `.tsbuildinfo/` ディレクトリに置き `actions/cache@v5` 単一 entry で管理していたが、テストファイル変更で本体 buildinfo の cache key も invalidate される過剰 invalidation が発生していた。本 PR で cache entry を **4 つに分割** (main / test / scripts / api) し、部分 invalidate を有効化する。

Closes #640

## 変更内容

- `.github/workflows/ci.yml` / `.github/workflows/deploy.yml`:
  - 単一 `actions/cache` step (path: `.tsbuildinfo`) を **4 cache step に分割**:
    - **main**: `path: .tsbuildinfo/tsconfig.tsbuildinfo`, hashFiles で `!*.{test,spec}.{ts,tsx}` / `!src/api/**` 除外
    - **test**: `path: .tsbuildinfo/tsconfig.test.tsbuildinfo`, hashFiles に `src/**/*.{ts,tsx}` 全体 (tsconfig.test.json は tsconfig.json を継承)
    - **scripts**: `path: .tsbuildinfo/tsconfig.scripts.tsbuildinfo`, hashFiles は `scripts/**/*.{ts,tsx}` のみ
    - **api**: `path: .tsbuildinfo/tsconfig.api.tsbuildinfo`, hashFiles は `src/api/**` + `src/lib/**` (markdownParser 依存)
  - ci.yml / deploy.yml は Issue #655 drift 防止規約に従い key を完全一致

## 採用案: Issue 本文の対応案 (2 step) を 4 step に拡張

scripts / api は PR #666 (Closes #634) / PR #705 (Closes #667) で tsconfig が分離済みのため、同一実装機会で 4 entry に拡張する方が手数効率が良いと判断。

## 検証

- [x] `pnpm test:run` pass (1041 tests / 56 files)
- [x] `pnpm lint` pass (127 files, no fixes)
- [x] `pnpm build` pass
- [x] yaml syntax 検査 (js-yaml で parse OK)
- 実機 CI 検証は本 PR の CI run で確認する

## ローカルレビュー結果

- 実装担当 → レビュワー → DA の 3 段階レビュー
- レビュワー: ✅ 承認 (`__tests__/**` negation の軽微指摘は follow-up 候補)
- DA: マージ可、軽微指摘 (api cache 片肺 / scope 拡張 / storage 試算 / drift 防止コスト / 実機検証) は follow-up で追跡

## 備考