### PR TITLE
refactor: 3 ページの MILESTONES JSDoc を同一文面に統一

### DIFF
--- a/src/pages/anchor.tsx
+++ b/src/pages/anchor.tsx
@@ -50,33 +50,35 @@ import {
 /**
  * 節目データ (`datasources/milestones.json`)。
  *
- * AnchorPage (個人史タイムライン) で「節目一覧 + 各記事の座標」を描画するために
- * 使用する。Coordinate (Issue #491) / Resurface (Issue #492) と同じ JSON を
- * 共有しているが、Issue #546 の判断で **集約せず各 page で個別 import** する
- * 設計を採用している (認知負荷の局所化を優先)。`src/lib/milestones.ts` のような
- * 集約点を作ると、各 page を読む際に「この MILESTONES はどこから来てどう加工
- * されたものか」を別ファイルまで追いかける必要が出るため、3 page で import 経路と
- * narrowing キャストを揃え、各 page の責務 (Coordinate / Resurface / AnchorPage
- * のどれに渡すか) をその場で完結して読めるようにする。撤退の単位は
- * docs/ANCHOR.md 「撤退可能性」節のとおり **コンポーネント (Coordinate /
- * Resurface) ごとの `show` フラグ** が一次手段であり、JSON の `[]` 化は 3 経路
- * まとめての停止 = 二次手段である。
+ * このページでは AnchorPage (個人史タイムライン) で「節目一覧 + 各記事の座標」を
+ * 描画するために使用する。
+ *
+ * 集約しない設計判断 (Issue #546):
+ * Coordinate (Issue #491) / Resurface (Issue #492) / AnchorPage (Issue #493) の
+ * 3 page が同じ JSON を共有しているが、Issue #546 の判断で **集約せず各 page で
+ * 個別 import** する設計を採用している (認知負荷の局所化を優先)。
+ * `src/lib/milestones.ts` のような集約点を作ると、各 page を読む際に「この
+ * MILESTONES はどこから来てどう加工されたものか」を別ファイルまで追いかける必要が
+ * 出るため、3 page で import 経路と narrowing キャストを揃え、各 page の責務
+ * (Coordinate / Resurface / AnchorPage のどれに渡すか) をその場で完結して読める
+ * ようにする。撤退の単位は docs/ANCHOR.md 「撤退可能性」節のとおり
+ * **コンポーネント (Coordinate / Resurface) ごとの `show` フラグ** が一次手段で
+ * あり、JSON の `[]` 化は 3 経路まとめての停止 = 二次手段である。
  *
  * ランタイム検証 (Issue #547):
  * - `as readonly Milestone[]` の型キャスト**ではなく**、`parseMilestones`
- *   (`src/lib/milestonesSchema.ts`) で lenient 検証する。これにより JSON 編集者が
- *   `tone: "happy"` のような値域外を入れた場合に、ランタイムでサイレントに
- *   その要素を除外できる (= 本番のページが壊れない fail-soft)。
- * - 全件不正で配列が空になった場合も、AnchorPage 側で穏やかな 0 件文言を表示する
- *   既存ロジックがそのまま機能する。
+ *   (`src/lib/milestonesSchema.ts`) で lenient 検証する。`tone` の値域外
+ *   (例: `"happy"`) や `date` (`YYYY-MM-DD`) の形式違反などの不正要素は、
+ *   ランタイムでサイレントに除外される (= 本番のページが壊れない fail-soft)。
+ * - 全件不正で配列が空になった場合も、各 page の 0 件フォールバックがそのまま
+ *   機能する。
  * - 厳密な検出 (CI で PR をブロック) は `src/lib/__tests__/milestonesSchema.test.ts`
  *   の `validateMilestonesStrict` 経由で別途担保する。
  *
- * 値域から外れた場合の実害は AnchorPage の責務範囲では以下に帰着する:
- * - 不正 `tone` (`"neutral" | "light" | "heavy"` 以外の文字列): `parseMilestones`
- *   が当該要素を除外するため、節目一覧にも各記事の座標にも一切現れない
- * - 不正 `date` (`YYYY-MM-DD` 形式違反): 同様に `parseMilestones` が当該要素を
- *   除外する (Issue #547 以前は表示と座標計算で挙動が非対称だったが、本検証で統一)
+ * このページでの実害: 不正要素 (値域外 `tone` / 形式違反 `date`) は除外されるため、
+ * 節目一覧にも各記事の座標にも一切現れない (Issue #547 以前は表示と座標計算で挙動が
+ * 非対称だったが、本検証で統一)。全件不正で空になった場合は AnchorPage が穏やかな
+ * 0 件文言を表示する。
  *
  * 撤退方法: `datasources/milestones.json` の配列を `[]` にすれば AnchorPage の
  * 節目一覧が空状態になる (AnchorPage 側で穏やかな 0 件文言を表示)。

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,26 +17,33 @@ import {
 /**
  * 節目データ (`datasources/milestones.json`)。
  *
- * Resurface (Issue #492 / N-5) で「節目記念日 (milestoneAnniversary)」の発火に
- * 使用する。Coordinate (Issue #491) / AnchorPage (Issue #493) と同じ JSON を
- * 共有しているが、Issue #546 の判断で **集約せず各 page で個別 import** する
- * 設計を採用している (認知負荷の局所化を優先)。`src/lib/milestones.ts` のような
- * 集約点を作ると、各 page を読む際に「この MILESTONES はどこから来てどう加工
- * されたものか」を別ファイルまで追いかける必要が出るため、3 page で import 経路と
- * narrowing キャストを揃え、各 page の責務 (Coordinate / Resurface / AnchorPage
- * のどれに渡すか) をその場で完結して読めるようにする。撤退の単位は
- * docs/ANCHOR.md 「撤退可能性」節のとおり **コンポーネント (Coordinate /
- * Resurface) ごとの `show` フラグ** が一次手段であり、JSON の `[]` 化は 3 経路
- * まとめての停止 = 二次手段である。
+ * このページでは Resurface (Issue #492 / N-5) で「節目記念日
+ * (milestoneAnniversary)」の発火に使用する。
+ *
+ * 集約しない設計判断 (Issue #546):
+ * Coordinate (Issue #491) / Resurface (Issue #492) / AnchorPage (Issue #493) の
+ * 3 page が同じ JSON を共有しているが、Issue #546 の判断で **集約せず各 page で
+ * 個別 import** する設計を採用している (認知負荷の局所化を優先)。
+ * `src/lib/milestones.ts` のような集約点を作ると、各 page を読む際に「この
+ * MILESTONES はどこから来てどう加工されたものか」を別ファイルまで追いかける必要が
+ * 出るため、3 page で import 経路と narrowing キャストを揃え、各 page の責務
+ * (Coordinate / Resurface / AnchorPage のどれに渡すか) をその場で完結して読める
+ * ようにする。撤退の単位は docs/ANCHOR.md 「撤退可能性」節のとおり
+ * **コンポーネント (Coordinate / Resurface) ごとの `show` フラグ** が一次手段で
+ * あり、JSON の `[]` 化は 3 経路まとめての停止 = 二次手段である。
  *
  * ランタイム検証 (Issue #547):
  * - `as readonly Milestone[]` の型キャスト**ではなく**、`parseMilestones`
  *   (`src/lib/milestonesSchema.ts`) で lenient 検証する。`tone` の値域外
- *   (例: `"happy"`) や `date` の形式違反などの不正要素はランタイムで除外される。
- * - 結果として Resurface の節目記念日経路にも不正データが渡らない (= 沈黙トリガー
- *   の誤発火を防ぐ)。
+ *   (例: `"happy"`) や `date` (`YYYY-MM-DD`) の形式違反などの不正要素は、
+ *   ランタイムでサイレントに除外される (= 本番のページが壊れない fail-soft)。
+ * - 全件不正で配列が空になった場合も、各 page の 0 件フォールバックがそのまま
+ *   機能する。
  * - 厳密な検出 (CI で PR をブロック) は `src/lib/__tests__/milestonesSchema.test.ts`
  *   の `validateMilestonesStrict` 経由で別途担保する。
+ *
+ * このページでの実害: 不正要素が除外されることで、Resurface の節目記念日経路にも
+ * 不正データが渡らない (= 沈黙トリガーの誤発火を防ぐ)。
  *
  * 撤退方法: `datasources/milestones.json` の配列を `[]` にすれば節目記念日が
  * 発火しなくなる (沈黙トリガーと暦の節目は引き続き機能する)。編集方法は

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -20,25 +20,32 @@ import {
 /**
  * 節目データ (`datasources/milestones.json`)。
  *
- * Coordinate (Issue #491) で「記事ごとの個人史座標」を算出するために使用する。
- * Resurface (Issue #492) / AnchorPage (Issue #493) と同じ JSON を共有しているが、
- * Issue #546 の判断で **集約せず各 page で個別 import** する設計を採用している
- * (認知負荷の局所化を優先)。`src/lib/milestones.ts` のような集約点を作ると、
- * 各 page を読む際に「この MILESTONES はどこから来てどう加工されたものか」を
- * 別ファイルまで追いかける必要が出るため、3 page で import 経路と narrowing
- * キャストを揃え、各 page の責務 (Coordinate / Resurface / AnchorPage のどれに
- * 渡すか) をその場で完結して読めるようにする。撤退の単位は docs/ANCHOR.md
- * 「撤退可能性」節のとおり **コンポーネント (Coordinate / Resurface) ごとの
- * `show` フラグ** が一次手段であり、JSON の `[]` 化は 3 経路まとめての停止 =
- * 二次手段である。
+ * このページでは Coordinate (Issue #491) で「記事ごとの個人史座標」を算出するために
+ * 使用する。
+ *
+ * 集約しない設計判断 (Issue #546):
+ * Coordinate (Issue #491) / Resurface (Issue #492) / AnchorPage (Issue #493) の
+ * 3 page が同じ JSON を共有しているが、Issue #546 の判断で **集約せず各 page で
+ * 個別 import** する設計を採用している (認知負荷の局所化を優先)。
+ * `src/lib/milestones.ts` のような集約点を作ると、各 page を読む際に「この
+ * MILESTONES はどこから来てどう加工されたものか」を別ファイルまで追いかける必要が
+ * 出るため、3 page で import 経路と narrowing キャストを揃え、各 page の責務
+ * (Coordinate / Resurface / AnchorPage のどれに渡すか) をその場で完結して読める
+ * ようにする。撤退の単位は docs/ANCHOR.md 「撤退可能性」節のとおり
+ * **コンポーネント (Coordinate / Resurface) ごとの `show` フラグ** が一次手段で
+ * あり、JSON の `[]` 化は 3 経路まとめての停止 = 二次手段である。
  *
  * ランタイム検証 (Issue #547):
  * - `as readonly Milestone[]` の型キャスト**ではなく**、`parseMilestones`
  *   (`src/lib/milestonesSchema.ts`) で lenient 検証する。`tone` の値域外
- *   (例: `"happy"`) や `date` の形式違反などの不正要素はランタイムで除外され、
- *   Coordinate に渡る前に弾かれる。
+ *   (例: `"happy"`) や `date` (`YYYY-MM-DD`) の形式違反などの不正要素は、
+ *   ランタイムでサイレントに除外される (= 本番のページが壊れない fail-soft)。
+ * - 全件不正で配列が空になった場合も、各 page の 0 件フォールバックがそのまま
+ *   機能する。
  * - 厳密な検出 (CI で PR をブロック) は `src/lib/__tests__/milestonesSchema.test.ts`
  *   の `validateMilestonesStrict` 経由で別途担保する。
+ *
+ * このページでの実害: 不正要素が除外されることで、Coordinate に渡る前に弾かれる。
  *
  * 撤退方法: `datasources/milestones.json` の配列を `[]` にすれば全記事の
  * Coordinate が消える。編集方法は `docs/MILESTONES.md` を参照する。


### PR DESCRIPTION
## 概要

Issue #751 に対応し、3 ページ (`src/pages/index.tsx` / `src/pages/posts/Post.tsx` / `src/pages/anchor.tsx`) の `MILESTONES` 定数に付与された JSDoc のうち、共有コアとなる文面をバイト一致で統一しました。コメントのみの変更で、ランタイム挙動・型・出力 DOM に影響はありません。

docs への移動やコードの集約は行わず、各ページに JSDoc を残す現状の構造 (#546 の局所化方針) を尊重しています。

## 変更内容

- src/pages/index.tsx: `MILESTONES` の JSDoc 共有コア部分を統一文面に揃え、ページ固有情報は保持
- src/pages/posts/Post.tsx: 同上 (共有コアをバイト一致に統一・ページ固有情報は保持)
- src/pages/anchor.tsx: 同上 (共有コアをバイト一致に統一・ページ固有情報は保持)
- 3 ページの JSDoc 共有コアをバイト一致に統一しつつ、各ページ固有の情報は維持
- docs への移動 / コードの集約は行わず、JSDoc を各ページに残す (#546 の局所化を尊重)

## 備考

- コメントのみの変更 (ロジック・型・DOM 出力に変更なし)
- テスト結果:
  - `pnpm test:run`: 1064 件 pass
  - `pnpm lint`: 成功
  - `pnpm build`: 成功
- レビュー済み (レビュワー承認・Devil's Advocate 承認とも取得済み)

Closes #751
