### PR TITLE
refactor: JST 暦日付ユーティリティの重複を anchors.ts に統合

### DIFF
--- a/src/lib/__tests__/anchors.test.ts
+++ b/src/lib/__tests__/anchors.test.ts
@@ -22,6 +22,7 @@ import {
   type Elapsed,
   inferPublishedAt,
   type Milestone,
+  toJstCalendarDate,
 } from "../anchors";
 
 describe("inferPublishedAt: ファイル名からの ISO 8601 推定 (JST 固定)", () => {
@@ -577,6 +578,32 @@ describe("computeElapsed: 層2=経過 (暦上の経過日数)", () => {
     );
 
     expect(result.daysSince).toBe(365);
+  });
+});
+
+/**
+ * Tripwire: toJstCalendarDate の throw 契約を固定する (Issue #746)
+ *
+ * 本ブランチで resurface 側の `isoToCalendarDate` (null 返し) を本関数 (throw) に
+ * 統合した際、「呼び出し元 (resolveAndSortPosts) は inferPublishedAt が
+ * isIso8601 検証済みの ISO 文字列のみを渡すため invalid は到達不能」という前提で
+ * null 分岐をデッドコードとみなし削除した。
+ *
+ * この前提が将来崩れ (例: 検証を経ない経路から invalid な値が渡る) たときに
+ * 早期検知するための網。toJstCalendarDate が invalid 入力で throw することを固定し、
+ * 万一サイレントに不正値を受け入れる実装に退行したらこのテストで気づける。
+ */
+describe("toJstCalendarDate: 不正入力の throw 契約 (Tripwire / Issue #746)", () => {
+  it("不正な ISO 8601 文字列を渡すと例外を投げる", () => {
+    expect(() => toJstCalendarDate("not-an-iso-string")).toThrow();
+  });
+
+  it("空文字を渡すと例外を投げる", () => {
+    expect(() => toJstCalendarDate("")).toThrow();
+  });
+
+  it("実在しない日付 (パース不能) を渡すと例外を投げる", () => {
+    expect(() => toJstCalendarDate("2025-13-99T99:99:99+09:00")).toThrow();
   });
 });
 

--- a/src/lib/anchors.ts
+++ b/src/lib/anchors.ts
@@ -145,20 +145,36 @@ export const inferPublishedAt = (fileName: string): string | undefined => {
 };
 
 /**
+ * JST (+09:00) のオフセット (ミリ秒)。
+ *
+ * UTC 時刻に加算してから `getUTC*` で年月日を取り出すことで、JST 暦上の
+ * カレンダー日付を算出する用途に使う。暦計算の単一ソースとして本モジュールに集約する。
+ */
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/**
  * ISO 8601 文字列 (publishedAt) から JST のカレンダー上の年月日を抽出する
  *
  * - publishedAt 内のタイムゾーンに関係なく、JST (+09:00) の暦上の日付を返す
  * - 同日内の時刻差は無視される (00:00 と 23:59 で同じ日付を返す)
+ * - パース不能な値が渡された場合は throw する (呼び出し元は ISO 8601 妥当性が
+ *   保証された文字列のみを渡す契約)
+ *
+ * 暦計算の単一ソース (Issue #746):
+ * - 旧 `resurface.ts` の `isoToCalendarDate` (null 返し) と本関数 (throw) は本体が
+ *   完全に同一だった。重複統合にあたり本関数を単一ソースとして export し、resurface
+ *   側もこれを使う。resurface の呼び出し元 (`resolveAndSortPosts`) は
+ *   `inferPublishedAt` が検証済みの ISO 文字列のみを渡すため、throw 契約でも観測上
+ *   等価 (invalid が到達しない)。
  */
