### PR TITLE
refactor: tsconfig.test.json で noUncheckedIndexedAccess を有効化

### DIFF
--- a/src/components/common/__tests__/Coordinate.allPosts.test.tsx
+++ b/src/components/common/__tests__/Coordinate.allPosts.test.tsx
@@ -277,8 +277,8 @@ describe("Coordinate (実16記事での回帰テスト)", () => {
       // 各 li に fixture どおりの label と日数が含まれる
       for (const [index, row] of expectedRows.entries()) {
         const item = items[index];
-        expect(item.textContent).toContain(row.label);
-        expect(item.textContent).toContain(String(row.daysSince));
+        expect(item?.textContent).toContain(row.label);
+        expect(item?.textContent).toContain(String(row.daysSince));
       }
     });
   });

--- a/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
+++ b/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
@@ -390,8 +390,8 @@ describe("AnchorPage (実16記事での回帰テスト)", () => {
     // 各 span が fixture の tone / テキストと一致する (= 描画順も含めた完全一致)
     for (const [index, row] of expectedRows.entries()) {
       const span = coordinateSpans[index];
-      expect(span.getAttribute("data-tone")).toBe(row.tone);
-      expect(span.textContent).toBe(`${row.label} から ${row.daysSince} 日目`);
+      expect(span?.getAttribute("data-tone")).toBe(row.tone);
+      expect(span?.textContent).toBe(`${row.label} から ${row.daysSince} 日目`);
     }
   };
 

--- a/src/hooks/__tests__/useAdjacentPosts.test.ts
+++ b/src/hooks/__tests__/useAdjacentPosts.test.ts
@@ -57,7 +57,10 @@ describe("findAdjacentPosts", () => {
   });
 
   it("記事が1つだけの場合は両方nullになる", () => {
-    const result = findAdjacentPosts([mockSummaries[0]], "20240103100000");
+    const result = findAdjacentPosts(
+      mockSummaries.slice(0, 1),
+      "20240103100000",
+    );
 
     expect(result.olderPost).toBeNull();
     expect(result.newerPost).toBeNull();

--- a/src/lib/__tests__/anchors.test.ts
+++ b/src/lib/__tests__/anchors.test.ts
@@ -157,7 +157,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0].daysSince).toBe(0);
+      expect(result[0]?.daysSince).toBe(0);
     });
 
     it("複数の節目すべてについて差分日数を返す", () => {
@@ -194,7 +194,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0].label).toBe("過去");
+      expect(result[0]?.label).toBe("過去");
     });
 
     it("全ての節目が publishedAt より後なら空配列を返す", () => {
@@ -333,7 +333,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0].label).toBe("過去-light");
+      expect(result[0]?.label).toBe("過去-light");
     });
   });
 
@@ -347,7 +347,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
         milestones,
       );
 
-      expect(result[0].daysSince).toBe(1);
+      expect(result[0]?.daysSince).toBe(1);
     });
 
     it("年をまたぐ場合も暦日数で計算される (2024-12-31 → 2025-01-01 は 1 日)", () => {
@@ -359,7 +359,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
         milestones,
       );
 
-      expect(result[0].daysSince).toBe(1);
+      expect(result[0]?.daysSince).toBe(1);
     });
 
     it("publishedAt 内の時刻に関係なく日付の差で計算される (00:00 と 23:59 で同じ)", () => {
@@ -372,8 +372,8 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       );
       const night = computeCoordinates("2025-01-10T23:59:59+09:00", milestones);
 
-      expect(morning[0].daysSince).toBe(9);
-      expect(night[0].daysSince).toBe(9);
+      expect(morning[0]?.daysSince).toBe(9);
+      expect(night[0]?.daysSince).toBe(9);
     });
   });
 
