### PR TITLE
chore: checkBuildCiSync.ts のテスト網羅性 + HINT_MESSAGE + isBuildCiMisconfigured 独立 export (Closes #724)

### DIFF
--- a/scripts/__tests__/checkBuildCiSync.test.ts
+++ b/scripts/__tests__/checkBuildCiSync.test.ts
@@ -1,16 +1,18 @@
 /**
- * scripts/checkBuildCiSync.ts の単体テスト (Issue #685 / #701)
+ * scripts/checkBuildCiSync.ts の単体テスト (Issue #685 / #701 / #724)
  *
  * 検証対象:
  *   - splitCommands: `&&` 区切りで command を取り出し、空 token を除外する
- *   - tokenizeCommand: 空白区切りで token 列を返し、空 token を除外する
+ *   - tokenizeCommand: 空白 (スペース / タブ) 区切りで token 列を返し、空 token を除外する
  *   - checkSync:
  *       - build に build:ci の全 command が順序を保って含まれていれば ok
  *       - 順序が崩れた / command が抜けていれば ng (reason 付き)
  *       - build:ci 側が空なら ok (検査対象なし)
  *       - wrapper prefix (`pnpm exec tsc` 等) を許容する
  *       - 部分一致誤検出 (`pnpm exec my-tsc-wrapper` ⊃ `tsc`) を排除する (Issue #701)
+ *       - prefix 違い (`wrapper-tsc`) / suffix 違い (`tsc-wrapper`) も誤検出しない (Issue #724)
  *       - multi-token command (`tsc --project tsconfig.api.json`) を token 列単位で扱う
+ *   - isBuildCiMisconfigured: build:ci 文字列が空 / 空白のみなら true、それ以外は false (Issue #724)
  *   - loadPackageScripts: package.json から scripts.build / scripts["build:ci"] を取り出し、
  *     欠落 / 型違反は throw する
  *   - main: buildCi が空文字列の場合に exit 1 で fail する (Issue #701)
@@ -22,6 +24,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   checkSync,
+  isBuildCiMisconfigured,
   loadPackageScripts,
   main,
   splitCommands,
@@ -44,6 +47,12 @@ describe("splitCommands", () => {
   it("空白のみの token を除外する", () => {
     expect(splitCommands("panda && && tsc")).toEqual(["panda", "tsc"]);
   });
+
+  it("`&&` のみの入力に対して空配列を返す (Issue #724)", () => {
+    // `&&` で分割すると ["", ""] になるが、trim + 空 filter で空配列になる
+    expect(splitCommands("&&")).toEqual([]);
+    expect(splitCommands(" && && ")).toEqual([]);
+  });
 });
 
 describe("tokenizeCommand", () => {
@@ -57,6 +66,16 @@ describe("tokenizeCommand", () => {
 
   it("連続する空白を 1 つの区切りとして扱う", () => {
     expect(tokenizeCommand("pnpm   exec   tsc")).toEqual([
+      "pnpm",
+      "exec",
+      "tsc",
+    ]);
+  });
+
+  it("タブ区切りも空白と同じ区切りとして扱う (Issue #724)", () => {
+    // `/\s+/` で split しているため、タブ (\t) もスペースと同じく区切り扱い
+    expect(tokenizeCommand("pnpm\texec\ttsc")).toEqual(["pnpm", "exec", "tsc"]);
+    expect(tokenizeCommand("pnpm \t exec \t tsc")).toEqual([
       "pnpm",
       "exec",
       "tsc",
@@ -154,6 +173,33 @@ describe("checkSync", () => {
     expect(result.reason).toContain("tsc");
   });
 
+  it("build 側 token が `wrapper-tsc` (prefix 違いハイフン繋ぎ) でも `tsc` を誤検出しない (Issue #724)", () => {
+    // `wrapper-tsc` は単一 token (ハイフンは区切り扱いされない) なので、
+    // 末尾完全一致では `wrapper-tsc` !== `tsc` で別 token と判定される。
+    const buildScript = "panda && wrapper-tsc && vite build";
+    const buildCiScript = "panda && tsc && vite build";
+    const result = checkSync(buildScript, buildCiScript);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("tsc");
+  });
+
+  it("build 側 token が `tsc-wrapper` (suffix 違いハイフン繋ぎ) でも `tsc` を誤検出しない (Issue #724)", () => {
+    // `tsc-wrapper` も同様に単一 token として扱われ、`tsc` とは別 token になる。
+    const buildScript = "panda && tsc-wrapper && vite build";
+    const buildCiScript = "panda && tsc && vite build";
+    const result = checkSync(buildScript, buildCiScript);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("tsc");
+  });
+
+  it("build:ci が `&&` のみ (= splitCommands 後に空 command 列) なら ok 扱い (Issue #724)", () => {
+    // `splitCommands("&&")` は空配列を返すため、checkSync は「検査対象なし」で
+    // ok を返す。文字列としての構成不備 (空文字 / 空白のみ) は `main` 側で
+    // `isBuildCiMisconfigured` により別途検査する責務分割になっている。
+    expect(checkSync("panda && tsc && vite build", "&&").ok).toBe(true);
+    expect(checkSync("panda && tsc && vite build", " && && ").ok).toBe(true);
+  });
+
   it("build が空かつ build:ci が非空なら ng", () => {
     const result = checkSync("", "panda && tsc && vite build");
     expect(result.ok).toBe(false);
@@ -164,6 +210,31 @@ describe("checkSync", () => {
     const result = checkSync("panda && tsc", "panda && tsc && vite build");
     expect(result.ok).toBe(false);
     expect(result.reason).toContain("vite build");
+  });
+});
+
+describe("isBuildCiMisconfigured", () => {
+  it("空文字列なら true を返す (Issue #724)", () => {
+    expect(isBuildCiMisconfigured("")).toBe(true);
+  });
+
+  it("空白のみ (スペース / タブ / 改行) なら true を返す (Issue #724)", () => {
+    expect(isBuildCiMisconfigured("   ")).toBe(true);
+    expect(isBuildCiMisconfigured("\t\n")).toBe(true);
+    expect(isBuildCiMisconfigured(" \t\n ")).toBe(true);
+  });
+
+  it("非空 command を含むなら false を返す (Issue #724)", () => {
+    expect(isBuildCiMisconfigured("panda && tsc && vite build")).toBe(false);
+    expect(isBuildCiMisconfigured("tsc")).toBe(false);
+  });
+
+  it("`&&` のみでも文字列としては非空なので false を返す (Issue #724)", () => {
+    // 本関数の判定対象は「文字列として空 / 空白のみか」であり、
+    // command 配列としての空 (例: `&&` → splitCommands 後 0 件) は
+    // checkSync 側で「検査対象なし → ok」として扱う責務分割。
+    expect(isBuildCiMisconfigured("&&")).toBe(false);
+    expect(isBuildCiMisconfigured(" && && ")).toBe(false);
   });
 });
 
@@ -246,7 +317,7 @@ describe("main", () => {
     }) as never);
   };
 
-  it("buildCi が空文字列なら exit 1 で fail する (Issue #701)", () => {
+  it("buildCi が空文字列なら exit 1 で fail し HINT_MESSAGE を stderr に出力する (Issue #701 / #724)", () => {
     const packagePath = join(tempDir, "package.json");
     writeFileSync(
       packagePath,
@@ -267,6 +338,12 @@ describe("main", () => {
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringMatching(/空文字列|構成不備/),
     );
+    // Issue #724: 空文字 fail 経路でも drift 時と同じ修正手順 HINT を出す
+    const allErrorMessages = errorSpy.mock.calls
+      .map((args) => args.join(" "))
+      .join("\n");
+    expect(allErrorMessages).toContain("Issue #685");
+    expect(allErrorMessages).toContain("対処方針");
   });
 
   it("buildCi が空白のみでも exit 1 で fail する (Issue #701)", () => {

--- a/scripts/checkBuildCiSync.ts
+++ b/scripts/checkBuildCiSync.ts
@@ -240,6 +240,34 @@ const HINT_MESSAGE = [
 ].join("\n");
 
 /**
+ * `scripts["build:ci"]` の文字列が「構成不備 (空 / 空白のみ)」かどうかを
+ * 判定する純粋関数。
+ *
+ * Issue #701 / #724: 旧実装では `main` 内インラインで
+ * `scripts.buildCi.trim().length === 0` を判定していたが、
+ *   - 単体テストから直接検証できない (`main` 経由でしか叩けない)
+ *   - 同種判定を他所で再利用するときに 1 箇所に集約しておきたい
+ * という理由で純粋関数として独立 export する。
+ *
+ * `checkSync` 自体は文字列入力に対する純粋関数として
+ * 「検査対象なし → ok」を維持する設計のため、構成不備判定は本関数 +
+ * 呼び出し側 (`main`) に集約する責務分割になっている。
+ *
+ * 判定対象は **文字列としての空 / 空白のみ** のみであり、
+ * `"&&"` や `"&& &&"` のような「command 列としては空だが文字列としては非空」
+ * のケースは `false` を返す (= 構成不備とは扱わない)。後者は `checkSync` 側で
+ * 「ciCommands.length === 0 → ok」と扱うのが既存契約。
+ *
+ * @param buildCiScript - `package.json` の `scripts["build:ci"]` の生文字列
+ * @returns 空文字 / 空白のみなら `true`、それ以外は `false`
+ *
+ * @internal テスト専用 export. 本番コードから import しないこと
+ */
+const isBuildCiMisconfigured = (buildCiScript: string): boolean => {
+  return buildCiScript.trim().length === 0;
+};
+
+/**
  * CLI エントリポイント。`package.json` を読み、`checkSync` の結果に応じて
  * stdout / stderr に出力し、drift / 構成不備時は `process.exit(1)` する。
  *
@@ -262,10 +290,13 @@ const main = (packageJsonPath: string = PACKAGE_JSON_PATH): void => {
     process.exit(1);
   }
 
-  if (scripts.buildCi.trim().length === 0) {
+  if (isBuildCiMisconfigured(scripts.buildCi)) {
     console.error(
       'checkBuildCiSync FATAL: package.json の scripts["build:ci"] が空文字列です (構成不備)。',
     );
+    console.error(`  build    = ${scripts.build}`);
+    console.error(`  build:ci = ${scripts.buildCi}`);
+    console.error(HINT_MESSAGE);
     process.exit(1);
   }
 
@@ -304,6 +335,7 @@ if (isDirectInvocation()) {
 export type { CheckResult, PackageScripts };
 export {
   checkSync,
+  isBuildCiMisconfigured,
   loadPackageScripts,
   main,
   splitCommands,


### PR DESCRIPTION
## 概要

Issue #724 対応（PR #717 / PR #720 (closed) cherry-pick）。closed PR #720 にあった独自価値を merged PR #717 ベースに移植する。

## 変更内容（2 commits）

### 1. `4ee339b` 実装側
- `scripts/checkBuildCiSync.ts`:
  - `isBuildCiMisconfigured(buildCi: string): boolean` 純粋関数を抽出し additive な新規 export 化（`main` 内インラインから独立）。`@internal` JSDoc 統一文言を付与
  - HINT_MESSAGE 出力経路を **空文字 fail (構成不備)** にも追加（旧実装は drift 検知時のみ）。`build` / `build:ci` の現在値も併記して context を補完

### 2. `d90a7ee` テスト追加（+9 件）
- `scripts/__tests__/checkBuildCiSync.test.ts`:
  - `splitCommands`: `&&` のみ入力 (+1)
  - `tokenizeCommand`: タブ区切り (+1)
  - `checkSync`: `wrapper-tsc` (prefix違い) / `tsc-wrapper` (suffix違い) / `&&` のみ buildCi の境界 (+3)
  - `isBuildCiMisconfigured` 新規 describe（空文字 / 空白のみ / 非空 / `&&` のみ）(+4)
  - 既存 main 空文字 fail テストに HINT_MESSAGE 出力検証を追記

## 備考

### `isBuildCiMisconfigured` 独立 export 採用根拠

`checkSync` (command 列の drift 検知) と `isBuildCiMisconfigured` (文字列空 = 構成不備) は責務が異なる。独立 export 化で **責務分割を test レベルで documenting** する。

### 既存命名の維持

PR #720 にあった命名変更 (`tokenizeWords` / `isSuffixMatch`) は採用せず、merged PR #717 の命名 (`tokenizeCommand` / `matchesAsSuffix`) を維持。既存 export シグネチャ完全不変、`isBuildCiMisconfigured` のみ additive 追加。

### 手動破壊検証

`package.json` の `build:ci` を空文字に変更 → `checkBuildCiSync FATAL: ... 空文字列です (構成不備)` の後に HINT_MESSAGE が stderr に出力され exit 1 を確認。検証後 `package.json` は復元済み。

### 検証

- `pnpm lint` / `pnpm type-check` / `pnpm type-check:scripts` / `pnpm test:run` (1051 件) / `pnpm build:ci` / `pnpm check:build-ci-sync` 全 pass
- `checkBuildCiSync.test.ts` 単体: 38 件 (既存 29 + 新規 9) 全 pass

Closes #724