### PR TITLE
chore: panda-hash-regression workflow に schedule + pull_request トリガーを追加 (Closes #526)

### DIFF
--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -3,14 +3,40 @@ name: Panda hash:true regression check
 # Issue #496 / Issue #475 の検証で、Tripwire テスト 647 件は `hash: true`
 # 有効化でも全 pass することが確認済み。ただし bundle size のメリットは
 # 小さい (gzip 後 +5.8%) ため本番は `hash: false` (デフォルト) で運用し、
-# regression 検知のため手動 (workflow_dispatch) でのみ実行する。
+# regression 検知のため定期 (schedule) / Panda 関連 PR (pull_request paths) /
+# 手動 (workflow_dispatch) の 3 系統で実行する。
 #
-# このworkflowは既存 CI に影響を与えないよう push / pull_request トリガーは
-# 持たず、workflow_dispatch のみで起動する。panda.config.ts の書き換えは
-# CI の working tree 上のみで行い、リポジトリには commit / push しない。
+# Issue #526: 元は `workflow_dispatch` のみだったため、手動実行しないと走らず
+# 「誰も実行しないまま機能が腐る」リスクがあった (Panda CSS のメジャー更新時や
+# Tripwire 命名規則整理 (Issue #477) 完了後など)。dependabot で `@pandacss/dev`
+# 更新 PR が頻繁に来るため、検知の頻度確保は重要。本 workflow では:
+#   - 案 A (schedule, 月初 cron): 月 1 回の定期検証で機能腐敗リスクを軽減
+#   - 案 B (pull_request paths): panda.config.ts / package.json / pnpm-lock.yaml
+#     変更 PR で即時検知し、dependabot の `@pandacss/dev` 更新 PR 等を捕捉
+# の併用方式 (案 A + 案 B) を採用する。CI billing への影響は「月 1 + 該当 PR」
+# 程度で、許容範囲。失敗時の通知は GitHub Actions の標準通知 (commit author
+# email / fail badge) で当面足りる。Slack / メール / Issue 自動起票は別
+# follow-up Issue で扱う (本 PR スコープ外)。
+#
+# panda.config.ts の書き換えは CI の working tree 上のみで行い、リポジトリには
+# commit / push しない。
 
 on:
   workflow_dispatch:
+  # 案 A: 月初 00:00 UTC に定期実行。@pandacss/dev のメジャー更新等で気づか
+  # ないうちに hash:true 耐性が劣化していないかを月 1 で検知する。cron は
+  # UTC 基準で動くため、JST では月初 09:00 相当 (DST なし)。
+  schedule:
+    - cron: "0 0 1 * *"
+  # 案 B: Panda の依存バージョン / 設定変更を伴う PR を即時検知する。
+  # dependabot による `@pandacss/dev` 更新 PR は package.json / pnpm-lock.yaml
+  # の変更を含むため、`pnpm-lock.yaml` を paths に含めることで捕捉できる。
+  # panda.config.ts は preflight / hash 設定の手動変更を検知するために追加。
+  pull_request:
+    paths:
+      - "panda.config.ts"
+      - "package.json"
+      - "pnpm-lock.yaml"
 
 # 本 workflow は repo を読むだけで write は不要。明示的に最小権限へ縛る。
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,10 @@ Tripwire テスト用に吐く data-* 属性の命名は以下を指針とする
   - CI で `hash:true` 実機検証を回すための workflow は `.github/workflows/panda-hash-regression.yml`（Issue #496 で追加済み）
   - GitHub Actions の "Panda hash:true regression check" workflow から手動 (workflow_dispatch) で実行できる
   - 実行内容: `pnpm test:run` と `panda + tsc + vite build` を `hash: true` で 1 回ずつ実行し、Tripwire 耐性の regression を検知する
+  - **自動実行トリガー（Issue #526）**: 上記 manual 実行に加え、以下 2 系統が自動実行する:
+    - **schedule (月初 00:00 UTC = `'0 0 1 * *'`)**: 月 1 回の定期検証で「機能が腐る」リスクを軽減
+    - **pull_request paths**: `panda.config.ts` / `package.json` / `pnpm-lock.yaml` 変更 PR で即時検知。dependabot の `@pandacss/dev` 更新 PR は `pnpm-lock.yaml` 変更を含むため自動捕捉される
+    - CI billing への影響は「月 1 + 該当 PR」程度で許容範囲。失敗時の通知は GitHub Actions 標準通知 (commit author email / fail badge) で当面足りる。Slack / メール / Issue 自動起票は別 follow-up Issue で扱う
 - **`build:ci` script と workflow の整合性メモ（Issue #528）**: hash:true build step は `package.json` の `build:ci` (= `panda && tsc && vite build`, test/lint/type-check:scripts を含まない軽量版) を呼ぶ。`build` script (本番経路) のコマンド列 (`panda && tsc && vite build` 部分) を変更する場合は `build:ci` も同期させること。**同期の有無は `scripts/checkBuildCiSync.ts` で自動検出される（Issue #685、`.github/workflows/ci.yml` の lint-and-typecheck job で実行）** ので、散文ルールが形骸化しても CI が drift を検知して fail する
   - baseline (hash:false) build step は bundle size 計測専用で tsc を意図的に省く運用 (Issue #625 DA #2) のため `build:ci` ではなく `pnpm exec panda && pnpm exec vite build` を直接呼ぶ非対称運用とする
 


### PR DESCRIPTION
## 概要

`.github/workflows/panda-hash-regression.yml` の trigger は元々 `workflow_dispatch` のみで、Panda CSS メジャー更新時や Tripwire 規約整理時に「誰も実行しないまま機能が腐る」リスクがあった。本 PR で **schedule (月初 cron) + pull_request paths** を追加し、自動検証頻度を確保する。

Closes #526

## 変更内容

- `.github/workflows/panda-hash-regression.yml`:
  - `schedule: cron: '0 0 1 * *'` を追加 (月初 0:00 UTC)
  - `pull_request: paths: [panda.config.ts, package.json, pnpm-lock.yaml]` を追加 (dependabot の `@pandacss/dev` 更新で即時検知)
  - 既存 `workflow_dispatch` は維持
  - 冒頭コメントに採用根拠 / Issue #526 参照 / CI billing 評価を記載
- `CLAUDE.md`:
  - 「Panda hash:true の運用判断」セクションの「再評価したい場合」項に schedule / pull_request 自動実行と通知設計 follow-up 方針を追記

## 採用案: A + B 併用

- 案 A (月初 cron): 長期腐敗リスクを月 1 定期検証で軽減
- 案 B (pull_request paths): dependabot の Panda 更新 PR で即時検知 (`pnpm-lock.yaml` 含むため自動捕捉)
- 案 C (現状維持) は文書ルールに依存し形骸化リスクが残るため不採用

## CI billing 影響

- 月 1 回 (cron) + 該当 PR (Panda 関連変更時のみ)
- dependabot の Panda 関連更新が月 1〜2 件程度想定で、毎月の追加実行は 2〜3 回程度
- 許容範囲

## 失敗時通知

本 PR スコープ外。GitHub Actions 標準通知 (commit author email / fail badge) で当面足りる。Slack / メール / Issue 自動起票の通知強化は follow-up Issue で扱う。

## ローカルレビュー結果

- 実装担当 → レビュワー → DA の 3 段階レビュー
- レビュワー: ✅ 承認 (`pull_request_target` 不使用で secret 漏洩リスクなし)
- DA: マージ可、軽微指摘 (paths 漏れ補強 / cron 遅延注記) は follow-up で追跡

## 備考