### PR TITLE
chore: tsc cache main key に !src/**/__tests__/** negation を追加 (Closes #729)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .tsbuildinfo/tsconfig.tsbuildinfo
-          key: tsc-main-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', '!src/**/*.test.ts', '!src/**/*.test.tsx', '!src/**/*.spec.ts', '!src/**/*.spec.tsx', '!src/api/**') }}
+          key: tsc-main-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', '!src/**/*.test.ts', '!src/**/*.test.tsx', '!src/**/*.spec.ts', '!src/**/*.spec.tsx', '!src/api/**', '!src/**/__tests__/**') }}
 
       # test 側 cache: tsconfig.test.json は tsconfig.json を継承するため、本体ソースの変更でも
       # invalidate する必要がある (本体 + テストファイル両方を hash 対象に含める)。
@@ -88,7 +88,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .tsbuildinfo/tsconfig.api.tsbuildinfo
-          key: tsc-api-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.api.json') }}-${{ hashFiles('src/api/**/*.ts', 'src/api/**/*.tsx', 'src/lib/**/*.ts', 'src/lib/**/*.tsx', '!src/**/*.test.ts', '!src/**/*.test.tsx', '!src/**/*.spec.ts', '!src/**/*.spec.tsx') }}
+          key: tsc-api-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.api.json') }}-${{ hashFiles('src/api/**/*.ts', 'src/api/**/*.tsx', 'src/lib/**/*.ts', 'src/lib/**/*.tsx', '!src/**/*.test.ts', '!src/**/*.test.tsx', '!src/**/*.spec.ts', '!src/**/*.spec.tsx', '!src/**/__tests__/**') }}
 
       - name: Type check
         run: pnpm type-check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .tsbuildinfo/tsconfig.tsbuildinfo
-          key: tsc-main-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', '!src/**/*.test.ts', '!src/**/*.test.tsx', '!src/**/*.spec.ts', '!src/**/*.spec.tsx', '!src/api/**') }}
+          key: tsc-main-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', '!src/**/*.test.ts', '!src/**/*.test.tsx', '!src/**/*.spec.ts', '!src/**/*.spec.tsx', '!src/api/**', '!src/**/__tests__/**') }}
 
       # test 側 cache: tsconfig.test.json は tsconfig.json を継承するため、本体ソースの変更でも
       # invalidate する必要がある (本体 + テストファイル両方を hash 対象に含める)。
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .tsbuildinfo/tsconfig.api.tsbuildinfo
-          key: tsc-api-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.api.json') }}-${{ hashFiles('src/api/**/*.ts', 'src/api/**/*.tsx', 'src/lib/**/*.ts', 'src/lib/**/*.tsx', '!src/**/*.test.ts', '!src/**/*.test.tsx', '!src/**/*.spec.ts', '!src/**/*.spec.tsx') }}
+          key: tsc-api-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json', 'tsconfig.api.json') }}-${{ hashFiles('src/api/**/*.ts', 'src/api/**/*.tsx', 'src/lib/**/*.ts', 'src/lib/**/*.tsx', '!src/**/*.test.ts', '!src/**/*.test.tsx', '!src/**/*.spec.ts', '!src/**/*.spec.tsx', '!src/**/__tests__/**') }}
 
       - name: Build project
         run: pnpm run build


### PR DESCRIPTION
## 概要

`tsconfig.json` の `exclude` には `src/**/__tests__/**` が含まれているが、`.github/workflows/ci.yml` / `.github/workflows/deploy.yml` の tsc-main / tsc-api cache key の `hashFiles` negation には反映されていなかった。

このため、`src/**/__tests__/**` 配下にあるテスト本体ではない helper / fixture ファイル等を変更した際に、tsc cache の key が変動して cache が不要に invalidate される問題があった。本 PR では tsconfig.json の `exclude` と整合させるため、tsc cache key の `hashFiles` negation 末尾に `!src/**/__tests__/**` を追加する。

Closes #729

## 変更内容

- `.github/workflows/ci.yml`: `tsc-main` / `tsc-api` cache key の `hashFiles` negation 末尾に `'!src/**/__tests__/**'` を追加し、`tsconfig.json` の `exclude` と整合させる
- `.github/workflows/deploy.yml`: `ci.yml` と同期して同じ negation を `tsc-main` / `tsc-api` の `hashFiles` に追加 (drift 禁止)

## 備考

- `tsc-test` 側は tsconfig.test.json でテストファイルを意図的に hash 対象に含めるため negation 不要。
- `tsc-scripts` 側は `scripts/**` のみを対象とし `src/**/__tests__/**` とは無関係なため変更不要。
- 既存 negation `!src/**/*.test.ts` 等はファイル名 pattern、追加した `!src/**/__tests__/**` はディレクトリ配下を対象とする補完関係。`__tests__` 配下の非 test fixture / helper を捕捉する目的で追加した。
- ローカル検証 (`pnpm lint` / `pnpm type-check` / `pnpm type-check:test` / `pnpm type-check:scripts` / `pnpm type-check:api` / `pnpm test:run` / `pnpm build`) 全て pass、`actionlint` でも syntax OK を確認済み。