### PR TITLE
refactor: tsconfig.scripts.json で noUncheckedIndexedAccess を有効化

### DIFF
--- a/scripts/__tests__/newPost.test.ts
+++ b/scripts/__tests__/newPost.test.ts
@@ -421,7 +421,7 @@ describe("loadMilestones: milestones.json の読み込み", () => {
     writeFileSync(path, JSON.stringify(data), "utf8");
     const result = loadMilestones(path);
     expect(result).toHaveLength(1);
-    expect(result?.[0].label).toBe("good");
+    expect(result?.[0]?.label).toBe("good");
   });
 
   it("tone が許容値外の要素は除外する", () => {
@@ -433,7 +433,7 @@ describe("loadMilestones: milestones.json の読み込み", () => {
     writeFileSync(path, JSON.stringify(data), "utf8");
     const result = loadMilestones(path);
     expect(result).toHaveLength(1);
-    expect(result?.[0].label).toBe("valid");
+    expect(result?.[0]?.label).toBe("valid");
   });
 });
 

--- a/scripts/newPost.ts
+++ b/scripts/newPost.ts
@@ -393,8 +393,9 @@ export const extractMarkdownTitle = (
   const lines = markdown.split(/\r?\n/);
   for (const line of lines) {
     const match = line.match(/^#\s+(.+?)\s*$/);
-    if (match) {
-      return match[1];
+    const title = match?.[1];
+    if (title !== undefined) {
+      return title;
     }
   }
   return fallbackFileName.replace(/\.md$/, "");
@@ -415,10 +416,10 @@ export const findPreviousPost = (
 ): PreviousPost | undefined => {
   const files = listPostFileNames(datasourcesDir);
   const candidates = files.filter((file) => file < newFileName);
-  if (candidates.length === 0) {
+  const latest = candidates[candidates.length - 1];
+  if (latest === undefined) {
     return undefined;
   }
-  const latest = candidates[candidates.length - 1];
   const publishedAt = inferPublishedAt(latest);
   if (publishedAt === undefined) {
     return undefined;
@@ -444,10 +445,10 @@ export const computeSiteOpeningFallback = (
   publishedAt: string,
 ): Elapsed | undefined => {
   const files = listPostFileNames(datasourcesDir);
-  if (files.length === 0) {
+  const oldest = files[0];
+  if (oldest === undefined) {
     return undefined;
   }
-  const oldest = files[0];
   const oldestIso = inferPublishedAt(oldest);
   if (oldestIso === undefined) {
     return undefined;

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -11,12 +11,8 @@
     // ambient globals (process / Buffer / __dirname 等) を有効化する。
     // scripts/__tests__ が vitest で実行されるため vitest/globals も含める。
     "types": ["node", "vitest/globals"],
-    // noUncheckedIndexedAccess は本体 (src) 先行で有効化したため (Issue #747)、
-    // extends 経由でここにも継承される。scripts 側の有効化は別 Issue (#749) で扱う
-    // 方針のため、継承を打ち消して false に戻し本 Issue のスコープを src に限定する。
-    // #749 で scripts 側を true 化する際は、この上書き行を削除すること
-    // (削除すれば本体 tsconfig からの true 継承が復活する)。
-    "noUncheckedIndexedAccess": false,
+    // noUncheckedIndexedAccess は本体 tsconfig (Issue #747) から extends 経由で
+    // true が継承される (Issue #749 で scripts 側も有効化済み)。
     // Incremental build (Issue #580): tsconfig.json / tsconfig.test.json と独立した
     // .tsbuildinfo を出力する。include が異なるため別ファイルにしないと衝突する。
     "tsBuildInfoFile": "./.tsbuildinfo/tsconfig.scripts.tsbuildinfo"


### PR DESCRIPTION
## 概要

`tsconfig.scripts.json` で `noUncheckedIndexedAccess` を有効化する (Closes #749)。

#747 で scripts 側に入れた `false` 上書きを削除し、本体 tsconfig からの `true` 継承を復活させた。これにより `scripts/` 配下のインデックスアクセスが `T | undefined` として型付けされ、未チェックアクセスがコンパイルエラーになる。`lintTokens` 等の手書き防御ロジックも型レベルで強制されるようになる。

## 変更内容

- `tsconfig.scripts.json`: `noUncheckedIndexedAccess` の `false` 上書き行と関連コメントを削除し、`true` 継承の旨を簡潔に記載
- 着手前実測で露出した型エラー 8 件 (newPost.ts 本体 6 件 / newPost.test.ts 2 件) を非 null アサーション (`!`) を使わずガード / optional chaining で解消
  - `scripts/newPost.ts`:
    - `extractMarkdownTitle`: `match?.[1]` を変数に取り undefined チェック後に return
    - `findPreviousPost`: `candidates.length` チェックを `candidates[last]` の undefined チェックに置換 (振る舞い不変)
    - `computeSiteOpeningFallback`: `files.length` チェックを `files[0]` の undefined チェックに置換 (振る舞い不変)
  - `scripts/__tests__/newPost.test.ts`: `result?.[0].label` を `result?.[0]?.label` へ (optional chaining で undefined narrowing)

## 備考

- テスト結果:
  - `pnpm test:run`: 1066 件 pass
  - `pnpm lint`: 成功
  - `pnpm build`: 成功
  - `type-check:scripts`: 成功
- レビュー済み (指摘なし)
