### PR TITLE
refactor: Issue #652 cognitive complexity 違反 6 ファイル分の予防的リファクタ

### DIFF
--- a/src/api/images.ts
+++ b/src/api/images.ts
@@ -2,6 +2,20 @@ import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 
+/**
+ * Biome 厳格化耐性メモ (Issue #652 / PR #623 follow-up)
+ *
+ * 本ファイルは `maxAllowedComplexity:8` 厳格化条件下でも違反 0 になるよう、
+ * ミドルウェア本体を「正規化 (`resolveImageRequest`) → 配信 (`serveImageFile`)」
+ * の 2 ヘルパーに分割している。再現手順:
+ *   1. `biome.jsonc` の `noExcessiveCognitiveComplexity` の `maxAllowedComplexity`
+ *      を 8 に下げる
+ *   2. `pnpm exec biome lint src/api/images.ts` で違反 0 を確認
+ *   3. `pnpm test:run` で既存テスト全 pass を確認
+ *
+ * 公開 API シグネチャ (`createImagesMiddleware` の戻り値型) は不変。
+ */
+
 const IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"];
 
 const MIME_TYPES: Record<string, string> = {
@@ -14,51 +28,96 @@ const MIME_TYPES: Record<string, string> = {
 };
 
 /**
+ * 画像配信リクエストの解析結果。
+ *
+ * - `kind: "passthrough"` は次のミドルウェアへ委譲することを示す
+ *   (GET 以外 / URL が空 / 画像拡張子でない、いずれかの理由でこの module 管轄外)
+ * - `kind: "forbidden"` はパストラバーサル疑い (403 を返す)
+ * - `kind: "serve"` は配信対象として確定したファイルの絶対パスと拡張子
+ */
+type ImageRequestResolution =
+  | { readonly kind: "passthrough" }
+  | { readonly kind: "forbidden" }
+  | { readonly kind: "serve"; readonly filePath: string; readonly ext: string };
+
+/**
+ * リクエストを解析し、画像配信ミドルウェアの分岐先 (passthrough / forbidden / serve)
+ * を決定する純粋ヘルパー。
+ *
+ * ミドルウェア本体から条件分岐の cognitive complexity を引き剥がすために抽出。
+ *
+ * @param req - HTTP リクエスト (method / url のみを参照)
+ * @returns 分岐先を示す ImageRequestResolution
+ */
+const resolveImageRequest = (
+  req: IncomingMessage,
+): ImageRequestResolution => {
+  if (req.method !== "GET") {
+    return { kind: "passthrough" };
+  }
+
+  const urlPath = req.url || "";
+  const filename = urlPath.replace(/^\//, "");
+  if (!filename) {
+    return { kind: "passthrough" };
+  }
+
+  const ext = path.extname(filename).toLowerCase();
+  if (!IMAGE_EXTENSIONS.includes(ext)) {
+    return { kind: "passthrough" };
+  }
+
+  const imagesPath = path.join(process.cwd(), "datasources", "images");
+  const filePath = path.join(imagesPath, filename);
+
+  // パストラバーサル攻撃を防止
+  const resolvedPath = path.resolve(filePath);
+  if (!resolvedPath.startsWith(path.resolve(imagesPath))) {
+    return { kind: "forbidden" };
+  }
+
+  return { kind: "serve", filePath, ext };
+};
+
+/**
+ * 解決済みのファイルパスから画像を読み込み、レスポンスを返すヘルパー。
+ *
+ * ENOENT 等で読み込みに失敗した場合は 404 を返す (理由文字列は固定)。
+ */
+const serveImageFile = (
+  res: ServerResponse,
+  filePath: string,
+  ext: string,
+): void => {
+  try {
+    const content = fs.readFileSync(filePath);
+    const mimeType = MIME_TYPES[ext] || "application/octet-stream";
+    res.setHeader("Content-Type", mimeType);
+    res.end(content);
+  } catch (_error) {
+    res.statusCode = 404;
+    res.end("Image not found");
+  }
+};
+
+/**
  * 画像配信ミドルウェアを作成
  * - GET /datasources/images/:filename: 画像ファイルを取得
  * @returns Viteサーバーミドルウェア関数
  */
 export const createImagesMiddleware = () => {
   return (req: IncomingMessage, res: ServerResponse, next: () => void) => {
-    if (req.method !== "GET") {
+    const resolution = resolveImageRequest(req);
+    if (resolution.kind === "passthrough") {
       next();
       return;
     }
-
-    const urlPath = req.url || "";
-    const filename = urlPath.replace(/^\//, "");
-
-    if (!filename) {
-      next();
-      return;
-    }
-
-    const ext = path.extname(filename).toLowerCase();
-    if (!IMAGE_EXTENSIONS.includes(ext)) {
-      next();
-      return;
-    }
-
-    const imagesPath = path.join(process.cwd(), "datasources", "images");
-    const filePath = path.join(imagesPath, filename);
-
-    // パストラバーサル攻撃を防止
-    const resolvedPath = path.resolve(filePath);
-    if (!resolvedPath.startsWith(path.resolve(imagesPath))) {
+    if (resolution.kind === "forbidden") {
       res.statusCode = 403;
       res.end("Forbidden");
       return;
     }
-
-    try {
-      const content = fs.readFileSync(filePath);
-      const mimeType = MIME_TYPES[ext] || "application/octet-stream";
-      res.setHeader("Content-Type", mimeType);
-      res.end(content);
-    } catch (_error) {
-      res.statusCode = 404;
-      res.end("Image not found");
-    }
+    serveImageFile(res, resolution.filePath, resolution.ext);
   };
 };
 

--- a/src/api/posts.ts
+++ b/src/api/posts.ts
@@ -4,6 +4,91 @@ import path from "node:path";
 import { extractSummaryFromContent } from "../lib/markdownParser";
 
 /**
+ * Biome 厳格化耐性メモ (Issue #652 / PR #623 follow-up)
+ *
+ * 本ファイルは `maxAllowedComplexity:8` 厳格化条件下でも違反 0 になるよう、
+ * ミドルウェア本体を「単一投稿配信 (`servePostDetail`) / 投稿一覧配信
+ * (`servePostList`)」の 2 ヘルパーに分割している。再現手順:
+ *   1. `biome.jsonc` の `noExcessiveCognitiveComplexity` の `maxAllowedComplexity`
+ *      を 8 に下げる
+ *   2. `pnpm exec biome lint src/api/posts.ts` で違反 0 を確認
+ *   3. `pnpm test:run` で既存テスト全 pass を確認
+ *
+ * 公開 API シグネチャ (`createPostsMiddleware` の戻り値型) は不変。
+ */
+
+/**
+ * 個別投稿 (`/api/posts/:id`) を配信するヘルパー。
+ *
+ * - パストラバーサル攻撃を防止するため、resolve 後のパスが datasources 配下に
+ *   収まることを確認する
+ * - ファイルが存在しない場合は 404、それ以外の例外でも 404 を返す
+ */
+const servePostDetail = (
+  res: ServerResponse,
+  datasourcesPath: string,
+  postId: string,
+): void => {
+  const filePath = path.join(datasourcesPath, `${postId}.md`);
+
+  // パストラバーサル攻撃を防止
+  const resolvedPath = path.resolve(filePath);
+  if (!resolvedPath.startsWith(path.resolve(datasourcesPath))) {
+    res.statusCode = 403;
+    res.end("Forbidden");
+    return;
+  }
+
+  try {
+    const content = fs.readFileSync(filePath, "utf8");
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.end(content);
+  } catch (_error) {
+    res.statusCode = 404;
+    res.end("Post not found");
+  }
+};
+
+/**
+ * 投稿一覧 (`/api/posts`) を配信するヘルパー。
+ *
+ * - datasources 配下から `.md` ファイルを列挙し、メタデータを `extractSummaryFromContent`
+ *   で抽出する
+ * - 投稿は id (= タイムスタンプ文字列) の降順 (新→古) でソートする
+ * - 読み込み失敗時は 500 を返す
+ */
+const servePostList = (
+  res: ServerResponse,
+  datasourcesPath: string,
+): void => {
+  try {
+    const files = fs
+      .readdirSync(datasourcesPath)
+      .filter((file: string) => file.endsWith(".md"));
+
+    const posts = files.map((file: string) => {
+      const timestamp = file.replace(".md", "");
+      const filePath = path.join(datasourcesPath, file);
+      const content = fs.readFileSync(filePath, "utf8");
+      return extractSummaryFromContent(content, timestamp);
+    });
+
+    // IDで降順ソート（新しい投稿が先）
+    posts.sort((a, b) => b.id.localeCompare(a.id));
+
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(posts));
+  } catch (_error) {
+    res.statusCode = 500;
+    res.end(
+      JSON.stringify({
+        error: "Failed to read datasources directory",
+      }),
+    );
+  }
+};
+
+/**
  * 投稿APIミドルウェアを作成
  * - GET /api/posts: 投稿一覧（メタデータ付き）を取得
  * - GET /api/posts/:id: 個別投稿を取得
@@ -22,53 +107,10 @@ export const createPostsMiddleware = () => {
     const urlPath = req.url || "";
     const postId = urlPath.replace(/^\//, "").replace(/\.md$/, "");
 
-    // 個別投稿の取得
     if (postId) {
-      const filePath = path.join(datasourcesPath, `${postId}.md`);
-
-      // パストラバーサル攻撃を防止
-      const resolvedPath = path.resolve(filePath);
-      if (!resolvedPath.startsWith(path.resolve(datasourcesPath))) {
-        res.statusCode = 403;
-        res.end("Forbidden");
-        return;
-      }
-
-      try {
-        const content = fs.readFileSync(filePath, "utf8");
-        res.setHeader("Content-Type", "text/plain; charset=utf-8");
-        res.end(content);
-      } catch (_error) {
-        res.statusCode = 404;
-        res.end("Post not found");
-      }
-    } else {
-      // 投稿一覧の取得（メタデータ付き）
-      try {
-        const files = fs
-          .readdirSync(datasourcesPath)
-          .filter((file: string) => file.endsWith(".md"));
-
-        const posts = files.map((file: string) => {
-          const timestamp = file.replace(".md", "");
-          const filePath = path.join(datasourcesPath, file);
-          const content = fs.readFileSync(filePath, "utf8");
-          return extractSummaryFromContent(content, timestamp);
-        });
-
-        // IDで降順ソート（新しい投稿が先）
-        posts.sort((a, b) => b.id.localeCompare(a.id));
-
-        res.setHeader("Content-Type", "application/json");
-        res.end(JSON.stringify(posts));
-      } catch (_error) {
-        res.statusCode = 500;
-        res.end(
-          JSON.stringify({
-            error: "Failed to read datasources directory",
-          }),
-        );
-      }
+      servePostDetail(res, datasourcesPath, postId);
+      return;
     }
+    servePostList(res, datasourcesPath);
   };
 };

--- a/src/hooks/useCodeBlockCopy.ts
+++ b/src/hooks/useCodeBlockCopy.ts
@@ -1,6 +1,61 @@
 import { useEffect } from "react";
 
 /**
+ * Biome 厳格化耐性メモ (Issue #652 / PR #623 follow-up)
+ *
+ * 本ファイルは `maxAllowedComplexity:8` 厳格化条件下でも違反 0 になるよう、
+ * `handleClick` 内のコピー成否分岐を `copyAndAnimate` ヘルパーへ抽出している。
+ * 再現手順:
+ *   1. `biome.jsonc` の `noExcessiveCognitiveComplexity` の `maxAllowedComplexity`
+ *      を 8 に下げる
+ *   2. `pnpm exec biome lint src/hooks/useCodeBlockCopy.ts` で違反 0 を確認
+ *   3. `pnpm test:run` で既存テスト全 pass を確認
+ *
+ * 公開 API シグネチャ (`useCodeBlockCopy` の引数・戻り値) は不変。
+ */
+
+/**
+ * コピー成功時の表示文言と復元までのディレイ (ms)。
+ */
+const COPY_SUCCESS_LABEL = "コピー済み!";
+const COPY_FAILURE_LABEL = "コピー失敗";
+const COPY_DEFAULT_LABEL = "コピー";
+const RESTORE_DELAY_MS = 2000;
+
+/**
+ * 指定 button 要素のテキストを一時的に label に切り替え、`delayMs` 後に
+ * `restoreTo` の文言へ戻すユーティリティ。
+ *
+ * コピー成功時 / 失敗時の表示切替を 1 つの関数に集約し、`handleClick` の
+ * cognitive complexity を引き下げる。
+ */
+const flashButtonLabel = (
+  target: HTMLElement,
+  transient: string,
+  restoreTo: string | null,
+  delayMs: number,
+): void => {
+  target.textContent = transient;
+  setTimeout(() => {
+    target.textContent = restoreTo;
+  }, delayMs);
+};
+
+/**
+ * クリップボードへのコピーと UI フィードバック (成功 / 失敗の文言切替) を
+ * 1 関数にまとめる。`handleClick` から try/catch 分岐を引き剥がすために抽出。
+ */
+const copyAndAnimate = async (target: HTMLElement, code: string): Promise<void> => {
+  try {
+    await navigator.clipboard.writeText(code);
+    const originalText = target.textContent;
+    flashButtonLabel(target, COPY_SUCCESS_LABEL, originalText, RESTORE_DELAY_MS);
+  } catch {
+    flashButtonLabel(target, COPY_FAILURE_LABEL, COPY_DEFAULT_LABEL, RESTORE_DELAY_MS);
+  }
+};
+
+/**
  * コードブロックのコピーボタンにイベントデリゲーションでクリックリスナーを設定するフック。
  *
  * クリック時、対象 button の `data-code` 属性値を `navigator.clipboard.writeText` に
@@ -23,30 +78,16 @@ export const useCodeBlockCopy = (
       return;
     }
 
-    const handleClick = async (event: MouseEvent) => {
+    const handleClick = (event: MouseEvent): void => {
       const target = event.target as HTMLElement;
       if (!target.classList.contains("copy-btn")) {
         return;
       }
-
       const code = target.getAttribute("data-code");
       if (!code) {
         return;
       }
-
-      try {
-        await navigator.clipboard.writeText(code);
-        const originalText = target.textContent;
-        target.textContent = "コピー済み!";
-        setTimeout(() => {
-          target.textContent = originalText;
-        }, 2000);
-      } catch {
-        target.textContent = "コピー失敗";
-        setTimeout(() => {
-          target.textContent = "コピー";
-        }, 2000);
-      }
+      void copyAndAnimate(target, code);
     };
 
     container.addEventListener("click", handleClick);

--- a/src/lib/anchors.ts
+++ b/src/lib/anchors.ts
@@ -234,6 +234,41 @@ export interface ComputeCoordinatesOptions {
 }
 
 /**
+ * 1 つの (milestone, publishedDate) ペアを評価し、Coordinate に変換する純粋関数。
+ *
+ * 戻り値が undefined の場合は以下のいずれかに該当する:
+ *   - `excludeHeavy: true` で tone === "heavy" の節目だった
+ *   - milestone.date の形式不正 (`toMilestoneCalendarDate` が null を返す)
+ *   - publishedAt より後 (未来) の節目だった
+ *
+ * `computeCoordinates` の本体から条件分岐を引き剥がし、cognitive complexity を
+ * 8 以下に抑えるために抽出 (Issue #652)。
+ */
+const tryBuildCoordinate = (
+  milestone: Milestone,
+  publishedDate: Date,
+  excludeHeavy: boolean,
+): Coordinate | undefined => {
+  if (excludeHeavy && milestone.tone === "heavy") {
+    return undefined;
+  }
+  const milestoneDate = toMilestoneCalendarDate(milestone.date);
+  if (milestoneDate === null) {
+    return undefined;
+  }
+  const days = diffInDays(milestoneDate, publishedDate);
+  if (days < 0) {
+    return undefined;
+  }
+  return {
+    kind: "coordinate",
+    label: milestone.label,
+    tone: milestone.tone,
+    daysSince: days,
+  };
+};
+
+/**
  * 層1=座標: publishedAt と登録節目の差分日数を計算する
  *
  * - publishedAt より後 (未来) の節目は結果から **除外 (filter)** する
@@ -247,6 +282,12 @@ export interface ComputeCoordinatesOptions {
  *   (`toMilestoneCalendarDate` の JSDoc / テスト「Milestone.date 不正値の仕様」参照)
  * - `options.excludeHeavy` が true のとき、tone === "heavy" の節目を結果から
  *   除外する。未指定または false のときは heavy を含めて返す (Issue #532)
+ *
+ * Biome 厳格化耐性メモ (Issue #652 / PR #623 follow-up):
+ * - 本関数は `maxAllowedComplexity:8` 厳格化条件下でも違反 0 になるよう、
+ *   per-milestone の評価を `tryBuildCoordinate` ヘルパーへ抽出している。
+ *   入力順保持 / 未来除外 / 形式不正除外 / excludeHeavy 除外の全仕様は
+ *   既存 `anchors.test.ts` で固定済み。
  *
  * @param publishedAt - 記事の公開日時 (ISO 8601 文字列)
  * @param milestones - 登録された節目の配列
@@ -265,23 +306,10 @@ export const computeCoordinates = (
 
   const coordinates: Coordinate[] = [];
   for (const milestone of milestones) {
-    if (excludeHeavy && milestone.tone === "heavy") {
-      continue;
+    const coordinate = tryBuildCoordinate(milestone, publishedDate, excludeHeavy);
+    if (coordinate !== undefined) {
+      coordinates.push(coordinate);
     }
-    const milestoneDate = toMilestoneCalendarDate(milestone.date);
-    if (milestoneDate === null) {
-      continue;
-    }
-    const days = diffInDays(milestoneDate, publishedDate);
-    if (days < 0) {
-      continue;
-    }
-    coordinates.push({
-      kind: "coordinate",
-      label: milestone.label,
-      tone: milestone.tone,
-      daysSince: days,
-    });
   }
   return coordinates;
 };

--- a/src/lib/resurface.ts
+++ b/src/lib/resurface.ts
@@ -203,6 +203,33 @@ const resolveAndSortPosts = (posts: readonly PostSummary[]): ResolvedPost[] => {
 };
 
 /**
+ * 1 件の候補に対し「today と同月同日」「yearsAgo >= 1」を満たすかを評価し、
+ * 一致時は yearsAgo を、不一致時は null を返す純粋関数。
+ *
+ * `pickSameMonthDay` 本体の cognitive complexity を 8 以下に抑えるために抽出
+ * (Issue #652)。
+ */
+const matchSameMonthDay = (
+  resolved: ResolvedPost,
+  todayDate: Date,
+): number | null => {
+  const postMonth = resolved.publishedDate.getUTCMonth();
+  const postDay = resolved.publishedDate.getUTCDate();
+  if (
+    postMonth !== todayDate.getUTCMonth() ||
+    postDay !== todayDate.getUTCDate()
+  ) {
+    return null;
+  }
+  const yearsAgo =
+    todayDate.getUTCFullYear() - resolved.publishedDate.getUTCFullYear();
+  if (yearsAgo < 1) {
+    return null;
+  }
+  return yearsAgo;
+};
+
+/**
  * 候補リストから「today と同月同日」の最も新しい年の記事を 1 件選ぶ。
  *
  * - 同月同日 = JST 暦上の (月, 日) が today と一致
@@ -210,27 +237,20 @@ const resolveAndSortPosts = (posts: readonly PostSummary[]): ResolvedPost[] => {
  *   最も小さい (= 最も新しい年) を選ぶ
  * - yearsAgo >= 1 のもののみ (今日以前の過去記事)
  *
+ * Biome 厳格化耐性メモ (Issue #652 / PR #623 follow-up):
+ * - 本関数は `maxAllowedComplexity:8` 厳格化条件下でも違反 0 になるよう、
+ *   per-candidate の判定を `matchSameMonthDay` ヘルパーへ抽出している。
+ *
  * @returns {{ resolved, yearsAgo } | null}
  */
 const pickSameMonthDay = (
   candidates: readonly ResolvedPost[],
   todayDate: Date,
 ): { readonly resolved: ResolvedPost; readonly yearsAgo: number } | null => {
-  const todayMonth = todayDate.getUTCMonth();
-  const todayDay = todayDate.getUTCDate();
-  const todayYear = todayDate.getUTCFullYear();
-
   let best: { resolved: ResolvedPost; yearsAgo: number } | null = null;
   for (const r of candidates) {
-    const postMonth = r.publishedDate.getUTCMonth();
-    const postDay = r.publishedDate.getUTCDate();
-    const postYear = r.publishedDate.getUTCFullYear();
-
-    if (postMonth !== todayMonth || postDay !== todayDay) {
-      continue;
-    }
-    const yearsAgo = todayYear - postYear;
-    if (yearsAgo < 1) {
+    const yearsAgo = matchSameMonthDay(r, todayDate);
+    if (yearsAgo === null) {
       continue;
     }
     // 最も新しい年 = yearsAgo が最小
@@ -309,6 +329,96 @@ const pickMilestoneAnniversary = (
 };
 
 /**
+ * 沈黙トリガー発動時の浮上対象を選定する純粋関数。
+ *
+ * - pastCandidates が空のとき null を返す (最新自身は選ばない方針)
+ * - 1 年前の同月同日記事を優先し、無ければ最古記事 (pastCandidates の末尾) を選ぶ
+ *
+ * `selectResurfaced` 本体から沈黙分岐を引き剥がし、cognitive complexity を 8 以下に
+ * 抑えるために抽出 (Issue #652)。
+ */
+const pickSilenceTarget = (
+  pastCandidates: readonly ResolvedPost[],
+  todayDate: Date,
+  lastPostDaysAgo: number,
+): ResurfacedEntry | null => {
+  if (pastCandidates.length === 0) {
+    // 過去候補が無い (= 全候補が excludeIds に含まれている等) 場合、浮上できない。
+    // 最新自身は選ばない方針 (Resurface は「過去の声」のみを差し出すため)。
+    return null;
+  }
+
+  // 沈黙時の選定: 1年前の同月同日 → 最古
+  const yearAgo = pickSameMonthDay(pastCandidates, todayDate);
+  if (yearAgo !== null && yearAgo.yearsAgo === 1) {
+    return {
+      post: yearAgo.resolved.post,
+      reason: {
+        kind: "silence",
+        lastPostDaysAgo,
+        sub: "yearAgo",
+      },
+    };
+  }
+
+  // 1年前候補が無ければ最古記事 (resolved の末尾)
+  const oldest = pastCandidates[pastCandidates.length - 1];
+  return {
+    post: oldest.post,
+    reason: {
+      kind: "silence",
+      lastPostDaysAgo,
+      sub: "oldest",
+    },
+  };
+};
+
+/**
+ * 沈黙トリガーが発動しない場合の浮上対象を選定する純粋関数。
+ *
+ * 優先順位:
+ *   (1) 暦の節目 (今日と同月同日の過去記事)
+ *   (2) 節目記念日 (節目からちょうど N 年経過した日の記事)
+ *   (3) どれも該当しない → null
+ *
+ * `selectResurfaced` 本体から非沈黙時の分岐を引き剥がし、cognitive complexity を
+ * 8 以下に抑えるために抽出 (Issue #652)。
+ */
+const pickNonSilenceTarget = (
+  pastCandidates: readonly ResolvedPost[],
+  milestones: readonly Milestone[],
+  todayDate: Date,
+): ResurfacedEntry | null => {
+  // (2) 暦の節目: 今日と同月同日の過去記事
+  const calendarHit = pickSameMonthDay(pastCandidates, todayDate);
+  if (calendarHit !== null) {
+    return {
+      post: calendarHit.resolved.post,
+      reason: {
+        kind: "calendar",
+        yearsAgo: calendarHit.yearsAgo,
+      },
+    };
+  }
+
+  // (3) 節目記念日 (節目からちょうど N 年経過した日に書かれた記事)
+  const milestoneHit = pickMilestoneAnniversary(pastCandidates, milestones);
+  if (milestoneHit !== null) {
+    return {
+      post: milestoneHit.resolved.post,
+      reason: {
+        kind: "milestoneAnniversary",
+        label: milestoneHit.label,
+        yearsSinceMilestone: milestoneHit.yearsSinceMilestone,
+      },
+    };
+  }
+
+  // (4) どれも該当しない
+  return null;
+};
+
+/**
  * Resurface の浮上対象を選定する純粋関数。
  *
  * 優先順位:
@@ -317,6 +427,13 @@ const pickMilestoneAnniversary = (
  *   (2) 暦の節目 (今日と同月同日の過去記事)
  *   (3) 座標上の意味 (節目記念日 = 節目からちょうど N 年経過した日の記事)
  *   (4) どれも該当しない → null
+ *
+ * Biome 厳格化耐性メモ (Issue #652 / PR #623 follow-up):
+ * - 本関数は `maxAllowedComplexity:8` 厳格化条件下でも違反 0 になるよう、
+ *   沈黙分岐を `pickSilenceTarget` / 非沈黙分岐を `pickNonSilenceTarget` の
+ *   2 ヘルパーへ抽出している。本体は `(1) 候補集合の構築` → `(2) 沈黙判定で分岐
+ *   委譲` の 2 ステップで完結する構造になる。優先順位 (1)-(4) の仕様は既存
+ *   `resurface.test.ts` で固定済み。
  *
  * @param posts - 全記事の PostSummary 配列 (順序不問、内部で publishedAt 解決順に並び替える)
  * @param milestones - 登録された節目の配列 (空配列許可)
@@ -358,67 +475,11 @@ export const selectResurfaced = (
     .slice(1)
     .filter((r) => !excludeIdSet.has(r.post.id));
 
-  // (1) 沈黙トリガー判定
   const lastPostDaysAgo = diffInDays(newest.publishedDate, todayDate);
   const isSilence = lastPostDaysAgo >= threshold;
 
   if (isSilence) {
-    if (pastCandidates.length === 0) {
-      // 過去候補が無い (= 全候補が excludeIds に含まれている等) 場合、浮上できない。
-      // 最新自身は選ばない方針 (Resurface は「過去の声」のみを差し出すため)。
-      return null;
-    }
-
-    // 沈黙時の選定: 1年前の同月同日 → 最古
-    const yearAgo = pickSameMonthDay(pastCandidates, todayDate);
-    if (yearAgo !== null && yearAgo.yearsAgo === 1) {
-      return {
-        post: yearAgo.resolved.post,
-        reason: {
-          kind: "silence",
-          lastPostDaysAgo,
-          sub: "yearAgo",
-        },
-      };
-    }
-
-    // 1年前候補が無ければ最古記事 (resolved の末尾)
-    const oldest = pastCandidates[pastCandidates.length - 1];
-    return {
-      post: oldest.post,
-      reason: {
-        kind: "silence",
-        lastPostDaysAgo,
-        sub: "oldest",
-      },
-    };
+    return pickSilenceTarget(pastCandidates, todayDate, lastPostDaysAgo);
   }
-
-  // (2) 暦の節目: 今日と同月同日の過去記事 (沈黙でないとき)
-  const calendarHit = pickSameMonthDay(pastCandidates, todayDate);
-  if (calendarHit !== null) {
-    return {
-      post: calendarHit.resolved.post,
-      reason: {
-        kind: "calendar",
-        yearsAgo: calendarHit.yearsAgo,
-      },
-    };
-  }
-
-  // (3) 節目記念日 (節目からちょうど N 年経過した日に書かれた記事)
-  const milestoneHit = pickMilestoneAnniversary(pastCandidates, milestones);
-  if (milestoneHit !== null) {
-    return {
-      post: milestoneHit.resolved.post,
-      reason: {
-        kind: "milestoneAnniversary",
-        label: milestoneHit.label,
-        yearsSinceMilestone: milestoneHit.yearsSinceMilestone,
-      },
-    };
-  }
-
-  // (4) どれも該当しない
-  return null;
+  return pickNonSilenceTarget(pastCandidates, milestones, todayDate);
 };


### PR DESCRIPTION
## 概要

Issue #652 (PR #623 follow-up) への対応。`maxAllowedComplexity:8` 厳格化条件下で違反する 8 関数 7 ファイルのうち、PR #731 と競合しない **5 ファイル / 6 関数** を本 PR で解消する。

refs #652

## 変更内容

### 対象関数の cognitive complexity 推移

| ファイル / 関数 | 旧 | 新 |
| --- | --- | --- |
| `src/api/images.ts:createImagesMiddleware` | 12 | 8 以下 |
| `src/api/posts.ts:createPostsMiddleware` | 15 | 8 以下 |
| `src/hooks/useCodeBlockCopy.ts:handleClick` | 9 | 8 以下 |
| `src/lib/anchors.ts:computeCoordinates` | 9 | 8 以下 |
| `src/lib/resurface.ts:pickSameMonthDay` | 9 | 8 以下 |
| `src/lib/resurface.ts:selectResurfaced` | 12 | 8 以下 |

旧 / 新 の確認方法: `biome.jsonc` の `noExcessiveCognitiveComplexity` を `{ "level": "error", "options": { "maxAllowedComplexity": 8 } }` に差し替えて `pnpm exec biome lint` を実行 (PR #623 と同じ再現手順)。

### コミット別の対応内容

- `7c5c114` **`src/api/images.ts`**: ミドルウェアを `resolveImageRequest` (リクエスト解析) + `serveImageFile` (ファイル配信) の 2 ヘルパーに分割
- `37073b2` **`src/api/posts.ts`**: ミドルウェアを `servePostDetail` (個別投稿配信) + `servePostList` (一覧配信) の 2 ヘルパーに分割
- `466b5b7` **`src/hooks/useCodeBlockCopy.ts`**: `handleClick` 内のコピー成否分岐を `copyAndAnimate` / `flashButtonLabel` の 2 ヘルパーへ抽出 + 表示文言を定数化
- `73ff277` **`src/lib/anchors.ts`**: `computeCoordinates` のループ内 per-milestone 判定を `tryBuildCoordinate` ヘルパーへ抽出
- `fba0f83` **`src/lib/resurface.ts`**: `pickSameMonthDay` の per-candidate 判定を `matchSameMonthDay` に / `selectResurfaced` を沈黙時 (`pickSilenceTarget`) と非沈黙時 (`pickNonSilenceTarget`) に分割

### Biome 厳格化耐性 JSDoc 追記

全 5 ファイルの該当箇所 JSDoc に「Issue #652 で `maxAllowedComplexity:8` 厳格化条件下でも違反 0」「再現手順 (biome.jsonc 編集 → biome lint → test:run)」「公開 API シグネチャ不変」を明記。

## 本 PR スコープ外

### `scripts/lintTokens.ts:398` (Issue #652 リスト残り 1 ファイル)

- PR #731 (`chore: walkDirectory を public 入口 / internal 再帰の 2 関数に分割`) が同ファイルを大幅修正中のため、本 PR では除外
- #731 merge 後に別ブランチで follow-up PR を作成し、Issue #652 を `Closes #652` でクローズする予定
- 本 PR は `refs #652` で参照のみ (Issue は open のまま)

### `scripts/newPost.ts:351` (Issue 起票時点で違反)

- Issue 起票時点では cognitive complexity 違反として列挙されていたが、PR #683 (`refactor: scripts/ 配下の null → undefined 揃え`) で `loadMilestones` (line 349-) が `parseMilestones` に委譲する形へ簡素化された結果、現時点では `maxAllowedComplexity:8` でも違反 0 を満たすことを実機確認 (`pnpm exec biome lint scripts/newPost.ts` で診断ゼロ)
- 本 PR では現状の `scripts/newPost.ts` を変更しない

## ローカル実機検証

- `pnpm lint`: 127 files pass
- `pnpm type-check` / `pnpm type-check:test` / `pnpm type-check:scripts` / `pnpm type-check:api`: 全 pass
- `pnpm test:run`: 56 files / 1051 tests pass
- `pnpm build`: panda + tsc + vite build pass
- `maxAllowedComplexity:8` 厳格化条件下でも対象 5 ファイル 6 関数の違反 0 (実機確認済み)

## 備考

- 公開 API シグネチャ (`createImagesMiddleware` / `createPostsMiddleware` / `useCodeBlockCopy` / `computeCoordinates` / `selectResurfaced`) は不変。呼び出し側の変更は発生しない
- 抽出したヘルパーはすべて module-private (`export` していない)。`calculateContrast.ts` の場合と異なり、本 PR では新規テスト追加を行わない (既存テストで振る舞いを十分固定済みのため)。将来追加が必要になった時点で個別 issue で対応する
- 振る舞い保証: 既存 1051 件のテストが全 pass しており、特に以下のテスト群が今回の refactor の意味的等価性を担保している
  - `src/api/__tests__/posts.test.ts` (個別投稿 / 一覧 / 403 / 404 / 500)
  - `src/hooks/__tests__/useCodeBlockCopy.test.ts` (クリック / 成功 / 失敗 / 他要素クリック)
  - `src/lib/__tests__/anchors.test.ts` (入力順保持 / 未来除外 / excludeHeavy / 形式不正除外)
  - `src/lib/__tests__/resurface.test.ts` (沈黙 / 暦の節目 / 節目記念日 / 4 優先順位)