### PR TITLE
chore: walkDirectory を public 入口 / internal 再帰の 2 関数に分割 (Closes #722)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,25 @@ jobs:
       # Issue #580: tsc --incremental の .tsbuildinfo を cache し、
       # type-check / type-check:test / type-check:scripts / type-check:api の cold ビルドを高速化する。
       # メインキー: lockfile + tsconfig.json / tsconfig.test.json / tsconfig.scripts.json / tsconfig.api.json + src/scripts の hash が完全一致した場合のみ hit
-      # restoreKeys: lockfile + tsconfig が一致なら部分的に再利用 (src 差分のみ再計算)
       # tsconfig.scripts.json は Issue #634 で新設 (scripts/ ambient 型の attack surface 制御)
       # tsconfig.api.json は Issue #667 で新設 (src/api/ を本体 tsc から分離し Node 型漏出を遮断)
+      #
+      # restoreKeys 削除の経緯 (Issue #722 follow-up / PR #731):
+      #   旧設定では `tsc-<OS>-<tsconfig-hash>-` および `tsc-<OS>-` を restoreKeys として
+      #   保持していたが、src/scripts の hash が不一致な過去 cache を fallback で復元すると、
+      #   tsc --incremental + --noEmit の semantic diagnostics キャッシュが
+      #   古いソースの行番号でエラー報告する問題が観測された
+      #   (例: `walkDirectory` の 4 引数版 ↔ 3 引数版を取り違える TS2554)。
+      #   src 変更ごとに strict match のみで cache 採用するよう restoreKeys を撤去し、
+      #   stale cache 起因の誤診断を根絶する。trade-off:
+      #     - cache hit 率は下がる (master 取り込み等で src hash が変わると毎回 clean build)
+      #     - CI 時間増加分は scripts/test/api/main 各 entry で数十秒程度
+      #     - 信頼性 > 速度 と判断
       - name: Cache tsc incremental build info (Issue #580)
         uses: actions/cache@v5
         with:
           path: .tsbuildinfo
           key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json', 'tsconfig.api.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts', 'scripts/**/*.tsx') }}
-          restore-keys: |
-            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json', 'tsconfig.api.json') }}-
-            tsc-${{ runner.os }}-
 
       - name: Type check
         run: pnpm type-check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,14 +55,13 @@ jobs:
       # (lint-and-typecheck job) 側の同 step も同期して変更すること。逆も同様。drift すると
       # ci.yml が warm にした .tsbuildinfo を deploy.yml 側が再利用できず (またはその逆)、warm cache が
       # 無駄になる。
+      # NOTE: PR #731 (Issue #722 follow-up) で restoreKeys を撤去した。経緯は ci.yml 側の
+      # 同 step コメント参照 (stale cache 起因の tsc --incremental + --noEmit 誤診断防止)。
       - name: Cache tsc incremental build info (Issue #655)
         uses: actions/cache@v5
         with:
           path: .tsbuildinfo
           key: tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json', 'tsconfig.api.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'scripts/**/*.ts', 'scripts/**/*.tsx') }}
-          restore-keys: |
-            tsc-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig.scripts.json', 'tsconfig.api.json') }}-
-            tsc-${{ runner.os }}-
 
       - name: Build project
         run: pnpm run build