@@ -436,7 +436,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0].daysSince).toBe(9);
+      expect(result[0]?.daysSince).toBe(9);
     });
 
     it('Milestone.date が "2025-00-01" のとき、Date.UTC のロールオーバーで 2024-12-01 として解釈される', () => {
@@ -451,7 +451,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0].daysSince).toBe(10);
+      expect(result[0]?.daysSince).toBe(10);
     });
 
     it('Milestone.date が "2025-99-99" のとき、Date.UTC のロールオーバーで 2033-06-07 として解釈される', () => {
@@ -465,7 +465,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0].daysSince).toBe(1);
+      expect(result[0]?.daysSince).toBe(1);
     });
 
     it('Milestone.date が "abc-de-fg" のとき、正規表現で reject されて結果から除外される', () => {
@@ -491,7 +491,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0].daysSince).toBe(1);
+      expect(result[0]?.daysSince).toBe(1);
     });
   });
 
@@ -520,7 +520,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       const result = computeCoordinates(publishedAt, milestones);
 
       expect(result).toHaveLength(1);
-      expect(result[0].daysSince).toBe(0);
+      expect(result[0]?.daysSince).toBe(0);
     });
   });
 });
@@ -728,7 +728,7 @@ describe("型レベル: Coordinate / Elapsed の nominal 化 (Issue #497)", () =
     const first = result[0];
 
     // discriminated union narrowing が効くことを確認
-    if (first.kind === "coordinate") {
+    if (first?.kind === "coordinate") {
       // tone への安全なアクセス
       expect(first.tone).toBe("neutral");
     }

--- a/src/lib/__tests__/anchors.test.ts
+++ b/src/lib/__tests__/anchors.test.ts
@@ -728,6 +728,9 @@ describe("型レベル: Coordinate / Elapsed の nominal 化 (Issue #497)", () =
     const first = result[0];
 
     // discriminated union narrowing が効くことを確認
+    // computeCoordinates が空配列を返す回帰では if ブロックがスキップされ
+    // 内側のアサートが実行されないまま緑になるため、先に first の存在を担保する
+    expect(first).toBeDefined();
     if (first?.kind === "coordinate") {
       // tone への安全なアクセス
       expect(first.tone).toBe("neutral");

--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -566,7 +566,7 @@ const x = 1;
       const result = parseMarkdown(content, "20240101100000");
 
       expect(result.toc).toHaveLength(1);
-      expect(result.toc[0].text).toBe("h3見出し");
+      expect(result.toc[0]?.text).toBe("h3見出し");
     });
 
     it("本文に見出しがない場合はtocが空配列になる", () => {
@@ -617,7 +617,7 @@ const x = 1;
       const result2 = parseMarkdown(content2, "20240102100000");
 
       expect(result2.toc).toHaveLength(1);
-      expect(result2.toc[0].text).toBe("見出しC");
+      expect(result2.toc[0]?.text).toBe("見出しC");
     });
   });
 

