### PR TITLE
chore: packageManager で pnpm を 11.2.2 に固定し libc lockfile ノイズを根治

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.5
-        with:
-          version: 11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.5
-        with:
-          version: 11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.5
-        with:
-          version: 11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -79,8 +79,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.5
-        with:
-          version: 11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.5
-        with:
-          version: 11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.5
-        with:
-          version: 11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@11.2.2",
   "scripts": {
     "dev": "panda --watch & vite",
     "build": "pnpm run lint && pnpm run test:run && pnpm run type-check && pnpm run type-check:api && pnpm run type-check:scripts && panda && tsc && tsc --project tsconfig.api.json && vite build",


### PR DESCRIPTION
## 概要

`package.json` の `packageManager` フィールドで pnpm を `11.2.2` に固定し、dependabot / ローカル / CI で使う pnpm を統一する。これにより dependabot PR の lockfile に混入していた `libc:` メタデータ削除ノイズを根治する。

## 変更内容

- `package.json`: `packageManager: "pnpm@11.2.2"` を追加
- `.github/workflows/{a11y,ci,deploy,panda-hash-regression,playwright,test}.yml`: `pnpm/action-setup` の `with: version: 11` を削除（`packageManager` から版を解決）

## 背景

dependabot PR の lockfile に、更新対象と無関係な native binary（`@biomejs/cli-linux-*` / `@rolldown/binding-linux-*` / `lightningcss-linux-*`）の `libc:` 行（約18行）が削除されるノイズが全 PR で発生していた。原因は dependabot 実行環境の pnpm がリポジトリ標準と異なる版で lockfile を再生成し `libc` フィールドを出力しないため。`packageManager` で版を固定することで dependabot・ローカル・CI を同一 pnpm に揃え、ノイズの発生源を断つ。

`pnpm/action-setup` は `with: version` と `packageManager` フィールドが併存すると競合エラーになるため、`version: 11` 入力を削除して `packageManager` から解決させる（実行される pnpm は従来どおり 11 系で、CI ランタイムに変化なし）。

## 検証

ローカル（corepack 経由 pnpm 11.2.2）で確認済み:

- `pnpm install --lockfile-only` で再生成 → **`pnpm-lock.yaml` に差分ゼロ**（libc 行 20 個を維持。10.30.1 / 11.2.2 とも同一形式）
- `pnpm install --frozen-lockfile` 成功
- `pnpm run build`（lint + test:run + type-check×3 + panda + tsc + tsc(api) + vite build）すべて成功

## 備考

- dependabot 設定変更系の PR のため、Anchor 型とは無関係。
- 既存の #768（`pnpm/action-setup` 6.0.5→6.0.8）と `uses:` 行が隣接するため、どちらかが先にマージされた場合はもう一方で軽微なコンフリクト解消が必要になる可能性がある。