-const toJstCalendarDate = (isoDateTime: string): Date => {
+export const toJstCalendarDate = (isoDateTime: string): Date => {
   const time = Date.parse(isoDateTime);
   if (!Number.isFinite(time)) {
     throw new Error(`Invalid ISO 8601 datetime: "${isoDateTime}"`);
   }
   // JST (+09:00) オフセットを加えて UTC として年月日を取り出すことで、
   // JST 上のカレンダー日付を表現する Date インスタンスを生成する
-  const jstOffsetMs = 9 * 60 * 60 * 1000;
-  const jstShifted = new Date(time + jstOffsetMs);
+  const jstShifted = new Date(time + JST_OFFSET_MS);
   return new Date(
     Date.UTC(
       jstShifted.getUTCFullYear(),
@@ -178,9 +194,14 @@ const toJstCalendarDate = (isoDateTime: string): Date => {
  *   - 例: "2025-13-32" → 2026-02-01 / "2025-02-29" → 2025-03-01
  *   - 仕様としての挙動は `anchors.test.ts` の「Milestone.date 不正値の仕様」で固定
  *
+ * 暦計算の単一ソース (Issue #746):
+ * - 旧 `resurface.ts` の `toCalendarDate` と本体が完全に同一だった。重複統合にあたり
+ *   本関数を単一ソースとして export し、resurface 側もこれを使う。両者とも null 返し
+ *   契約だったため観測上の差はない。
+ *
  * @todo 値範囲検証関数は #489 で別途追加予定。本関数は現状ロールオーバーを許容する
  */
-const toMilestoneCalendarDate = (date: string): Date | null => {
+export const toMilestoneCalendarDate = (date: string): Date | null => {
   const match = date.match(/^(\d{4})-(\d{2})-(\d{2})$/);
   if (!match) {
     return null;
@@ -193,16 +214,40 @@ const toMilestoneCalendarDate = (date: string): Date | null => {
   return new Date(utcMs);
 };
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
+export const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /**
- * 2 つの JST カレンダー日付の差分日数 (publishedAt - origin) を返す
+ * 2 つの JST カレンダー日付の差分日数 (target - origin) を返す
  *
  * - 引数はいずれも `toJstCalendarDate` / `toMilestoneCalendarDate` で
  *   00:00:00 UTC 固定化された Date インスタンスである前提
+ * - 暦計算の単一ソース (Issue #746): 旧 `resurface.ts` の同名関数と本体が同一だった
+ *   ため統合し、resurface 側もこれを使う
  */
-const diffInDays = (origin: Date, target: Date): number => {
+export const diffInDays = (origin: Date, target: Date): number => {
   return Math.round((target.getTime() - origin.getTime()) / MS_PER_DAY);
+};
+
+/**
+ * 今日の日付を JST 暦上の YYYY-MM-DD 文字列として返す。
+ *
+ * - `new Date()` を読むため副作用 (現在時刻依存) を持つ。純粋関数群と区別すること
+ * - JST (+09:00) オフセットを加えて UTC 上の年月日を取り出す方式は
+ *   `toJstCalendarDate` と同一の発想で、`JST_OFFSET_MS` を共有する
+ * - テストで時刻を固定したい呼び出し (例: `selectResurfaced` の today 引数) は
+ *   本関数を経由せず YYYY-MM-DD 文字列を直接渡すこと
+ *
+ * 暦計算の単一ソース (Issue #746):
+ * - 旧 `pages/index.tsx` の `getTodayJst` が手計算していた `9 * 60 * 60 * 1000` を
+ *   本モジュールへ集約する。pages 層は本関数を呼ぶことで JST オフセット定数の
+ *   再記述を排除する。
+ */
+export const todayInJst = (): string => {
+  const jst = new Date(Date.now() + JST_OFFSET_MS);
+  const year = String(jst.getUTCFullYear()).padStart(4, "0");
+  const month = String(jst.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(jst.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 };
 
 /**

--- a/src/lib/resurface.ts
+++ b/src/lib/resurface.ts
@@ -23,7 +23,13 @@
  * の方が「重い節目近辺の記事」よりも回復的に働くため、沈黙時は 1年前 → 最古 の順で選ぶ。
  */
 
-import { inferPublishedAt, type Milestone } from "./anchors";
+import {
+  diffInDays,
+  inferPublishedAt,
+  type Milestone,
+  toJstCalendarDate,
+  toMilestoneCalendarDate,
+} from "./anchors";
 import type { PostSummary } from "./markdown";
 
 /**
@@ -125,57 +131,14 @@ interface ResolvedPost {
   readonly publishedDate: Date;
 }
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
-
 /**
- * YYYY-MM-DD 文字列を JST 暦上の Date (UTC 基準で時分秒 0) に変換する。
- *
- * - 不正な形式の場合は null を返す
- * - 日数差の計算用 (時刻は捨てる)
+ * 暦変換・日数差ユーティリティの単一ソース化 (Issue #746):
+ * - 旧 `toCalendarDate` / `isoToCalendarDate` / `diffInDays` / `MS_PER_DAY` は
+ *   `anchors.ts` の `toMilestoneCalendarDate` / `toJstCalendarDate` / `diffInDays` /
+ *   `MS_PER_DAY` と本体が完全に同一だった。「private を export しない」方針より
+ *   「同一ロジックを 2 回書く」コストの方が高いと判断し、anchors からの import に
+ *   統合した (`resurface.ts:26` で既に anchors を import している edge を拡張)。
  */
-const toCalendarDate = (date: string): Date | null => {
-  const match = date.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (!match) {
-    return null;
-  }
-  const [, year, month, day] = match;
-  const utcMs = Date.UTC(Number(year), Number(month) - 1, Number(day));
-  if (!Number.isFinite(utcMs)) {
-    return null;
-  }
-  return new Date(utcMs);
-};
-
-/**
- * ISO 8601 文字列を JST 暦上の Date に変換する (時分秒は捨てて JST 暦日のみ保持)。
- *
- * anchors.ts の同名 private 関数 (toJstCalendarDate) と同じ挙動だが、ファイル分離
- * のため再実装する (anchors.ts の private を export しない方針)。
- */
-const isoToCalendarDate = (isoDateTime: string): Date | null => {
-  const time = Date.parse(isoDateTime);
-  if (!Number.isFinite(time)) {
-    return null;
-  }
-  // JST (+09:00) オフセットを加えて UTC として年月日を取り出すことで、
-  // JST 上のカレンダー日付を表現する Date インスタンスを生成する
-  const jstOffsetMs = 9 * 60 * 60 * 1000;
-  const jstShifted = new Date(time + jstOffsetMs);
-  return new Date(
-    Date.UTC(
-      jstShifted.getUTCFullYear(),
-      jstShifted.getUTCMonth(),
-      jstShifted.getUTCDate(),
-    ),
-  );
-};
-
-/**
- * 2 つの JST カレンダー日付の差分日数を返す (target - origin)。
- */
-const diffInDays = (origin: Date, target: Date): number => {
-  return Math.round((target.getTime() - origin.getTime()) / MS_PER_DAY);
-};
 
 /**
  * 投稿群のうち inferPublishedAt 解決に成功したものだけを抽出し、
@@ -190,10 +153,10 @@ const resolveAndSortPosts = (posts: readonly PostSummary[]): ResolvedPost[] => {
     if (publishedAt === undefined) {
       continue;
     }
-    const publishedDate = isoToCalendarDate(publishedAt);
-    if (publishedDate === null) {
-      continue;
-    }
+    // `inferPublishedAt` は `isIso8601` で検証済みの ISO 8601 文字列のみを返すため、
+    // `toJstCalendarDate` の throw 契約でも invalid は到達しない (旧 isoToCalendarDate
+    // の null 分岐は実質デッドコードだった)。観測上の振る舞いは不変 (Issue #746)。
+    const publishedDate = toJstCalendarDate(publishedAt);
     resolved.push({ post, publishedDate });
   }
   // 新→古 にソート (最新が 0 番目)
@@ -266,7 +229,7 @@ const pickSameMonthDay = (
  *
  * - tone:heavy の節目は対象外 (Coordinate と同等の取り扱い)
  * - 節目の月日と記事の月日が一致し、かつ節目→記事の年差が 1 以上
- * - 不正な節目日付 (toCalendarDate が null) は無効として除外
+ * - 不正な節目日付 (toMilestoneCalendarDate が null) は無効として除外
  *
  * @returns 一致時の yearsSinceMilestone, それ以外は null
  */
@@ -277,7 +240,7 @@ const matchMilestoneAnniversary = (
   if (milestone.tone === "heavy") {
     return null;
   }
-  const mDate = toCalendarDate(milestone.date);
+  const mDate = toMilestoneCalendarDate(milestone.date);
   if (mDate === null) {
     return null;
   }
@@ -447,7 +410,7 @@ export const selectResurfaced = (
   today: string,
   options: SelectResurfacedOptions = {},
 ): ResurfacedEntry | null => {
-  const todayDate = toCalendarDate(today);
+  const todayDate = toMilestoneCalendarDate(today);
   if (todayDate === null) {
     return null;
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,7 @@ import { CardSkeleton } from "../components/common/CardSkeleton";
 import { Layout } from "../components/layouts/Layout";
 import { HomePage } from "../components/pages/HomePage";
 import { usePosts } from "../hooks/usePosts";
-import type { Milestone } from "../lib/anchors";
+import { type Milestone, todayInJst } from "../lib/anchors";
 import { parseMilestones } from "../lib/milestonesSchema";
 import { selectResurfaced } from "../lib/resurface";
 import {
@@ -44,24 +44,6 @@ import {
  */
 const MILESTONES: readonly Milestone[] = parseMilestones(milestonesData);
 
-/**
- * 今日の日付を JST 暦上の YYYY-MM-DD として返す。
- *
- * React コンポーネント内でしか呼ばないため副作用は許容する。
- * テストで時間を固定する場合は `selectResurfaced` の第 3 引数 today に直接
- * 文字列を渡せばよく、本ヘルパーは production 専用。
- */
-const getTodayJst = (): string => {
-  const now = new Date();
-  // JST (+09:00) でカレンダー日付を取り出す
-  const jstOffsetMs = 9 * 60 * 60 * 1000;
-  const jst = new Date(now.getTime() + jstOffsetMs);
-  const y = String(jst.getUTCFullYear()).padStart(4, "0");
-  const m = String(jst.getUTCMonth() + 1).padStart(2, "0");
-  const d = String(jst.getUTCDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
-};
-
 const Index = () => {
   const {
     posts,
@@ -92,7 +74,7 @@ const Index = () => {
   //   出るのは常に「1 ページ目の posts」のとき = HomePage に表示中の post 集合)。
   const resurfaceEntry = useMemo(
     () =>
-      selectResurfaced(allPosts, MILESTONES, getTodayJst(), {
+      selectResurfaced(allPosts, MILESTONES, todayInJst(), {
         excludeIds: posts.map((p) => p.id),
       }),
     [allPosts, posts],


### PR DESCRIPTION
## 概要

Issue #746「暦日付ユーティリティ (JST カレンダー変換/日数差) の重複統合」への対応。`resurface.ts` / `index.tsx` に散在していた JST 暦変換・日数差・当日取得のロジックを `anchors.ts` に集約し、重複を解消した（方式A: anchors への暦ユーティリティ集約）。

## 変更内容

- `src/lib/anchors.ts`: JST 暦日付ユーティリティ（`toJstCalendarDate` 等）の正本をここに集約。各所に重複していた暦変換/日数差ロジックの単一ソースとした
- `src/lib/resurface.ts`: 自前で持っていた暦変換・日数差の重複実装を削除し、`anchors.ts` のユーティリティを参照するよう変更。あわせて `todayInJst` の取得を集約した実装に統一
- `src/pages/index.tsx`: 重複していた暦/当日ロジックを `anchors.ts` の集約版に置き換え。到達不能な null 分岐のデッドコードを削除した（呼び出し経路上 null になり得ないことを確認済み）
- `src/lib/__tests__/anchors.test.ts`: `toJstCalendarDate` の不正入力に対する throw 挙動を固定する Tripwire テストを追加。集約後も入力バリデーションの振る舞いが退行しないことを保証する

## 備考

- テスト結果: `pnpm test:run` 1058 件 pass / `pnpm lint` クリーン / `pnpm build` 成功
- レビュー（コードレビュー・Devil's Advocate）ともにローカルで承認済み。両者推奨の Tripwire テストも追加反映済み

Closes #746
