### PR TITLE
refactor: src に noUncheckedIndexedAccess を先行有効化

### DIFF
--- a/src/hooks/useAdjacentPosts.ts
+++ b/src/hooks/useAdjacentPosts.ts
@@ -26,9 +26,11 @@ export const findAdjacentPosts = (
     return { olderPost: null, newerPost: null };
   }
 
-  const newerPost = currentIndex > 0 ? summaries[currentIndex - 1] : null;
+  const newerPost = currentIndex > 0 ? (summaries[currentIndex - 1] ?? null) : null;
   const olderPost =
-    currentIndex < summaries.length - 1 ? summaries[currentIndex + 1] : null;
+    currentIndex < summaries.length - 1
+      ? (summaries[currentIndex + 1] ?? null)
+      : null;
 
   return { olderPost, newerPost };
 };

--- a/src/hooks/useAdjacentPosts.ts
+++ b/src/hooks/useAdjacentPosts.ts
@@ -26,7 +26,8 @@ export const findAdjacentPosts = (
     return { olderPost: null, newerPost: null };
   }
 
-  const newerPost = currentIndex > 0 ? (summaries[currentIndex - 1] ?? null) : null;
+  const newerPost =
+    currentIndex > 0 ? (summaries[currentIndex - 1] ?? null) : null;
   const olderPost =
     currentIndex < summaries.length - 1
       ? (summaries[currentIndex + 1] ?? null)

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -163,7 +163,11 @@ const getStaticPostSummaries = async (): Promise<PostSummary[]> => {
   });
 
   for (const filePath in modules) {
-    const content = (await modules[filePath]()) as string;
+    const loadModule = modules[filePath];
+    if (!loadModule) {
+      continue;
+    }
+    const content = (await loadModule()) as string;
     const timestamp = filePath.split("/").pop()?.replace(".md", "") || "";
     if (timestamp) {
       summaries.push(extractSummaryFromContent(content, timestamp));

--- a/src/lib/resurface.ts
+++ b/src/lib/resurface.ts
@@ -325,7 +325,12 @@ const pickSilenceTarget = (
   }
 
   // 1年前候補が無ければ最古記事 (resolved の末尾)
+  // length === 0 は冒頭で early return 済みのため末尾要素は必ず存在するが、
+  // noUncheckedIndexedAccess 下では型が undefined を含むため明示ガードする。
   const oldest = pastCandidates[pastCandidates.length - 1];
+  if (oldest === undefined) {
+    return null;
+  }
   return {
     post: oldest.post,
     reason: {
@@ -426,7 +431,12 @@ export const selectResurfaced = (
     return null;
   }
 
+  // length === 0 は直前で early return 済みのため先頭要素は必ず存在するが、
+  // noUncheckedIndexedAccess 下では型が undefined を含むため明示ガードする。
   const newest = resolved[0];
+  if (newest === undefined) {
+    return null;
+  }
   // newest を浮上対象として選ぶことは設計上ない (最新は Featured で既に表示されているため
   // Resurface には「過去の声」しか出さない)。さらに、HomePage で既に表示中の post (id) を
   // 除外することで View Transition `view-transition-name` の重複衝突を回避する

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -16,6 +16,10 @@
     // (process / Buffer / __dirname 等) を有効化する。
     // ブラウザ向け型 (vitest/globals / @testing-library/jest-dom) は不要なので含めない。
     "types": ["node"],
+    // noUncheckedIndexedAccess は本体 (src) 先行で有効化したため (Issue #747)、
+    // extends 経由でここにも継承される。api 側の有効化は別 Issue (#748) で扱う
+    // 方針のため、継承を打ち消して false に戻し本 Issue のスコープを src に限定する。
+    "noUncheckedIndexedAccess": false,
     // Incremental build (Issue #580): tsconfig.json / tsconfig.test.json /
     // tsconfig.scripts.json と独立した .tsbuildinfo を出力する。
     // include / types が異なるため別ファイルにしないと衝突する。

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -19,6 +19,8 @@
     // noUncheckedIndexedAccess は本体 (src) 先行で有効化したため (Issue #747)、
     // extends 経由でここにも継承される。api 側の有効化は別 Issue (#748) で扱う
     // 方針のため、継承を打ち消して false に戻し本 Issue のスコープを src に限定する。
+    // #748 で api 側を true 化する際は、この上書き行を削除すること
+    // (削除すれば本体 tsconfig からの true 継承が復活する)。
     "noUncheckedIndexedAccess": false,
     // Incremental build (Issue #580): tsconfig.json / tsconfig.test.json /
     // tsconfig.scripts.json と独立した .tsbuildinfo を出力する。

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
 
     /* Linting */
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -14,6 +14,8 @@
     // noUncheckedIndexedAccess は本体 (src) 先行で有効化したため (Issue #747)、
     // extends 経由でここにも継承される。scripts 側の有効化は別 Issue (#749) で扱う
     // 方針のため、継承を打ち消して false に戻し本 Issue のスコープを src に限定する。
+    // #749 で scripts 側を true 化する際は、この上書き行を削除すること
+    // (削除すれば本体 tsconfig からの true 継承が復活する)。
     "noUncheckedIndexedAccess": false,
     // Incremental build (Issue #580): tsconfig.json / tsconfig.test.json と独立した
     // .tsbuildinfo を出力する。include が異なるため別ファイルにしないと衝突する。

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -11,6 +11,10 @@
     // ambient globals (process / Buffer / __dirname 等) を有効化する。
     // scripts/__tests__ が vitest で実行されるため vitest/globals も含める。
     "types": ["node", "vitest/globals"],
+    // noUncheckedIndexedAccess は本体 (src) 先行で有効化したため (Issue #747)、
+    // extends 経由でここにも継承される。scripts 側の有効化は別 Issue (#749) で扱う
+    // 方針のため、継承を打ち消して false に戻し本 Issue のスコープを src に限定する。
+    "noUncheckedIndexedAccess": false,
     // Incremental build (Issue #580): tsconfig.json / tsconfig.test.json と独立した
     // .tsbuildinfo を出力する。include が異なるため別ファイルにしないと衝突する。
     "tsBuildInfoFile": "./.tsbuildinfo/tsconfig.scripts.tsbuildinfo"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -14,6 +14,10 @@
     // node は src/api/__tests__ や src/lib/__tests__ の一部が node:fs / process /
     // __dirname 等を参照するため必要 (Issue #667)。
     "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client", "node"],
+    // noUncheckedIndexedAccess は本体 (src) 先行で有効化したため (Issue #747)、
+    // extends 経由でここにも継承される。test 側の有効化は別 Issue (#750) で扱う
+    // 方針のため、継承を打ち消して false に戻し本 Issue のスコープを src に限定する。
+    "noUncheckedIndexedAccess": false,
     // テストでは setup 用の helper 変数等で意図的に未使用なものを許容する
     "noUnusedLocals": false,
     "noUnusedParameters": false,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -17,6 +17,8 @@
     // noUncheckedIndexedAccess は本体 (src) 先行で有効化したため (Issue #747)、
     // extends 経由でここにも継承される。test 側の有効化は別 Issue (#750) で扱う
     // 方針のため、継承を打ち消して false に戻し本 Issue のスコープを src に限定する。
+    // #750 で test 側を true 化する際は、この上書き行を削除すること
+    // (削除すれば本体 tsconfig からの true 継承が復活する)。
     "noUncheckedIndexedAccess": false,
     // テストでは setup 用の helper 変数等で意図的に未使用なものを許容する
     "noUnusedLocals": false,


### PR DESCRIPTION
## 概要

`tsconfig.json` に `noUncheckedIndexedAccess` を有効化し、`src` 配下を先行対応した。配列・オブジェクトのインデックスアクセスが `T | undefined` 型として扱われるようになり、未チェックのインデックスアクセスに起因する潜在的な undefined 参照を型レベルで検知できるようにする。

`src` にスコープを限定するため、子 config（`tsconfig.api.json` / `tsconfig.scripts.json` / `tsconfig.test.json`）では `false` で上書きしている。各領域の `true` 化は後続 Issue（#748 / #749 / #750）で個別に対応予定。

Closes #747

## 変更内容

- `tsconfig.json`: `noUncheckedIndexedAccess: true` を追加し、プロジェクト全体のベースで有効化
- `tsconfig.api.json` / `tsconfig.scripts.json` / `tsconfig.test.json`: `noUncheckedIndexedAccess: false` で上書きし、有効化のスコープを `src` に限定（除去意図のコメントを併記。後続 #748 / #749 / #750 で各領域を true 化予定）
- `src/lib/markdown.ts`: 有効化により顕在化したインデックスアクセスの undefined 可能性に対応
- `src/lib/resurface.ts`: 同上
- `src/hooks/useAdjacentPosts.ts`: 同上、およびフォーマット整合

実測で顕在化したエラーは src 配下 5 件で、いずれも修正済み。

## 備考

- テスト結果:
  - `pnpm test:run`: 1064 件 pass
  - `pnpm lint`: 成功
  - `pnpm build`: 成功
- レビュー・Devil's Advocate レビュー実施済み（要修正点は対応済み: `useAdjacentPosts` のフォーマット整合 / 子 config への除去意図コメント追記）
