### PR TITLE
refactor: markdown.ts の HTML エスケープ重複を統合

### DIFF
--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { escapeHtmlAttr, parseMarkdown } from "../markdown";
+import { escapeHtmlAttr, escapeHtmlText, parseMarkdown } from "../markdown";
 
 // 極長入力境界値テストで使用するバイト数。1MB 程度の入力で escapeHtmlAttr が
 // throw せず、長さ・末尾エスケープが保たれることを確認する用途。
@@ -440,6 +440,34 @@ const x = 1;
     it("複数の特殊文字を同時にエスケープできる", () => {
       expect(escapeHtmlAttr("<img src=\"x\" onload='alert(1)'>&")).toBe(
         "&lt;img src=&quot;x&quot; onload=&#39;alert(1)&#39;&gt;&amp;",
+      );
+    });
+  });
+
+  describe("escapeHtmlText", () => {
+    it("&をエスケープできる", () => {
+      expect(escapeHtmlText("a&b")).toBe("a&amp;b");
+    });
+
+    it("<と>をエスケープできる", () => {
+      expect(escapeHtmlText("<script>")).toBe("&lt;script&gt;");
+    });
+
+    it("ダブルクォートはエスケープせず同一文字列で返す", () => {
+      expect(escapeHtmlText('"hello"')).toBe('"hello"');
+    });
+
+    it("シングルクォートはエスケープせず同一文字列で返す", () => {
+      expect(escapeHtmlText("it's")).toBe("it's");
+    });
+
+    it("特殊文字を含まない文字列はそのまま返す", () => {
+      expect(escapeHtmlText("hello world")).toBe("hello world");
+    });
+
+    it("テキストコンテキスト対象の3文字のみエスケープしクォートは保持する", () => {
+      expect(escapeHtmlText("<a href=\"x\" data-y='z'>&")).toBe(
+        "&lt;a href=\"x\" data-y='z'&gt;&amp;",
       );
     });
   });

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -56,6 +56,23 @@ export const escapeHtmlAttr = (str: string): string => {
 };
 
 /**
+ * HTML のテキストコンテンツに埋め込む文字列をエスケープする
+ *
+ * 属性値ではないテキストノード（pre/code の表示内容など）向けに、
+ * `& < >` の 3 文字のみをエスケープする。`"` / `'` は属性区切り文字を
+ * 兼ねないテキストコンテキストでは無害なため意図的に対象外とする
+ * （属性値に埋め込む場合は escapeHtmlAttr を使うこと）。
+ * @param str エスケープ対象の文字列
+ * @returns エスケープ済み文字列
+ */
+export const escapeHtmlText = (str: string): string => {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+};
+
+/**
  * parseMarkdown 呼び出しごとに専用の Marked インスタンスを生成する。
  *
  * tocItems は parseMarkdown のローカル配列をクロージャ経由で renderer に共有させる。
@@ -83,16 +100,8 @@ const createMarkedInstance = (tocItems: TocItem[]): Marked => {
     code({ text, lang }) {
       const safeLang = lang ? lang.replace(/[^a-zA-Z0-9-]/g, "") : "";
       const langClass = safeLang ? ` class="language-${safeLang}"` : "";
-      const escapedForAttr = text
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#39;");
-      const escapedForDisplay = text
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;");
+      const escapedForAttr = escapeHtmlAttr(text);
+      const escapedForDisplay = escapeHtmlText(text);
       return `<div class="code-block-wrapper"><button type="button" class="copy-btn" data-code="${escapedForAttr}">コピー</button><pre><code${langClass}>${escapedForDisplay}</code></pre></div>`;
     },
   };


### PR DESCRIPTION
## 概要

`src/lib/markdown.ts` に散在していた HTML エスケープロジックの重複を統合し、エスケープ規則を単一ソース化するリファクタリング。Issue #745 の対応。

## 変更内容

- `src/lib/markdown.ts`: `code()` レンダラ内の手書き 5 文字インラインエスケープ (`escapedForAttr`) を既存の `escapeHtmlAttr(text)` 呼び出しへ置換し、属性コンテキスト用エスケープを単一ソース化。テキストコンテキスト用の 3 文字版 (`&` `<` `>`) は `escapeHtmlText` として export 抽出・命名し、用途の意図を明示。属性ブレイクアウト防御 (`'` → `&#39;`) とバイト単位の出力は従来どおり維持
- `src/lib/__tests__/markdown.test.ts`: `escapeHtmlText` の振る舞いを固定する回帰テストを追加。`&` `<` `>` の 3 文字のみエスケープし `"` / `'` を保持する点 (`escapeHtmlAttr` との差分) を担保

## 備考

- 振る舞いを変えない純粋なリファクタリングであり、出力 HTML は従来と同一
- テスト結果: `pnpm test:run` 1061 件 pass / `pnpm lint` 成功 / `pnpm build` 成功
- レビューおよび Devil's Advocate レビュー実施済み、指摘なし

Closes #745
