### PR TITLE
chore: panda-hash-regression workflow 失敗時に Issue 自動起票を追加 (Closes #733)

### DIFF
--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -57,8 +57,12 @@ on:
       - "postcss.config.*"
 
 # 本 workflow は repo を読むだけで write は不要。明示的に最小権限へ縛る。
+# Issue #733: 失敗時に Issue を自動起票するため、`issues: write` を追加する。
+# 起票は最終 step (`Open or update issue on failure`) でのみ使用し、それ以前の
+# build / test step は read 権限しか触らない。
 permissions:
   contents: read
+  issues: write
 
 jobs:
   hash-regression:
@@ -601,3 +605,116 @@ jobs:
               echo "_(baseline produced only one kind; missing = n/a)_";
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open or update issue on failure
+        # Issue #733: 失敗時に能動的な通知経路として Issue を自動起票する。
+        # 検討選択肢 (a) Slack 通知 / (b) メール通知 / (c) Issue 自動起票 /
+        # (d) 現状維持 のうち、(c) Issue 自動起票 を採用する。判断根拠:
+        #   - (a) Slack: webhook secret の管理コストが増える (workspace /
+        #     webhook URL を新規導入する必要があり、外部依存追加最小化の
+        #     方針 (memory feedback_no_new_libraries) と整合しない)
+        #   - (b) メール: GitHub Actions の標準通知 (commit author email へ
+        #     workflow 失敗時に自動送付) で既に同等のメール経路は確保済み。
+        #     workflow 側で追加実装する意味が薄い (= 実質 (d) と等価)
+        #   - (c) Issue: リポジトリ内で履歴管理でき、`gh` CLI を使えば外部
+        #     依存追加なしで実装可能。dedup は「title 一意性 + open issue
+        #     検索」で十分担保できる
+        #
+        # 起票内容には workflow run URL / event 名 / 失敗 step の特定情報を
+        # 含める。dedup 戦略は以下:
+        #   1. `gh issue list --search` で同名タイトルの open issue を検索
+        #   2. ヒットしなければ `gh issue create` で新規起票
+        #   3. ヒットすれば最古の open issue (= 元起票) にコメント追記
+        #
+        # job 全体の失敗 (test 失敗 / build 失敗 / sed 失敗 / setup 失敗 等)
+        # を網羅するため `if: failure()` で発火させる。job が成功 (= test /
+        # build 共に pass) の場合はスキップする。
+        #
+        # 重複検索の race condition について:
+        #   - cron (月 1) と PR trigger は並走可能だが、同名タイトル検索 +
+        #     `gh issue create` は GitHub API の即時整合性により多くの場合
+        #     1 起票に収束する。万一 2 起票になった場合は手動で片方を close
+        #     する運用とし、自動 close 機構は導入しない (実装複雑化に対する
+        #     メリットが小さい)
+        if: failure()
+        env:
+          # GitHub CLI 認証用。`permissions: issues: write` と組み合わせて
+          # GITHUB_TOKEN で issue 操作を行う。
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: >-
+            ${{ github.server_url }}/${{ github.repository
+            }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # 起票時刻は ISO 8601 (UTC) で残す。GitHub Actions runner はデフォ
+          # ルト UTC なので date -u で揃える。
+          run_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          # title は dedup のキーになるため、固定文字列で揃える。run id 等の
+          # 可変情報を入れると別 issue 扱いになり dedup が効かなくなる。
+          issue_title="panda-hash-regression workflow が失敗しました"
+          # body はコメント / 新規起票で共通利用する。heredoc は本文を
+          # `printf` で組み立てる方式に揃える: shell script の indent と
+          # heredoc 本文の indent を独立させたい一方、`<<-EOF` だと leading
+          # tab しか剥がせず markdown 内の半角スペース indent が崩れる。
+          # printf + 個別 echo の方が markdown 制御を維持しやすい。
+          body_file=$(mktemp)
+          {
+            echo "## panda-hash-regression workflow 失敗の通知"
+            echo ""
+            echo "\`.github/workflows/panda-hash-regression.yml\` が失敗しました。"
+            echo ""
+            echo "- **Run URL**: ${RUN_URL}"
+            echo "- **Event**: \`${EVENT_NAME}\`"
+            echo "- **Commit SHA**: \`${RUN_SHA}\`"
+            echo "- **Run time (UTC)**: ${run_time}"
+            echo ""
+            echo "## 確認手順"
+            echo ""
+            echo "1. Run URL を開き、失敗 step のログを確認する"
+            echo "   - \`Enable Panda hash:true\` 失敗: \`panda.config.ts\` の"
+            echo "     preflight 行書式が drift している可能性"
+            echo "   - \`Run tests with hash:true\` 失敗: Tripwire テストの"
+            echo "     hash 耐性に regression がある (\`data-*\` 属性が hash 化"
+            echo "     に追従できていない)"
+            echo "   - \`Build project with hash:true\` 失敗: Panda 生成物または"
+            echo "     hook class との整合に regression がある"
+            echo "2. 詳細は Issue #496 / Issue #475 / CLAUDE.md の"
+            echo "   \"Panda hash:true の運用判断\" を参照する"
+            echo "3. 修正 PR を出すか、原因 issue を別途切る"
+            echo ""
+            echo "## 自動起票について"
+            echo ""
+            echo "- 本 Issue は \`panda-hash-regression\` workflow 失敗時に"
+            echo "  自動起票されたものです (Issue #733 の実装)。"
+            echo "- 同名タイトルの open issue が既に存在する場合はコメントが"
+            echo "  追記され、新規起票はされません。"
+            echo "- 解決後はこの Issue を手動で close してください。次回失敗時に"
+            echo "  また自動起票されます。"
+          } > "${body_file}"
+
+          # 既存 open issue を検索。`--search` は GitHub の検索構文を使う
+          # ため、タイトル完全一致は `in:title` + ダブルクォートで囲む。
+          # `--json number,title` で取得し、jq でタイトル完全一致のみを
+          # フィルタする (検索構文は部分一致もヒットさせるため、二重フィル
+          # ターで dedup を担保する)。
+          existing_number=$(
+            gh issue list \
+              --state open \
+              --search "in:title \"${issue_title}\"" \
+              --json number,title \
+              --jq ".[] | select(.title == \"${issue_title}\") | .number" \
+              | head -n 1
+          )
+
+          if [ -n "${existing_number}" ]; then
+            echo "既存 open issue #${existing_number} にコメントを追記します"
+            gh issue comment "${existing_number}" --body-file "${body_file}"
+          else
+            echo "既存 open issue が見つからないため新規起票します"
+            gh issue create \
+              --title "${issue_title}" \
+              --body-file "${body_file}" \
+              --label "ci,chore"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ Tripwire テスト用に吐く data-* 属性の命名は以下を指針とする
   - **自動実行トリガー（Issue #526）**: 上記 manual 実行に加え、以下 2 系統が自動実行する:
     - **schedule (月初 00:00 UTC = `'0 0 1 * *'`)**: 月 1 回の定期検証で「機能が腐る」リスクを軽減
     - **pull_request paths**: `panda.config.ts` / `package.json` / `pnpm-lock.yaml` 変更 PR で即時検知。dependabot の `@pandacss/dev` 更新 PR は `pnpm-lock.yaml` 変更を含むため自動捕捉される
-    - CI billing への影響は「月 1 + 該当 PR」程度で許容範囲。失敗時の通知は GitHub Actions 標準通知 (commit author email / fail badge) で当面足りる。Slack / メール / Issue 自動起票は別 follow-up Issue で扱う
+    - CI billing への影響は「月 1 + 該当 PR」程度で許容範囲。失敗時の通知は GitHub Actions 標準通知 (commit author email / fail badge) に加え、**Issue 自動起票 (Issue #733)** を併用する: workflow 失敗時に最終 step (`Open or update issue on failure`, `if: failure()`) が `gh issue list` で同名タイトルの open issue を検索し、無ければ `gh issue create` で新規起票、有ればコメント追記する dedup 戦略で、外部依存追加なしに能動的な通知経路を確保する。Slack (webhook secret 管理コスト増) は採用しない
 - **`build:ci` script と workflow の整合性メモ（Issue #528）**: hash:true build step は `package.json` の `build:ci` (= `panda && tsc && vite build`, test/lint/type-check:scripts を含まない軽量版) を呼ぶ。`build` script (本番経路) のコマンド列 (`panda && tsc && vite build` 部分) を変更する場合は `build:ci` も同期させること。**同期の有無は `scripts/checkBuildCiSync.ts` で自動検出される（Issue #685、`.github/workflows/ci.yml` の lint-and-typecheck job で実行）** ので、散文ルールが形骸化しても CI が drift を検知して fail する
   - baseline (hash:false) build step は bundle size 計測専用で tsc を意図的に省く運用 (Issue #625 DA #2) のため `build:ci` ではなく `pnpm exec panda && pnpm exec vite build` を直接呼ぶ非対称運用とする
 


### PR DESCRIPTION
## 概要

`.github/workflows/panda-hash-regression.yml` の失敗時通知 (Issue #526 で follow-up に出した項目) を実装する。検討選択肢 (a) Slack / (b) メール / (c) Issue 自動起票 / (d) 現状維持 のうち **(c) Issue 自動起票** を採用し、外部依存追加なしに能動的な通知経路を確保する。

Closes #733

## 変更内容

- `.github/workflows/panda-hash-regression.yml`:
  - `permissions:` に `issues: write` を追加 (最終 step でのみ使用)
  - job 末尾に `if: failure()` の `Open or update issue on failure` step を追加
  - `gh issue list --search "in:title \"...\""` + `jq` でタイトル完全一致の open issue を検索
  - 既存 open issue が無ければ `gh issue create` で新規起票 (label: `ci,chore`)
  - 既存 open issue があればコメント追記
  - Issue 本文には Run URL / event 名 / commit SHA / 失敗時刻 (UTC) / 確認手順を含める
- `CLAUDE.md`: 失敗時通知の散文を「GitHub Actions 標準通知 + Issue 自動起票」併用方式に更新

## 採用根拠

- **(a) Slack 不採用**: Slack workspace / webhook URL を新規導入する必要があり、webhook secret 管理コストが増える。外部依存追加最小化方針と整合しない
- **(b) メール不採用**: GitHub Actions の標準通知 (commit author email へ workflow 失敗時に自動送付) で既に同等のメール経路は確保済み。workflow 側で追加実装する意味が薄い
- **(c) Issue 自動起票 採用**: リポジトリ内で履歴管理でき、`gh` CLI を使えば外部依存追加なしで実装可能。dedup は title 一意性 + open issue 検索で担保
- **(d) 現状維持 不採用**: cron (月 1) 実行は Actions タブを能動的に開かない限り見落としやすい。能動的な通知経路を整備する価値はある

## dedup 戦略

1. `gh issue list --state open --search "in:title \"panda-hash-regression workflow が失敗しました\"" --json number,title --jq '.[] | select(.title == "...") | .number' | head -n 1` で既存 open issue を検索 (`--search` は部分一致もヒットするため jq でタイトル完全一致のみ抽出)
2. ヒット 0 件 → `gh issue create` で新規起票
3. ヒット 1 件以上 → 最古の open issue (= 元起票) に `gh issue comment` で追記
4. 解決後はユーザーが手動 close する運用とし、自動 close は導入しない

### race condition について

cron (月初 UTC 00:00) と PR trigger が並走する可能性は極小だが、もし同タイミングで複数 run が失敗した場合、`gh issue list` の即時整合性は GitHub API の indexing 遅延に依存する。最悪 2 起票になる可能性は残るが、その場合は手動で片方を close する運用とする (実装複雑化に対するメリットが小さいため自動 dedup-after-create は導入しない)。

## 手動検証手順 (merge 後)

実機検証は merge 後にユーザー側で行ってください。検証 pattern:

1. **意図的に失敗させて起票が走るか確認**:
   - `chore/test-panda-hash-issue-on-failure` 等の捨てブランチを切り、`panda.config.ts` の `preflight: true` 行を `preflight: false` 等に書き換える (sed パッチが効かなくなる)
   - workflow_dispatch から該当ブランチで手動実行する (PR を出して trigger させる方法でも可。`panda.config.ts` を変更しているため pull_request paths にも引っかかる)
   - workflow が失敗し、`Open or update issue on failure` step で新規 Issue が起票されることを確認
2. **dedup の確認**:
   - 上記で起票された Issue を open のまま、同じ捨てブランチで workflow を再実行する
   - 新規起票はされず、既存 Issue にコメントが追記されることを確認
3. **後片付け**:
   - 起票された Issue を手動 close
   - 捨てブランチを削除

> なお、本 PR (`chore/panda-hash-regression-issue-on-failure`) は CI 緑経路を通るため、自動起票 step は失敗時にしか実行されず、本 PR の CI 上では起票はトリガーされません (起票 step 自体の YAML / bash 構文は構造検証済み)。

## 備考

- 既存ラベル `ci` / `chore` は repo に存在することを確認済み
- `GITHUB_TOKEN` で `issues: write` 権限は十分。新規 PAT は不要
- yaml 構文 / bash 構文を node + bash -n で構造検証済み