### PR TITLE
refactor: tsconfig.api.json で noUncheckedIndexedAccess を有効化

### DIFF
--- a/src/api/__tests__/posts.test.ts
+++ b/src/api/__tests__/posts.test.ts
@@ -94,8 +94,9 @@ describe("createPostsMiddleware", () => {
 
       middleware(req as IncomingMessage, res as ServerResponse, next);
 
-      const [responseBody] = (res.end as ReturnType<typeof vi.fn>).mock
-        .calls[0] ?? [""];
+      const endMock = res.end as ReturnType<typeof vi.fn>;
+      expect(endMock).toHaveBeenCalledOnce();
+      const responseBody = endMock.mock.calls[0]?.[0];
       const result = JSON.parse(responseBody);
       expect(result).toHaveLength(2);
       expect(result.map((p: { id: string }) => p.id)).toEqual(["post", "note"]);

--- a/src/api/__tests__/posts.test.ts
+++ b/src/api/__tests__/posts.test.ts
@@ -94,9 +94,9 @@ describe("createPostsMiddleware", () => {
 
       middleware(req as IncomingMessage, res as ServerResponse, next);
 
-      const result = JSON.parse(
-        (res.end as ReturnType<typeof vi.fn>).mock.calls[0][0],
-      );
+      const [responseBody] = (res.end as ReturnType<typeof vi.fn>).mock
+        .calls[0] ?? [""];
+      const result = JSON.parse(responseBody);
       expect(result).toHaveLength(2);
       expect(result.map((p: { id: string }) => p.id)).toEqual(["post", "note"]);
     });

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -16,12 +16,8 @@
     // (process / Buffer / __dirname 等) を有効化する。
     // ブラウザ向け型 (vitest/globals / @testing-library/jest-dom) は不要なので含めない。
     "types": ["node"],
-    // noUncheckedIndexedAccess は本体 (src) 先行で有効化したため (Issue #747)、
-    // extends 経由でここにも継承される。api 側の有効化は別 Issue (#748) で扱う
-    // 方針のため、継承を打ち消して false に戻し本 Issue のスコープを src に限定する。
-    // #748 で api 側を true 化する際は、この上書き行を削除すること
-    // (削除すれば本体 tsconfig からの true 継承が復活する)。
-    "noUncheckedIndexedAccess": false,
+    // noUncheckedIndexedAccess は本体 tsconfig (Issue #747) で有効化済みで、
+    // extends 経由でここにも true として継承される (Issue #748 で api 側を有効化)。
     // Incremental build (Issue #580): tsconfig.json / tsconfig.test.json /
     // tsconfig.scripts.json と独立した .tsbuildinfo を出力する。
     // include / types が異なるため別ファイルにしないと衝突する。


### PR DESCRIPTION
## 概要

`tsconfig.api.json` で `noUncheckedIndexedAccess` を有効化する (Closes #748)。

本体 (`src`) は Issue #747 で先行有効化済みで、その際 api 側はスコープ外とするため
`tsconfig.api.json` で `noUncheckedIndexedAccess: false` の上書きを入れて継承を打ち消していた。
本 PR でその上書きを削除し、本体 tsconfig からの `true` 継承を復活させて api 側も有効化する。

## 変更内容

- `tsconfig.api.json`: Issue #747 で入れた `noUncheckedIndexedAccess: false` の上書き行を削除し、本体 tsconfig からの `true` 継承を復活。コメントも現状に合わせて更新
- `src/api/__tests__/posts.test.ts`: 有効化により実測されたエラー 1 件を修正。`res.end` の呼び出し検証 (`toHaveBeenCalledOnce`) を `mock.calls[0]?.[0]` のインデックスアクセスより先行させ、退行時の診断性を改善（呼び出し未発生時に JSON.parse の不明瞭なエラーではなく呼び出し回数アサートで落ちる）

## 備考

- 動作確認: `pnpm test:run` 1066 件 pass / `pnpm lint` クリーン / `pnpm build` 成功 / `pnpm type-check:api` 成功
- レビュー・Devil's Advocate レビューとも実施済み（DA 推奨のテスト可読性改善も反映）
