### PR TITLE
chore: CLAUDE.md を実態に最新化（Vite 8 / build 説明 / ブランチ prefix を feat 系に統一）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `pnpm i` - 依存関係のインストール（最初に必ず実行）
 - `pnpm dev` - 開発サーバー起動（Panda CSS ウォッチモード付き）
-- `pnpm build` - プロダクションビルド（Panda CSS生成 → TypeScript型チェック → Viteビルド）
+- `pnpm build` - プロダクションビルド（lint → test:run → type-check（src）→ type-check:api → type-check:scripts → Panda CSS生成 → tsc（src）→ tsc（tsconfig.api.json）→ Viteビルド の順に実行）
 - `pnpm test` - テストをウォッチモードで実行
 - `pnpm test:run` - テストを1回実行
 - `pnpm test:ui` - Vitest UIでテスト実行
@@ -23,7 +23,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### 技術スタック
 
 - **フロントエンド**: React 19 + TypeScript
-- **ビルドツール**: Vite 6
+- **ビルドツール**: Vite 8
 - **テスト**: Vitest + React Testing Library + jsdom
 - **スタイリング**: Panda CSS（型安全なCSS-in-JS）
 - **ルーティング**: React Router DOM（`src/main.tsx` で Routes を手動登録、`src/pages/` 配下にページコンポーネントを置く慣行）
@@ -100,7 +100,7 @@ Tripwire テスト用に吐く data-* 属性の命名は以下を指針とする
 
 `panda.config.ts` の `hash:true` は**本番では無効（デフォルト）**で運用する。将来再評価する開発者向けの判断材料を残す。
 
-- **Tripwire テストは `hash:true` 耐性あり**: PR #474 で導入した `data-*` 属性方式により、`hash:true` を一時有効化しても Tripwire テスト 647 件は全 pass（Issue #475 にて master `d609ef0` で実機検証、2026-05-15）。Issue #422 の構造的耐性は実機で担保された
+- **Tripwire テストは `hash:true` 耐性あり**: PR #474 で導入した `data-*` 属性方式により、`hash:true` を一時有効化しても Tripwire テストは全 pass（Issue #475 にて master `d609ef0` で実機検証、**2026-05-15 時点**の 647 件で確認）。この「647 件」は検証を実施した特定時点のスナップショット値であり、現在のテスト総数とは異なる（テストは継続的に増加している）。Issue #422 の構造的耐性は実機で担保された
 - **bundle size はトレードオフ**: 生 CSS は `-25.6%` だが、hash 化で class 名のエントロピーが上がり gzip 圧縮率が低下するため、**gzip 後は `+5.8%`**。実環境は gzip 配信が標準なので、転送量で見るとほぼ等価
 - **手書き hook class（`index-row-*` / `copy-btn` 等）は Panda hash 化対象外**: `hash:true` を有効化しても影響を受けない
 - **再評価したい場合**: 別 Issue として切り出すこと
@@ -127,9 +127,11 @@ Tripwire テスト用に吐く data-* 属性の命名は以下を指針とする
 1. **masterへの直接コミット禁止**: masterブランチに直接コミットしてはならない
 2. **ブランチ作成必須**: ファイルを操作する場合は必ずブランチを切ってから編集・コミットすること
 3. **ブランチ名のプレフィックス**: ブランチ名には必ず以下のプレフィックスをつけること
-   - `feature/` - 新機能開発
+   - `feat/` - 新機能開発
    - `fix/` - バグ修正
-   - `chore/` - リファクタリング、ドキュメント更新など
+   - `chore/` - ドキュメント更新や自動生成ファイルの更新など
+   - `refactor/` - コードのリファクタリング
+   - `update/` - ドキュメントや設定ファイルの更新
    - `posts/${yyyymmdd}` - 今日の記事を書くとき
 4. **英語でのブランチ名**: ブランチ名は英語で記述すること
 5. **簡潔な命名**: ブランチ名は短く、わかりやすいものにする