--- a/scripts/__tests__/lintTokens.test.ts
+++ b/scripts/__tests__/lintTokens.test.ts
@@ -10,6 +10,7 @@
 import {
   mkdirSync,
   mkdtempSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -39,6 +40,7 @@ import {
   tryStat,
   type Violation,
   walkDirectory,
+  walkDirectoryRecursive,
 } from "../lintTokens";
 
 const makeState = (overrides: Partial<ScanState> = {}): ScanState => ({
@@ -377,6 +379,66 @@ describe("walkDirectory", () => {
       // 共有されていない)。
       expect(r2.length).toBeGreaterThan(0);
     });
+  });
+});
+
+// ========================================================================
+// walkDirectoryRecursive (Issue #722 / 案 B 採用)
+//
+// PR #703 (Issue #658) 時点の `walkDirectory(current, results, onSkip?, visited?)`
+// から visited オプショナルを排除する目的で、本 PR で public 入口
+// `walkDirectory` (visited を意識しない) と internal 再帰
+// `walkDirectoryRecursive` (visited 必須) の 2 関数に分割した。
+//
+// `walkDirectoryRecursive` は外部から直接呼ばれることを想定しない internal API
+// だが、`visited` 必須化の契約 (= 呼び出し側が `Set<string>` を明示的に渡さない
+// と再帰経路で visited 漏れの regression が起きうる) を担保する単体テストを
+// 本ブロックで残す。
+// ========================================================================
+describe("walkDirectoryRecursive", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "lint-tokens-walk-rec-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("呼び出し側から渡された visited Set を再帰経路で共有できる", () => {
+    // tmpDir/
+    //   sub/
+    //     deep.ts          # 通常ファイル
+    // visited に sub の実体パスを事前登録しておくと、sub 配下の deep.ts は
+    // 走査されない (= visited 共有が機能している)。
+    const sub = join(tmpDir, "sub");
+    mkdirSync(sub);
+    writeFileSync(join(sub, "deep.ts"), "x", "utf8");
+
+    const results: string[] = [];
+    const visited = new Set<string>();
+    // sub を事前訪問済みとして登録する。`walkDirectoryRecursive` は
+    // `realpathSync` で正規化したパスを visited のキーにするため
+    // (macOS の `/var/folders` → `/private/var/folders` 等)、テスト側でも
+    // 同じ正規化を経由した値を渡す必要がある。
+    visited.add(realpathSync(sub));
+    walkDirectoryRecursive(tmpDir, results, undefined, visited);
+
+    // sub が visited なので deep.ts は収集されない。
+    expect(results).not.toContain(join(sub, "deep.ts"));
+  });
+
+  it("visited が空の場合は public walkDirectory と同じく全ファイルを集められる", () => {
+    writeFileSync(join(tmpDir, "ok.ts"), "x", "utf8");
+    const sub = join(tmpDir, "sub");
+    mkdirSync(sub);
+    writeFileSync(join(sub, "deep.ts"), "x", "utf8");
+
+    const results: string[] = [];
+    walkDirectoryRecursive(tmpDir, results, undefined, new Set<string>());
+    expect(results).toContain(join(tmpDir, "ok.ts"));
+    expect(results).toContain(join(sub, "deep.ts"));
   });
 });
 

--- a/scripts/lintTokens.ts
+++ b/scripts/lintTokens.ts
@@ -475,14 +475,12 @@ const collectTargetFiles = (
     return results;
   }
 
-  // `visited` を明示渡しすることで「呼び出し単位で独立した Set を使う」
-  // 意図を呼び出し側に固定する (Issue #703 Minor 1 / リファクタ耐性向上)。
-  // 省略しても `walkDirectory` のデフォルト引数で新規 Set が生成されるため
-  // 動作は同じだが、`collectTargetFiles` 1 回分の走査が独立した visited
-  // スコープを持つことを明示することで、将来 `walkDirectory` のシグネチャ
-  // 変更 (例: visited を必須化 / デフォルト引数廃止) が起きても
-  // `collectTargetFiles` 側を書き換える必要がなくなる。
-  walkDirectory(target, results, onSkip, new Set<string>());
+  // Issue #722 で `walkDirectory` を「public 入口 (visited を意識しない 3 引数版)」と
+  // 「internal 再帰 `walkDirectoryRecursive` (visited 必須)」の 2 関数に分割した。
+  // `collectTargetFiles` 側は public 入口のみを呼べばよく、visited Set の生成 /
+  // 取り回し責務は `walkDirectory` 内に閉じ込められている (= 呼び出し側で
+  // visited 漏れによる無限ループ regression が起きない構造)。
+  walkDirectory(target, results, onSkip);
   return results;
 };
 