--- a/src/lib/__tests__/milestonesSchema.test.ts
+++ b/src/lib/__tests__/milestonesSchema.test.ts
@@ -61,7 +61,7 @@ describe("parseMilestones (lenient)", () => {
     ];
     const result = parseMilestones(input);
     expect(result).toHaveLength(1);
-    expect(result[0].label).toBe("有効");
+    expect(result[0]?.label).toBe("有効");
   });
 
   it("date が文字列でない要素を除外できる", () => {
@@ -71,7 +71,7 @@ describe("parseMilestones (lenient)", () => {
     ];
     const result = parseMilestones(input);
     expect(result).toHaveLength(1);
-    expect(result[0].label).toBe("good");
+    expect(result[0]?.label).toBe("good");
   });
 
   it("date が YYYY-MM-DD 形式でない要素を除外できる", () => {
@@ -83,7 +83,7 @@ describe("parseMilestones (lenient)", () => {
     ];
     const result = parseMilestones(input);
     expect(result).toHaveLength(1);
-    expect(result[0].label).toBe("valid");
+    expect(result[0]?.label).toBe("valid");
   });
 
   it("label が文字列でない要素を除外できる", () => {
@@ -93,7 +93,7 @@ describe("parseMilestones (lenient)", () => {
     ];
     const result = parseMilestones(input);
     expect(result).toHaveLength(1);
-    expect(result[0].label).toBe("valid");
+    expect(result[0]?.label).toBe("valid");
   });
 
   it("label が空文字列の要素を除外できる", () => {
@@ -103,7 +103,7 @@ describe("parseMilestones (lenient)", () => {
     ];
     const result = parseMilestones(input);
     expect(result).toHaveLength(1);
-    expect(result[0].label).toBe("valid");
+    expect(result[0]?.label).toBe("valid");
   });
 
   it("tone が許容値外の要素を除外できる", () => {
@@ -149,7 +149,9 @@ describe("parseMilestones (lenient)", () => {
       label: "extra",
       tone: "neutral",
     });
-    expect("unknown" in result[0]).toBe(false);
+    const first = result[0];
+    expect(first).toBeDefined();
+    expect(first && "unknown" in first).toBe(false);
   });
 });
 
@@ -224,8 +226,8 @@ describe("validateMilestonesStrict (strict)", () => {
     expect(caught).not.toBeNull();
     expect(caught?.message).toContain("index=1");
     expect(caught?.message).toContain("field=tone");
-    expect(caught?.issues[0].index).toBe(1);
-    expect(caught?.issues[0].field).toBe("tone");
+    expect(caught?.issues[0]?.index).toBe(1);
+    expect(caught?.issues[0]?.field).toBe("tone");
   });
 
   it("MilestoneValidationError は name に固有値を持つ", () => {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -14,12 +14,9 @@
     // node は src/api/__tests__ や src/lib/__tests__ の一部が node:fs / process /
     // __dirname 等を参照するため必要 (Issue #667)。
     "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client", "node"],
-    // noUncheckedIndexedAccess は本体 (src) 先行で有効化したため (Issue #747)、
-    // extends 経由でここにも継承される。test 側の有効化は別 Issue (#750) で扱う
-    // 方針のため、継承を打ち消して false に戻し本 Issue のスコープを src に限定する。
-    // #750 で test 側を true 化する際は、この上書き行を削除すること
-    // (削除すれば本体 tsconfig からの true 継承が復活する)。
-    "noUncheckedIndexedAccess": false,
+    // noUncheckedIndexedAccess は本体 tsconfig (src) で有効化済み (Issue #747)。
+    // test 側も Issue #750 で true 化し、ここでの false 上書きを撤去したため、
+    // extends 経由で本体からの true 継承がそのまま適用される。
     // テストでは setup 用の helper 変数等で意図的に未使用なものを許容する
     "noUnusedLocals": false,
     "noUnusedParameters": false,


### PR DESCRIPTION
## 概要

`tsconfig.test.json` で `noUncheckedIndexedAccess` を有効化する。Issue #750 対応で、影響範囲が最大かつ最後の対象となる test 系 tsconfig を真に有効化し、子 config の `false` 上書きを全廃する。

#747 で各 tsconfig を段階導入した際に test 系へ入れていた最後の `false` 上書きを削除し、ルートからの `true` 継承を復活させた。これにより `src` / `api` / `scripts` / `test` の全 tsconfig で `noUncheckedIndexedAccess: true` となり、子 config による `false` 上書きが全廃された。

## 変更内容

- `tsconfig.test.json`: `noUncheckedIndexedAccess: false` の上書きを削除し、ルートからの `true` 継承を復活
- 継承復活で顕在化した型エラー実測 29 件 / 6 ファイルを `!`（non-null assertion）を使わずに修正
  - querySelectorAll の要素アクセスを optional chaining 化（components テスト）
  - 単一要素配列の生成を `slice` に変更（useAdjacentPosts テスト）
  - 必要箇所は事前 assert / optional chaining で narrowing
- `anchors.test.ts`: union narrowing アサートに `toBeDefined` ガードを追加し、空配列に縮退した際の回帰検知漏れを防止

## 備考

- テスト結果: `pnpm test:run` 1066 件 pass / lint pass / build 全 type-check 完走
- レビュワー承認・Devil's Advocate 承認とも取得済み（DA 任意改善の `toBeDefined` ガード追加も対応済み）

Closes #750