@@ -143,9 +145,11 @@ Tripwire テスト用に吐く data-* 属性の命名は以下を指針とする
 
 ```bash
 # 良い例
-feature/user-authentication
+feat/user-authentication
 fix/login-error
 chore/update-dependencies
+refactor/improve-performance
+update/claude-md
 posts/20250101
 
 # 悪い例

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `pnpm i` - 依存関係のインストール（最初に必ず実行）
 - `pnpm dev` - 開発サーバー起動（Panda CSS ウォッチモード付き）
-- `pnpm build` - プロダクションビルド（lint → test:run → type-check（src）→ type-check:api → type-check:scripts → Panda CSS生成 → tsc（src）→ tsc（tsconfig.api.json）→ Viteビルド の順に実行）
+- `pnpm build` - プロダクションビルド（lint・テスト・型チェック(src/api/scripts)を全て通した後、Panda CSS生成 → tsc(src + api) → Vite ビルド）
 - `pnpm test` - テストをウォッチモードで実行
 - `pnpm test:run` - テストを1回実行
 - `pnpm test:ui` - Vitest UIでテスト実行
@@ -111,7 +111,7 @@ Tripwire テスト用に吐く data-* 属性の命名は以下を指針とする
     - **schedule (月初 00:00 UTC = `'0 0 1 * *'`)**: 月 1 回の定期検証で「機能が腐る」リスクを軽減
     - **pull_request paths**: `panda.config.ts` / `package.json` / `pnpm-lock.yaml` 変更 PR で即時検知。dependabot の `@pandacss/dev` 更新 PR は `pnpm-lock.yaml` 変更を含むため自動捕捉される
     - CI billing への影響は「月 1 + 該当 PR」程度で許容範囲。失敗時の通知は GitHub Actions 標準通知 (commit author email / fail badge) に加え、**Issue 自動起票 (Issue #733)** を併用する: workflow 失敗時に最終 step (`Open or update issue on failure`, `if: failure()`) が `gh issue list` で同名タイトルの open issue を検索し、無ければ `gh issue create` で新規起票、有ればコメント追記する dedup 戦略で、外部依存追加なしに能動的な通知経路を確保する。Slack (webhook secret 管理コスト増) は採用しない
-- **`build:ci` script と workflow の整合性メモ（Issue #528）**: hash:true build step は `package.json` の `build:ci` (= `panda && tsc && vite build`, test/lint/type-check:scripts を含まない軽量版) を呼ぶ。`build` script (本番経路) のコマンド列 (`panda && tsc && vite build` 部分) を変更する場合は `build:ci` も同期させること。**同期の有無は `scripts/checkBuildCiSync.ts` で自動検出される（Issue #685、`.github/workflows/ci.yml` の lint-and-typecheck job で実行）** ので、散文ルールが形骸化しても CI が drift を検知して fail する
+- **`build:ci` script と workflow の整合性メモ（Issue #528）**: hash:true build step は `package.json` の `build:ci` (= `panda && tsc && tsc --project tsconfig.api.json && vite build`, test/lint/type-check:scripts を含まない軽量版) を呼ぶ。`build` script (本番経路) のコマンド列 (`panda && tsc && vite build` 部分) を変更する場合は `build:ci` も同期させること。**同期の有無は `scripts/checkBuildCiSync.ts` で自動検出される（Issue #685、`.github/workflows/ci.yml` の lint-and-typecheck job で実行）** ので、散文ルールが形骸化しても CI が drift を検知して fail する
   - baseline (hash:false) build step は bundle size 計測専用で tsc を意図的に省く運用 (Issue #625 DA #2) のため `build:ci` ではなく `pnpm exec panda && pnpm exec vite build` を直接呼ぶ非対称運用とする
 
 ### 設定ファイル


### PR DESCRIPTION
## 概要

ドキュメント全般精査の一環として、プロジェクトルートの `CLAUDE.md` を実装の実態に最新化する。Closes #755

## 変更内容

- 技術スタックの `Vite 6` → `Vite 8`（`package.json` の `vite ^8.0.10` に整合）
- `pnpm build` の説明を実 build script（lint・テスト・型チェックを前段で全通し後、Panda 生成 → tsc(src + api) → Vite ビルド）に整合。逐語の `&&` 列ハードコードは避け要約
- `build:ci` 整合性メモ（Issue #528）に欠落していた `tsc --project tsconfig.api.json` を追記し、実 `build:ci` と一致
- Tripwire テスト数記述（647 件）は**スナップショットとして保持**し、検証時点（2026-05-15 / master `d609ef0`）の値であることを明示補強（現状値への書き換えはしない）
- ブランチ prefix を実運用・`.claude/skills` と整合する `feat/` 系へ統一（`feature/` → `feat/`、`refactor/`・`update/` を追加、「ブランチ名の例」も追随）

## 備考

- ローカルで DA + レビュー承認済み
- テスト数のスナップショット保持は DA が「現状値 1055 への書き換えは hash:true 実機検証の監査記録を虚偽化するため不可」と支持
- ブランチ prefix の `feat/` 系統一はオーナー承認済み方針
- ドキュメントのみの変更でコードへの影響なし