--- a/scripts/lintTokens.ts
+++ b/scripts/lintTokens.ts
@@ -327,8 +327,8 @@ const shouldSkipEntry = (entry: string): boolean => {
 };
 
 /**
- * ディレクトリを再帰走査し、受理可能ファイルを `results` に追記する。
- * `collectTargetFiles` から呼び出される内部ヘルパー。
+ * ディレクトリを再帰走査し、受理可能ファイルを `results` に追記する内部ヘルパー
+ * (Issue #722 で `walkDirectory` から分割)。
  *
  * `statSync` を直接呼ぶと broken symlink 等で throw する潜在問題があるため、
  * `tryStat` 経由で取得し、stat 失敗エントリは静かにスキップする
@@ -340,30 +340,41 @@ const shouldSkipEntry = (entry: string): boolean => {
  *   ある。そこで `realpathSync` で正規化したディレクトリ実体パスを
  *   `visited: Set<string>` に記録し、既訪問なら skip する (案 1)。
  *
- *   - `visited` のスコープは `walkDirectory` 呼び出し単位 (= `collectTargetFiles`
- *     1 回分)。呼び出し間で再利用しないことで、`TARGET_PATHS` の各ターゲット
- *     が独立した走査を行えるようにする (例: `src/` と `scripts/` の両方が
- *     `tmp/cache` を symlink で指していても両方を走査対象にする)
+ *   - `visited` のスコープは public 入口 `walkDirectory` 呼び出し単位
+ *     (= `collectTargetFiles` 1 回分)。呼び出し間で再利用しないことで、
+ *     `TARGET_PATHS` の各ターゲットが独立した走査を行えるようにする
+ *     (例: `src/` と `scripts/` の両方が `tmp/cache` を symlink で指していても
+ *     両方を走査対象にする)
  *   - `realpathSync` が失敗 (broken symlink / ELOOP 等) した場合は安全側 skip
  *     + `onSkip` 通知 (`tryRealpath` 経由)
  *   - ファイルは再帰呼び出しを伴わないため visited 記録対象外 (= ループ
  *     リスクなし)。記録すると同一実体ファイルを複数の symlink 経由で参照
  *     しているケースで片方が落ちる副作用が出るため、ディレクトリのみ管理する
  *
+ * 設計判断 (Issue #722 / 案 B):
+ *   PR #703 (Issue #658) で `walkDirectory(current, results, onSkip?, visited?)`
+ *   と visited をオプショナルで導入したが、DA レビュー M-1 で「外部呼び出し時に
+ *   visited を渡し忘れる余地が残る」と指摘された。本 PR で **public 入口
+ *   `walkDirectory` (visited を意識しない) と internal 再帰 `walkDirectoryRecursive`
+ *   (visited 必須) の 2 関数に分割**することで、再帰経路では visited 漏れを
+ *   型レベルで防止し、外部呼び出し側は visited を意識せず使えるようにした
+ *   (= API 表面の明確化)。
+ *
  * @param results **in-out**: 検出した受理可能ファイルのパスを末尾に push する
  *   (Issue #621 / N1)
  * @param onSkip 省略可。stat / realpath 失敗 / symlink ループで skip した場合に
  *   呼ばれるコールバック (Issue #637 / Issue #658)。`main()` が件数集計用に渡す
- * @param visited 省略可。訪問済みディレクトリ実体パスの `Set` (Issue #658)。
- *   省略時は呼び出しごとに新規生成され、当該呼び出し内でのみ共有される
+ * @param visited **必須**: 訪問済みディレクトリ実体パスの `Set` (Issue #658)。
+ *   再帰経路で visited 漏れを防ぐため public 入口 `walkDirectory` 側で新規生成し、
+ *   この内部関数では受け取りを必須化する (Issue #722 / 案 B)
  *
  * @internal テスト専用 export. 本番コードから import しないこと
  */
