### PR TITLE
chore: dependabot に playwright グループを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,11 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
+      playwright:
+        patterns:
+          - "playwright"
+          - "@playwright/test"
+          - "@axe-core/playwright"
 
   - package-ecosystem: "github-actions"
     directory: ".github/workflows/"


### PR DESCRIPTION
## 概要

dependabot の npm エコシステムに `playwright` グループを追加し、`playwright` / `@playwright/test` / `@axe-core/playwright` を常に同一 PR で同時更新させる。

## 変更内容

- `.github/dependabot.yml`: `playwright` グループ (`playwright` / `@playwright/test` / `@axe-core/playwright`) を追加

## 背景

`playwright` と `@playwright/test` は完全一致バージョンでの同時更新が前提で、ずれると `.bin/playwright` が古い方に解決され、実行時に `two different versions of @playwright/test` で e2e/axe テストが破綻する。グループ未設定のため dependabot が両者を別々の PR (#771 / #773) に分割し、各 PR 単独ではバージョン不整合で CI が失敗していた。本グループ化により、今後この 2 つ (+ playwright-core を peer 共有する `@axe-core/playwright`) は 1 つの PR で同時更新される。

マージ後、既存の #771 / #773 は dependabot により `playwright` グループの 1 PR として作り直される見込み。

## 備考

dependabot 設定変更のため、Anchor 型とは無関係。