### PR TITLE
refactor: イベント narrowing の堅牢化と Post.tsx 文言定数化

### DIFF
--- a/src/hooks/__tests__/useCodeBlockCopy.test.ts
+++ b/src/hooks/__tests__/useCodeBlockCopy.test.ts
@@ -146,6 +146,30 @@ describe("useCodeBlockCopy", () => {
     });
   });
 
+  it("HTMLElementでないターゲットのクリックでは何も起きない", async () => {
+    container.innerHTML = `
+      <div class="code-block-wrapper">
+        <button class="copy-btn" data-code="test">コピー</button>
+        <pre><code>test</code></pre>
+      </div>
+    `;
+
+    setupHook(container);
+
+    // SVG 要素は HTMLElement ではない（SVGElement）。
+    // instanceof HTMLElement narrowing が null/非要素ターゲットを弾くことを固定する。
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    container.appendChild(svg);
+
+    expect(svg instanceof HTMLElement).toBe(false);
+
+    await act(async () => {
+      svg.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+  });
+
   it("copy-btnクラスを持たない要素のクリックでは何も起きない", async () => {
     container.innerHTML = `
       <div class="code-block-wrapper">

--- a/src/hooks/__tests__/useImageLightbox.test.ts
+++ b/src/hooks/__tests__/useImageLightbox.test.ts
@@ -110,6 +110,30 @@ describe("useImageLightbox", () => {
     expect(result.current.imageAlt).toBe("");
   });
 
+  it("HTMLImageElementでないターゲットのクリックでは反応しない", () => {
+    const { result } = renderHook(() => useImageLightbox(containerRef));
+
+    // SVG の <image> 要素は HTMLImageElement ではない（SVGImageElement）。
+    // instanceof narrowing が tagName 文字列比較ではなく型で判定することを固定する。
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const svgImage = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "image",
+    );
+    svg.appendChild(svgImage);
+    container.appendChild(svg);
+
+    expect(svgImage instanceof HTMLImageElement).toBe(false);
+
+    act(() => {
+      svgImage.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.imageSrc).toBe("");
+    expect(result.current.imageAlt).toBe("");
+  });
+
   it("containerRefがnullの場合にエラーにならない", () => {
     const nullRef: React.RefObject<HTMLElement | null> = { current: null };
 

--- a/src/hooks/useCodeBlockCopy.ts
+++ b/src/hooks/useCodeBlockCopy.ts
@@ -79,7 +79,10 @@ export const useCodeBlockCopy = (
     }
 
     const handleClick = (event: MouseEvent): void => {
-      const target = event.target as HTMLElement;
+      if (!(event.target instanceof HTMLElement)) {
+        return;
+      }
+      const target = event.target;
       if (!target.classList.contains("copy-btn")) {
         return;
       }

--- a/src/hooks/useImageLightbox.ts
+++ b/src/hooks/useImageLightbox.ts
@@ -34,12 +34,12 @@ export const useImageLightbox = (
     }
 
     const handleClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement;
-      if (target.tagName === "IMG") {
-        const imgElement = target as HTMLImageElement;
-        if (imgElement.src) {
-          open(imgElement.src, imgElement.alt || "");
-        }
+      if (!(event.target instanceof HTMLImageElement)) {
+        return;
+      }
+      const imgElement = event.target;
+      if (imgElement.src) {
+        open(imgElement.src, imgElement.alt || "");
       }
     };
 

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -52,6 +52,20 @@ import {
  */
 const MILESTONES: readonly Milestone[] = parseMilestones(milestonesData);
 
+/**
+ * Post ページの記事未検出時 EmptyState の表示文言定数 (Issue #753 7-b)。
+ *
+ * Issue #629 / #694 / #695 のロードマップに沿って、表示文言を JSX 直書きから
+ * ファイル内トップレベル定数に外出しし、HomePage / PostDetailPage / Coordinate /
+ * AnchorPage と方針を揃える。単一ファイル完結のため i18nLiterals.ts ではなく
+ * ファイル内ローカル定数とする (`i18nLiterals.ts` 基準に沿う)。リテラル定数には
+ * `as const` を付与して literal type を温存する。
+ */
+const POST_NOT_FOUND_TITLE = "記事が見つかりません" as const;
+const POST_NOT_FOUND_DESCRIPTION =
+  "お探しの記事は削除されたか、URLが間違っている可能性があります。" as const;
+const POST_NOT_FOUND_ACTION_LABEL = "← 記事一覧に戻る" as const;
+
 const Post = () => {
   const { timestamp } = useParams<{ timestamp: string }>();
   const { post, loading, notFound } = usePost(timestamp);
@@ -61,10 +75,10 @@ const Post = () => {
     return (
       <EmptyState
         icon={FileQuestion}
-        title="記事が見つかりません"
-        description="お探しの記事は削除されたか、URLが間違っている可能性があります。"
+        title={POST_NOT_FOUND_TITLE}
+        description={POST_NOT_FOUND_DESCRIPTION}
         action={{
-          label: "← 記事一覧に戻る",
+          label: POST_NOT_FOUND_ACTION_LABEL,
           href: "/",
         }}
       />


### PR DESCRIPTION
## 概要

Issue #753 の「微小堅牢化・一貫性バケット」対応。レビュワー承認・Devil's Advocate 承認とも取得済み（指摘なし）。

Closes #753

## 変更内容

- **7-a: イベントターゲット narrowing を `instanceof` ベースに置換**
  - `src/hooks/useImageLightbox.ts`: イベントターゲットの `as` 二段アサーションを `instanceof HTMLElement` による narrowing に置換し、実行時の型安全性を向上
  - `src/hooks/useCodeBlockCopy.ts`: 同様に `as` 二段アサーションを `instanceof` narrowing に置換
- **7-b: Post.tsx の EmptyState 文言をファイル内定数に外出し**
  - `src/pages/posts/Post.tsx`: EmptyState の文言を `as const` でファイル内トップレベル定数に外出しし、文言の一貫性を確保
- **Tripwire テスト追加**
  - `src/hooks/__tests__/useImageLightbox.test.ts`: narrowing 挙動の回帰固定テストを追加
  - `src/hooks/__tests__/useCodeBlockCopy.test.ts`: narrowing 挙動の回帰固定テストを追加

## 備考

- `pnpm test:run`: 1066 件 pass
- `pnpm lint`: 成功
- `pnpm build`: 成功
- Tripwire テスト 2 件追加