-const walkDirectory = (
+const walkDirectoryRecursive = (
   current: string,
   results: string[],
-  onSkip?: SkipCallback,
-  visited: Set<string> = new Set<string>(),
+  onSkip: SkipCallback | undefined,
+  visited: Set<string>,
 ): void => {
   // 現在ディレクトリを訪問済みに記録する。`current` 自身も symlink 経由で
   // 渡された可能性があるため、`realpathSync` で実体パスに正規化する。
@@ -390,13 +401,42 @@ const walkDirectory = (
       continue;
     }
     if (entryStats.isDirectory()) {
-      walkDirectory(fullPath, results, onSkip, visited);
+      walkDirectoryRecursive(fullPath, results, onSkip, visited);
       continue;
     }
     if (entryStats.isFile() && isAcceptableFile(fullPath)) {
       results.push(fullPath);
     }
   }
+};
+
+/**
+ * ディレクトリを再帰走査し、受理可能ファイルを `results` に追記する public 入口
+ * (Issue #722 で `walkDirectoryRecursive` から分離)。
+ *
+ * 内部で visited Set を新規生成し、再帰呼び出しは `walkDirectoryRecursive` に
+ * 委譲する。**外部呼び出し側 (= `collectTargetFiles` / テスト) は visited を
+ * 意識せず使える**。再帰経路で visited を取り回す責務は internal 側に閉じ込めて
+ * あるため、visited 渡し忘れによる無限ループ regression を構造的に防ぐ
+ * (DA レビュー M-1 / Issue #722 / 案 B 採用)。
+ *
+ * visited のスコープは「この `walkDirectory` 呼び出し単位」で、呼び出し間で
+ * 再利用しない (= 同一実体を指す独立ターゲット (`src/` と symlink された別 root)
+ * は別個に走査される)。挙動詳細は `walkDirectoryRecursive` JSDoc を参照。
+ *
+ * @param results **in-out**: 検出した受理可能ファイルのパスを末尾に push する
+ *   (Issue #621 / N1)
+ * @param onSkip 省略可。stat / realpath 失敗 / symlink ループで skip した場合に
+ *   呼ばれるコールバック (Issue #637 / Issue #658)
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+const walkDirectory = (
+  target: string,
+  results: string[],
+  onSkip?: SkipCallback,
+): void => {
+  walkDirectoryRecursive(target, results, onSkip, new Set<string>());
 };
 
 /**
@@ -1063,4 +1103,5 @@ export {
   tryRealpath,
   tryStat,
   walkDirectory,
+  walkDirectoryRecursive,
 };


### PR DESCRIPTION
## 概要

Issue #722 対応（PR #704 / #719 follow-up）。`walkDirectory` の `visited` 引数を「public 入口（visited 不要）」と「internal 再帰（visited 必須）」の 2 関数に分割し、visited 渡し忘れ regression を型レベルで遮断する（案 B 採用）。

## 変更内容

### `scripts/lintTokens.ts`

- `walkDirectory(target, results, onSkip?)`: public 入口。内部で `new Set<string>()` を確保して `walkDirectoryRecursive` に委譲
- `walkDirectoryRecursive(current, results, onSkip, visited)`: internal 再帰。visited 必須（型レベルで渡し忘れを防止）
- 両関数とも `@internal テスト専用 export. 本番コードから import しないこと` JSDoc 文言を統一
- 既存呼び出し側 (`collectTargetFiles`) は public 入口のシグネチャと互換のため変更不要

### `scripts/__tests__/lintTokens.test.ts`

`walkDirectoryRecursive` 用テスト 2 件追加:
- 呼び出し側から渡された visited Set を再帰経路で共有できる
- visited が空の場合は public walkDirectory と同じく全ファイルを集められる

macOS の `/var` ↔ `/private/var` 対応のため test キー正規化に `realpathSync` を import 利用。

## 後続コミット（補足）

`93082e7` の本体修正以降、CI 失敗の解決と master 取り込みのため以下を追加した:

- **`2006dda`** (`.github/workflows/ci.yml` / `deploy.yml`): `.tsbuildinfo` cache の `restoreKeys` ブロックを撤去。`type-check:scripts` の `TS2554` 失敗は `restoreKeys` のフォールバックで stale な buildinfo が復元され、`tsc --incremental + --noEmit` の semantic diagnostics キャッシュが古い行番号で誤報する挙動が一致したため。strict key match のみで cache 採用させて誤診断を構造的に遮断する。Issue #642 の N-3「第 2 段 restoreKeys 効果検証」を実質的に解決（残る M1 / N2 は #642 で継続）
- **`25b82db`** (Merge `origin/master`): `#726`（Closes #640）で導入された 4 cache entry 分離構造（`tsc-main` / `tsc-test` / `tsc-scripts` / `tsc-api`）を取り込み、各 entry の `restoreKeys` を撤去する形でコンフリクトを解消
- **`8a2b4af`** (`scripts/lintTokens.ts`): merge auto-resolution が `collectTargetFiles` の `walkDirectory(target, results, onSkip, new Set<string>())` 4 引数呼び出しを master 側のまま残してしまったため、`93082e7` の意図通り 3 引数呼び出しに再修正。本件は型レベル（`TS2554`）で CI が検知して構造的に防いだ事例であり、案 B 設計の優位性を実証する形となった

## 備考

### 案 B 採用根拠

- 案 A (visited 必須化、呼び出し側で `new Set()` を毎回明示) は ceremony 化で情報量が薄い
- 案 B は public API 表面を簡潔に保ちつつ、再帰経路の visited 漏れを **型レベルで** 構造的に排除
- `visited` の存在を呼び出し側に意識させない API 抽象として優位

### 既存挙動の維持

- symlink ループ防止 (`realpathSync` + `visited`) のロジックは `walkDirectoryRecursive` に温存
- public 入口の既存 12 テスト + 新規 2 テストで等価性を担保
- visited スコープ: 呼び出し単位で新規生成、`TARGET_PATHS` 独立走査の仕様維持

### 検証

- `pnpm lint` / `pnpm type-check` / `pnpm type-check:scripts` / `pnpm type-check:test` / `pnpm type-check:api` / `pnpm test:run` (1053 件) / `pnpm build` 全 pass
- CI 全 6 check（lint-and-typecheck / test / e2e / axe / precommit-guard-tests / yamllint）SUCCESS

Closes #722
