### PR TITLE
chore: ci.yml に type-check:api step を追加して tsc-api cache 片肺運用を解消 (Closes #730)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,11 @@ jobs:
 
       - name: Type check (scripts) (Issue #634)
         run: pnpm type-check:scripts
+
+      # Issue #730: PR #640 で `tsc-api-*` cache step を ci.yml にも追加したが、ci.yml では
+      # `type-check:api` を実行する step が無く、cache が read/write されない「片肺運用」に
+      # なっていた。`type-check:api` step を追加することで以下を解消する:
+      #   - api 型エラーを PR 段階で検知できる (従来は master push 時の deploy.yml まで未検知)
+      #   - tsc-api cache を ci.yml ↔ deploy.yml の双方向で活用できる (cache key 整合性の回復)
+      - name: Type check (api) (Issue #730)
+        run: pnpm type-check:api


### PR DESCRIPTION
## 概要

PR #640 follow-up (Issue #730)。`tsc-api-*` cache step は `.github/workflows/ci.yml` と `.github/workflows/deploy.yml` の両方に存在するが、ci.yml では `type-check:api` を実行する step が無いため cache が read/write されず、実質的に deploy.yml だけが活用している「片肺運用」になっていた。

Issue で挙げられた選択肢のうち **(a) ci.yml に `type-check:api` step を追加** を採用する。理由:

- **api 型エラーを PR 段階で検知できる**: 従来は ci.yml に `type-check:api` step が無く、`pnpm run build` 経由で型チェックが走る deploy.yml (master push 時) まで api 側の型エラーが検知できなかった。PR 段階で fail させることで master を壊さずに済む
- **tsc-api cache を双方向で活用できる**: ci.yml ↔ deploy.yml の cache key 戦略の整合性が回復し、ci.yml で warm にした `.tsbuildinfo/tsconfig.api.tsbuildinfo` を deploy.yml 側が再利用できる (逆方向も同様)
- (b) は ci 時間を抑えられるが、api 型エラーの早期検知という価値を失う点で劣ると判断

## 変更内容

- `.github/workflows/ci.yml`: lint-and-typecheck job の `Type check (scripts)` 直後に `Type check (api)` step を追加。step 命名は既存 `Type check (test)` / `Type check (scripts) (Issue #634)` のスタイルに合わせ、追加理由を comment で残した

## 備考

- ローカル全検証 (`pnpm lint` / `pnpm type-check` / `pnpm type-check:test` / `pnpm type-check:scripts` / `pnpm type-check:api` / `pnpm test:run` / `pnpm build`) すべて pass
- `actionlint .github/workflows/ci.yml` 通過 (YAML / GitHub Actions 構文 OK)
- `pnpm type-check:api` script は `package.json` に既存 (`build` script でも使用中) のため、本変更で前提が壊れることはない
- deploy.yml 側は `pnpm run build` 経由で `type-check:api` を実行しているため変更不要

Closes #730