### PR TITLE
chore: tsc cache hashFiles glob 拡張 + tsconfig.test.json コメント修正 (Closes #642)

### DIFF
--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -18,8 +18,8 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     // Incremental build (Issue #580): tsconfig.json と独立した .tsbuildinfo を出力。
-    // 本体と test で include は同じだが、設定差分により別ビルド状態を持つため
-    // ファイルを分離する。
+    // include は本体を継承する (extends: "./tsconfig.json" により本体の include がそのまま
+    // 適用される) が、設定差分により別ビルド状態を持つためファイルを分離する。
     "tsBuildInfoFile": "./.tsbuildinfo/tsconfig.test.tsbuildinfo"
   },
   // 本体 tsconfig が src/api/** を exclude しているのを、テスト側では取り消す


### PR DESCRIPTION
## 概要

Issue #642 の残部 (M1 + N2) を対応する。N-3 (`restoreKeys` 第 2 段) は PR #731 (master `8a2b4af` を含む squash merge) で実質解決済みのため、本 PR で Issue #642 は全 AC 達成となり完全クローズする。

## 変更内容

- **M1 (差分なし、確認のみ)**: `.github/workflows/ci.yml` / `.github/workflows/deploy.yml` の tsc cache hashFiles glob 整合性を実機確認。`tsc-scripts` cache step の hashFiles はいずれも `'scripts/**/*.ts', 'scripts/**/*.tsx'` を含んでおり、将来 `scripts/` 配下に `.tsx` が追加された場合でもキャッシュキーへ反映される構成になっている。`tsc-main` / `tsc-test` / `tsc-api` も `.ts` / `.tsx` の両方を hashFiles に含んでおり整合性 OK。よって M1 は現状で AC 達成、差分は不要と判定。
- **N2**: `tsconfig.test.json` 行 21-22 のコメントを「本体と test で include は同じだが」から「include は本体を継承する (`extends: \"./tsconfig.json\"` により本体の include がそのまま適用される) が」に書き換え。TypeScript の `extends` 仕様 (`include`/`exclude`/`files` が継承される) を正確に表現し、本体 tsconfig の include 変更が test 側に自動追従する事実をコメントから読み取れるようにする。

### Issue #642 全 AC 達成状況

- **N-3**: PR #731 で `walkDirectory` を public 入口 / internal 再帰に分割した際に `restoreKeys` 第 2 段の意図と整合 (実質解決済み)
- **M1**: 本 PR で glob 整合性を確認、現状の `scripts/**/*.{ts,tsx}` 両対応で AC 達成
- **N2**: 本 PR でコメントを `extends` 継承表現に修正

## 備考

- yaml ファイルへの変更は無いため CI workflow の挙動への影響は無い (M1 は確認のみ)
- N2 はコメント変更のみで TypeScript 設定の挙動には影響しない
- ローカル全検証 pass: `pnpm lint` / `pnpm type-check` / `pnpm type-check:test` / `pnpm type-check:scripts` / `pnpm type-check:api` / `pnpm test:run` (1053 tests passed) / `pnpm build`

Closes #642