### PR TITLE
chore: aria-hidden 装飾要素のテストアサーション方針を整理 (Closes #709)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -495,6 +495,37 @@ describe("add", () => {
 - テストファイルは対象ファイルと同階層の `__tests__/` 以下に置き、`*.test.ts` / `*.test.tsx` とする(既存ディレクトリ構成を踏襲)
 - 共通セットアップは `src/test/` に集約する
 
+#### `aria-hidden` 装飾要素のアサーション方針（Issue #709 で確定）
+
+`aria-hidden="true"` を持つ装飾要素（Em ダッシュ `—` / 矢印 `↑` / 中点 `・` / 視覚短縮形 `全 N 件` 等）の中身を**素の `getByText` だけでアサートしてはいけない**。`aria-hidden="true"` は「SR から無視される装飾要素」を宣言する属性であり、`getByText` の「画面に観測可能なテキスト = SR 読み上げ可能」というセマンティクスと矛盾するため。
+
+採用方針は **(b) 属性ベースクエリ or hybrid アサート** の二択（PR #692 follow-up / Issue #709 で確定）:
+
+- **方式 b-1（純属性ベース）**: `container.querySelector('[aria-hidden="true"]')` 等で取得し、`textContent` を assert する
+  - 採用例: `Coordinate.test.tsx` の separator 「・」検証（`container.querySelectorAll('span[aria-hidden="true"]')` + `expect(separator?.textContent).toBe("・")`）
+- **方式 b-2（hybrid）**: `getByText(...)` で取得した直後に `toHaveAttribute("aria-hidden", "true")` を必ずチェーンする
+  - 採用例: `Header.test.tsx` の「全 N 件」検証（`expect(screen.getByText("全 5 件")).toHaveAttribute("aria-hidden", "true")`）
+  - 「テキストが DOM に存在し、かつ意図的に aria-hidden である」ことを 1 行で表現できるため、可読性を優先する場合に有用
+
+**選択基準**: 単一要素を狙い撃ちできる場合は b-2（hybrid）を優先、複数の aria-hidden 要素を列挙して個別検証する場合は b-1（querySelectorAll）を使う。
+
+**棄却した選択肢**:
+
+- **(a) 現状維持（素の `getByText`）**: Testing Library のセマンティクスと乖離するため棄却
+- **(c) CSS `::before content` への追い出し**: 装飾文字の意味（Em ダッシュ vs 矢印 vs 中点）を Tripwire テストから直接観測できなくなり、テスト網が緩むため棄却。装飾文字は HTML 上の文字列として保持し、aria-hidden で SR から隠す現方針を維持する
+
+```typescript
+// 悪い例: aria-hidden 装飾要素を素の getByText でアサート（Issue #709 違反）
+expect(screen.getByText("—")).toBeInTheDocument();
+
+// 良い例 b-1: 属性ベースクエリ + textContent
+const separators = container.querySelectorAll('span[aria-hidden="true"]');
+expect(separators[0]?.textContent).toBe("—");
+
+// 良い例 b-2: getByText + toHaveAttribute をチェーン
+expect(screen.getByText("—")).toHaveAttribute("aria-hidden", "true");
+```
+
 ### テストケース名のルール
 
 テストケース名は以下のルールに従うこと：

--- a/src/components/atoms/__tests__/IndexRow.test.tsx
+++ b/src/components/atoms/__tests__/IndexRow.test.tsx
@@ -86,7 +86,11 @@ describe("IndexRow", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("—")).toBeInTheDocument();
+    // Issue #709: Em ダッシュは aria-hidden の装飾要素のため、素の
+    // `getByText` ではなく `toHaveAttribute("aria-hidden", "true")` を
+    // チェーンする hybrid 方式 (CLAUDE.md「aria-hidden 装飾要素のアサーション
+    // 方針」b-2) で「装飾文字として SR から隠されている」ことを同時に保証する。
+    expect(screen.getByText("—")).toHaveAttribute("aria-hidden", "true");
   });
 
   it("タイトルが空の場合は「無題の記事」を表示する", () => {

--- a/src/components/layouts/__tests__/Header.test.tsx
+++ b/src/components/layouts/__tests__/Header.test.tsx
@@ -25,13 +25,14 @@ describe("Header", () => {
   it("記事数を視覚短縮形「全 N 件」で表示できる", () => {
     // R-4 (Issue #392) で BookOpen 装飾は削除し、表記を「全 N 件」に統一。
     // 視覚短縮形は aria-hidden の span に分離し、SR からは隠す。
+    // Issue #709: 装飾要素は素の `getByText` ではなく hybrid (`toHaveAttribute`)
+    // で「DOM に存在しつつ SR から意図的に隠されている」ことを同時に保証する。
     render(
       <MemoryRouter>
         <Header postCount={5} />
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("全 5 件")).toBeInTheDocument();
     expect(screen.getByText("全 5 件")).toHaveAttribute("aria-hidden", "true");
   });
 
@@ -55,7 +56,10 @@ describe("Header", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("全 0 件")).toBeInTheDocument();
+    // Issue #709: 「全 0 件」は aria-hidden の装飾要素のため hybrid アサート、
+    // 「記事 0 件」は SR 用の visuallyHidden テキスト (aria-hidden を持たない)
+    // のため通常の getByText で良い。
+    expect(screen.getByText("全 0 件")).toHaveAttribute("aria-hidden", "true");
     expect(screen.getByText("記事 0 件")).toBeInTheDocument();
   });
 
@@ -70,13 +74,17 @@ describe("Header", () => {
   });
 
   it("大きな記事数でも表示できる", () => {
+    // Issue #709: 「全 999 件」は aria-hidden 装飾要素のため hybrid アサート。
     render(
       <MemoryRouter>
         <Header postCount={999} />
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("全 999 件")).toBeInTheDocument();
+    expect(screen.getByText("全 999 件")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
   });
 
   it("headerタグが使用されている", () => {


### PR DESCRIPTION
## 概要

PR #711 (Closes #692) のレビューで指摘された「`aria-hidden=\"true\"` 装飾要素を `getByText` でアサートする矛盾」の運用方針を整理する。

Closes #709

## 棚卸し結果

`aria-hidden=\"true\"` + テキスト内容を持つ要素は計 5 箇所:

| Component | テキスト | 既存テストのアサート方式 |
|---|---|---|
| `IndexRow.tsx:241` | `—` | **NG** 素の `getByText(\"—\")` (1 件) |
| `BackToTop.tsx:103` | `↑` | OK (テストで text 観測なし) |
| `Coordinate.tsx:175` | `・` | OK (querySelectorAll + textContent / 既に b-1 採用) |
| `Header.tsx:65` | `全 N 件` | **NG** 素の `getByText` (3 件中 2 件)、1 件のみ hybrid |
| `AnchorPage.tsx:394` | `{tone}` | OK (data-tone 属性ベース) |

違反は計 **3 件** (IndexRow×1 + Header×2)。

## 採用方針

**(b) 属性ベース or hybrid アサート** を採用:
- **b-1**: `container.querySelector('[aria-hidden=\"true\"]')` + `textContent` (複数列挙)
- **b-2**: `getByText(...).toHaveAttribute(\"aria-hidden\", \"true\")` (hybrid、単一要素)

(a) 素 `getByText` は禁止。(c) CSS `::before` 退避は Tripwire 観測性低下で棄却。

## 変更内容

- `CLAUDE.md`: 「テスト方針」配下に新節を追加 (方針 b の明文化、b-1 / b-2 使い分け、コードサンプル付き)
- `src/components/atoms/__tests__/IndexRow.test.tsx`: Em ダッシュ getByText を hybrid (b-2) に変更
- `src/components/layouts/__tests__/Header.test.tsx`: 「全 N 件」getByText を hybrid (b-2) に変更

違反 3 件すべて本 PR で対応 (件数が少ないため別 Issue 分割せず)。

## 検証

- [x] `pnpm test:run` pass (1041 tests / 56 files)
- [x] `pnpm lint` pass (127 files, no fixes)

## ローカルレビュー結果

- 実装担当 → レビュワー → DA の 3 段階レビュー
- レビュワー: ✅ 承認
- DA: マージ可、軽微指摘 (commit 射程混在 / hybrid 矛盾の明文化 / 棚卸し証跡) は follow-up で追跡

## 備考