### PR TITLE
feat: React 19 Document Metadata でページ別 title/meta を追加

### DIFF
--- a/src/components/common/TableOfContents.tsx
+++ b/src/components/common/TableOfContents.tsx
@@ -99,35 +99,33 @@ const handleSmoothScroll = (
   }
 };
 
-export const TableOfContents: React.FC<TableOfContentsProps> = React.memo(
-  ({ toc }) => {
-    if (toc.length === 0) {
-      return null;
-    }
+export const TableOfContents = React.memo(({ toc }: TableOfContentsProps) => {
+  if (toc.length === 0) {
+    return null;
+  }
 
-    return (
-      <Disclosure defaultOpen>
-        <div className={containerStyle} data-token-border="border.subtle">
-          <DisclosureButton className={buttonStyle}>目次</DisclosureButton>
-          <DisclosurePanel className={panelStyle}>
-            <ul className={listStyle}>
-              {toc.map((item) => (
-                <li key={item.id} className={listItemStyle}>
-                  <a
-                    href={`#${item.id}`}
-                    onClick={handleSmoothScroll}
-                    className={`${linkBaseStyle} ${item.level === 3 ? indentedLinkStyle : ""}`}
-                  >
-                    {item.text}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </DisclosurePanel>
-        </div>
-      </Disclosure>
-    );
-  },
-);
+  return (
+    <Disclosure defaultOpen>
+      <div className={containerStyle} data-token-border="border.subtle">
+        <DisclosureButton className={buttonStyle}>目次</DisclosureButton>
+        <DisclosurePanel className={panelStyle}>
+          <ul className={listStyle}>
+            {toc.map((item) => (
+              <li key={item.id} className={listItemStyle}>
+                <a
+                  href={`#${item.id}`}
+                  onClick={handleSmoothScroll}
+                  className={`${linkBaseStyle} ${item.level === 3 ? indentedLinkStyle : ""}`}
+                >
+                  {item.text}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </DisclosurePanel>
+      </div>
+    </Disclosure>
+  );
+});
 
 TableOfContents.displayName = "TableOfContents";

--- a/src/components/pages/AnchorPage.tsx
+++ b/src/components/pages/AnchorPage.tsx
@@ -6,7 +6,7 @@ import {
   inferPublishedAt,
   type Milestone,
 } from "../../lib/anchors";
-import { UNTITLED_POST } from "../../lib/i18nLiterals";
+import { SITE_NAME, UNTITLED_POST } from "../../lib/i18nLiterals";
 import type { PostSummary } from "../../lib/markdown";
 
 interface AnchorPageProps {
@@ -262,6 +262,41 @@ const skippedNoteStyles = css({
 const ANCHOR_PAGE_HEADING = "Anchor" as const;
 const ANCHOR_PAGE_DESCRIPTION =
   "登録された節目と、各記事の座標を一覧表示します。" as const;
+
+/**
+ * `/anchor` ルートの Document Metadata 文言 (React 19 ネイティブ metadata)。
+ *
+ * - title は `Anchor | Lazy Note` をテンプレートリテラル 1 文字列で構築する
+ *   (React 19 の `<title>` は単一テキスト子のみ許容)。本体の `Anchor` は
+ *   ページ見出し `ANCHOR_PAGE_HEADING` と同一語彙だが、`<title>` 文言は
+ *   表示見出しとは別の関心事 (タブ / 検索結果 / 共有カードの文言) なので
+ *   サフィックス込みの専用定数として持つ。
+ * - description は運用画面の概要をページ説明文と揃える (`ANCHOR_PAGE_DESCRIPTION`)。
+ */
+const ANCHOR_META_TITLE = `${ANCHOR_PAGE_HEADING} | ${SITE_NAME}` as const;
+const ANCHOR_META_DESCRIPTION = ANCHOR_PAGE_DESCRIPTION;
+
+/**
+ * `/anchor` ルートの Document Metadata (React 19 ネイティブ metadata)。
+ *
+ * **1 ルート 1 タイトル**: 本ページが描画する `<title>` はこの 1 つのみ。
+ * `<Routes>` は同時に 1 ルートしかマウントしないため、`<Transition
+ * appear={false}>` で旧 / 新ページ DOM が一時共存しても React ツリー上は
+ * 常に 1 ページ分の `<title>` しか存在しない。
+ *
+ * `og:*` は最小限 (title / description / type / site_name) を添える。
+ * Anchor は記事一覧ではなく運用ビューなので `og:type` は `website`。
+ */
+const AnchorPageMetadata = () => (
+  <>
+    <title>{ANCHOR_META_TITLE}</title>
+    <meta name="description" content={ANCHOR_META_DESCRIPTION} />
+    <meta property="og:title" content={ANCHOR_META_TITLE} />
+    <meta property="og:description" content={ANCHOR_META_DESCRIPTION} />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content={SITE_NAME} />
+  </>
+);
 const ANCHOR_MILESTONES_SECTION_HEADING = "節目一覧" as const;
 const ANCHOR_MILESTONES_LIST_ARIA_LABEL = "節目一覧" as const;
 const ANCHOR_POSTS_SECTION_HEADING = "各記事の座標" as const;
@@ -349,6 +384,9 @@ export const AnchorPage = memo(({ posts, milestones }: AnchorPageProps) => {
 
   return (
     <div className={containerStyles}>
+      {/* React 19 ネイティブ Document Metadata。<head> へ hoist される。
+          本ページが描画する <title> はこの 1 つだけ (1 ルート 1 タイトル)。 */}
+      <AnchorPageMetadata />
       <div className={sectionGapStyles}>
         <div>
           <h1 className={pageHeadingStyles}>{ANCHOR_PAGE_HEADING}</h1>

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import { css } from "../../../styled-system/css";
+import { SITE_NAME } from "../../lib/i18nLiterals";
 import type { PostSummary } from "../../lib/markdown";
 import type { ResurfacedEntry } from "../../lib/resurface";
 import { BentoCard } from "../atoms/BentoCard";
@@ -22,6 +23,49 @@ const HOMEPAGE_EMPTY_STATE_DESCRIPTION =
   "まもなく素晴らしい記事が公開される予定です。創造性に満ちたコンテンツをお届けします。" as const;
 const HOMEPAGE_BENTO_ARIA_LABEL = "注目の記事" as const;
 const HOMEPAGE_INDEX_HEADING = "Index" as const;
+
+/**
+ * `/` ルートの Document Metadata 文言 (React 19 ネイティブ metadata)。
+ *
+ * トップページは `${SITE_NAME}` のみのシンプルな title とする (記事一覧の
+ * ハブであり個別の主題を持たないため)。description はサイト全体の説明を
+ * `index.html` の静的 `<meta>` と揃える。これらは単一ファイルで完結する
+ * 文言なので、ファイル内 `as const` 定数に閉じる (CLAUDE.md i18nLiterals 基準)。
+ */
+const HOMEPAGE_META_TITLE = SITE_NAME;
+const HOMEPAGE_META_DESCRIPTION =
+  "Lazy Note - シンプルで読みやすいブログプラットフォーム。日々の思考やアイデアを気軽に記録・共有できます。" as const;
+
+/**
+ * `/` ルートの Document Metadata (React 19 ネイティブ metadata)。
+ *
+ * 設計上の caveat (タスク指示):
+ * - **1 ルート 1 タイトル**: 本ページが描画する `<title>` はこの 1 つのみ。
+ *   `<Routes>` は同時に 1 ルートしかマウントしないため、View Transition の
+ *   `<Transition appear={false}>` で旧 / 新ページ DOM が一時共存しても、React
+ *   ツリー上は常に 1 ページ分の `<title>` しか存在しない (= 複数 `<title>` が
+ *   同時に hoist されない)。本コンポーネントは EmptyState 分岐でも通常分岐でも
+ *   この共通フラグメントを最上位に 1 度だけ描画する。
+ * - **title はテンプレートリテラル 1 文字列**: React 19 の `<title>` は単一の
+ *   テキスト子のみを許容する (配列 / 複数ノードは警告)。本ページは
+ *   `HOMEPAGE_META_TITLE` (= `SITE_NAME`) の 1 文字列を直接渡す。
+ * - **静的フォールバック**: `index.html` の `<title>Lazy Note</title>` は初期
+ *   描画 (JS 評価前 / loading 中) のフォールバックとして残す。React マウント後
+ *   は本フラグメントが `<head>` を上書きする。
+ *
+ * `og:*` はトップページの共有時カードのために最小限 (title / description /
+ * type) を添える。`og:site_name` も `SITE_NAME` を参照する。
+ */
+const HomePageMetadata = () => (
+  <>
+    <title>{HOMEPAGE_META_TITLE}</title>
+    <meta name="description" content={HOMEPAGE_META_DESCRIPTION} />
+    <meta property="og:title" content={HOMEPAGE_META_TITLE} />
+    <meta property="og:description" content={HOMEPAGE_META_DESCRIPTION} />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content={SITE_NAME} />
+  </>
+);
 
 interface HomePageProps {
   posts: PostSummary[];
@@ -210,6 +254,9 @@ export const HomePage = memo(
     if (posts.length === 0) {
       return (
         <div className={containerStyles}>
+          {/* Document Metadata は EmptyState 分岐でも同一文言を 1 度だけ描画する
+              (= ルートとして常に 1 つの <title> を保証する)。 */}
+          <HomePageMetadata />
           <EmptyState
             icon={FileText}
             title={HOMEPAGE_EMPTY_STATE_TITLE}
@@ -221,13 +268,19 @@ export const HomePage = memo(
 
     return (
       <div className={containerStyles}>
+        {/* React 19 ネイティブ Document Metadata。<head> へ hoist される。
+            本ページが描画する <title> はこの 1 つだけ (1 ルート 1 タイトル)。 */}
+        <HomePageMetadata />
         <div className={sectionGapStyles}>
           {/* Featured: 最新 1 記事 */}
           {featured && <FeaturedCard post={featured} />}
 
           {/* Bento: 2-7 記事目 */}
           {bentoPosts.length > 0 && (
-            <section className={bentoGridStyles} aria-label={HOMEPAGE_BENTO_ARIA_LABEL}>
+            <section
+              className={bentoGridStyles}
+              aria-label={HOMEPAGE_BENTO_ARIA_LABEL}
+            >
               {bentoPosts.map((post, idx) => (
                 <BentoCard key={post.id} post={post} size={bentoSizes[idx]} />
               ))}

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -3,7 +3,7 @@ import { css } from "../../../styled-system/css";
 import { useCodeBlockCopy } from "../../hooks/useCodeBlockCopy";
 import { useImageLightbox } from "../../hooks/useImageLightbox";
 import { inferPublishedAt, type Milestone } from "../../lib/anchors";
-import { UNTITLED_POST } from "../../lib/i18nLiterals";
+import { SITE_NAME, UNTITLED_POST } from "../../lib/i18nLiterals";
 import type { Post, PostSummary } from "../../lib/markdown";
 import { sanitizePostHtml } from "../../lib/sanitize";
 import { buildPostHeroTransitionName } from "../../lib/viewTransition";
@@ -28,6 +28,57 @@ import { TableOfContents } from "../common/TableOfContents";
 //   再度分離を検討する (現時点では YAGNI)。
 const POST_DETAIL_NAV_ARIA_LABEL = "ページナビゲーション" as const;
 const POST_DETAIL_BACK_TO_TOP_LABEL = "← TOPに戻る" as const;
+
+/**
+ * `/posts/:timestamp` ルートの `<title>` を組み立てる純粋関数
+ * (React 19 ネイティブ metadata)。
+ *
+ * 設計上の caveat (タスク指示):
+ * - **title はテンプレートリテラル 1 文字列**: `${記事タイトル} | ${SITE_NAME}`
+ *   を 1 本のテンプレートリテラルとして返す。React 19 の `<title>` は単一の
+ *   テキスト子しか許容しないため、`{post.title}` と区切り文字を別ノードに
+ *   分けず 1 文字列に連結する。
+ * - **未設定タイトルのフォールバック**: `post.title` が空文字のときは
+ *   `UNTITLED_POST` (= 本文表示の H1 と同じフォールバック) を採用し、
+ *   `<title>` も `無題の記事 | Lazy Note` と揃える。
+ *
+ * ※ ロード前 / 記事未検出時の `<title>` は本コンポーネントではなく呼び出し側
+ *   (`src/pages/posts/Post.tsx`) が担う (PostDetailPage は post が解決した後に
+ *   のみマウントされるため)。
+ */
+const buildPostDetailTitle = (title: string): string =>
+  `${title || UNTITLED_POST} | ${SITE_NAME}`;
+
+/**
+ * `/posts/:timestamp` ルートの Document Metadata (React 19 ネイティブ metadata)。
+ *
+ * - title: `${記事タイトル} | Lazy Note` (`buildPostDetailTitle`)。
+ * - description: 記事の `excerpt` (抜粋) を使う。空のときは `<meta>` 自体を
+ *   出さない (空 description はクローラに無意味なため)。
+ * - og:type は記事ページなので `article`。og:title / og:description は
+ *   `<title>` / description と揃える。og:site_name は `SITE_NAME`。
+ *
+ * **1 ルート 1 タイトル**: 本ページが描画する `<title>` はこの 1 つのみ。
+ * `<Routes>` は同時に 1 ルートしかマウントしないため、`<Transition
+ * appear={false}>` で旧 / 新ページ DOM が一時共存しても React ツリー上は
+ * 常に 1 ページ分の `<title>` しか存在しない。
+ */
+const PostDetailMetadata = ({ post }: { post: Post }) => {
+  const title = buildPostDetailTitle(post.title);
+  const description = post.excerpt;
+  return (
+    <>
+      <title>{title}</title>
+      {description ? <meta name="description" content={description} /> : null}
+      <meta property="og:title" content={title} />
+      {description ? (
+        <meta property="og:description" content={description} />
+      ) : null}
+      <meta property="og:type" content="article" />
+      <meta property="og:site_name" content={SITE_NAME} />
+    </>
+  );
+};
 
 interface PostDetailPageProps {
   post: Post;
@@ -88,6 +139,10 @@ export const PostDetailPage = ({
   const publishedAt = inferPublishedAt(post.id);
   return (
     <>
+      {/* React 19 ネイティブ Document Metadata。<head> へ hoist される。
+          本ページが描画する <title> はこの 1 つだけ (1 ルート 1 タイトル)。 */}
+      <PostDetailMetadata post={post} />
+
       {/* Navigation */}
       <nav
         aria-label={POST_DETAIL_NAV_ARIA_LABEL}

--- a/src/components/pages/__tests__/AnchorPage.test.tsx
+++ b/src/components/pages/__tests__/AnchorPage.test.tsx
@@ -446,4 +446,42 @@ describe("AnchorPage", () => {
       expect(items[2]).toHaveAttribute("data-tone", "light");
     });
   });
+
+  describe("Document Metadata (React 19 ネイティブ metadata)", () => {
+    it("ページ名とサイト名を連結した document.title にできる", () => {
+      render(
+        <MemoryRouter>
+          <AnchorPage posts={basePosts} milestones={baseMilestones} />
+        </MemoryRouter>,
+      );
+
+      // `Anchor | Lazy Note` 形式 (テンプレートリテラル 1 文字列)。
+      expect(document.title).toBe("Anchor | Lazy Note");
+    });
+
+    it("description メタタグを head に 1 つだけ出力できる", () => {
+      render(
+        <MemoryRouter>
+          <AnchorPage posts={basePosts} milestones={baseMilestones} />
+        </MemoryRouter>,
+      );
+
+      const metas = document.head.querySelectorAll('meta[name="description"]');
+      expect(metas).toHaveLength(1);
+      expect(metas[0]?.getAttribute("content")).toBe(
+        "登録された節目と、各記事の座標を一覧表示します。",
+      );
+    });
+
+    it("ページ最上位で title を 1 つだけ描画する (複数 title を hoist しない)", () => {
+      // View Transition 共存検証: 1 ルート 1 タイトルの設計確認。
+      render(
+        <MemoryRouter>
+          <AnchorPage posts={basePosts} milestones={baseMilestones} />
+        </MemoryRouter>,
+      );
+
+      expect(document.head.querySelectorAll("title")).toHaveLength(1);
+    });
+  });
 });

--- a/src/components/pages/__tests__/HomePage.test.tsx
+++ b/src/components/pages/__tests__/HomePage.test.tsx
@@ -473,4 +473,93 @@ describe("HomePage", () => {
       expect(text).not.toMatch(buildPulseForbiddenVocabRegex());
     });
   });
+
+  describe("Document Metadata (React 19 ネイティブ metadata)", () => {
+    it("マウント時に document.title をサイト名にできる", () => {
+      render(
+        <MemoryRouter>
+          <HomePage
+            posts={mockPosts}
+            currentPage={1}
+            totalPages={1}
+            onPageChange={mockOnPageChange}
+          />
+        </MemoryRouter>,
+      );
+
+      // 期待値リテラルは i18nLiterals.SITE_NAME を import せず直書きする
+      // (期待値共有による同義反復 / regression 検知不能を避ける方針)。
+      expect(document.title).toBe("Lazy Note");
+    });
+
+    it("記事ゼロ件 (EmptyState) でも document.title をサイト名にできる", () => {
+      render(
+        <MemoryRouter>
+          <HomePage
+            posts={[]}
+            currentPage={1}
+            totalPages={1}
+            onPageChange={mockOnPageChange}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(document.title).toBe("Lazy Note");
+    });
+
+    it("description メタタグを head に 1 つだけ出力できる", () => {
+      render(
+        <MemoryRouter>
+          <HomePage
+            posts={mockPosts}
+            currentPage={1}
+            totalPages={1}
+            onPageChange={mockOnPageChange}
+          />
+        </MemoryRouter>,
+      );
+
+      const metas = document.head.querySelectorAll('meta[name="description"]');
+      expect(metas).toHaveLength(1);
+      expect(metas[0]?.getAttribute("content")).toBe(
+        "Lazy Note - シンプルで読みやすいブログプラットフォーム。日々の思考やアイデアを気軽に記録・共有できます。",
+      );
+    });
+
+    it("og:type を website にできる", () => {
+      render(
+        <MemoryRouter>
+          <HomePage
+            posts={mockPosts}
+            currentPage={1}
+            totalPages={1}
+            onPageChange={mockOnPageChange}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(
+        document.head
+          .querySelector('meta[property="og:type"]')
+          ?.getAttribute("content"),
+      ).toBe("website");
+    });
+
+    it("ページ最上位で title を 1 つだけ描画する (複数 title を hoist しない)", () => {
+      // View Transition 共存検証: 1 ルート 1 タイトルの設計確認。
+      // HomePage を 1 度マウントしたとき head の <title> は常に 1 つ。
+      render(
+        <MemoryRouter>
+          <HomePage
+            posts={mockPosts}
+            currentPage={1}
+            totalPages={1}
+            onPageChange={mockOnPageChange}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(document.head.querySelectorAll("title")).toHaveLength(1);
+    });
+  });
 });

--- a/src/components/pages/__tests__/PostDetailPage.test.tsx
+++ b/src/components/pages/__tests__/PostDetailPage.test.tsx
@@ -619,4 +619,110 @@ describe("PostDetailPage", () => {
       expect(results).toHaveNoViolations();
     });
   });
+
+  describe("Document Metadata (React 19 ネイティブ metadata)", () => {
+    it("記事タイトルとサイト名を連結した document.title にできる", () => {
+      render(
+        <MemoryRouter>
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
+        </MemoryRouter>,
+      );
+
+      // `${記事タイトル} | Lazy Note` 形式 (テンプレートリテラル 1 文字列)。
+      expect(document.title).toBe("テスト記事タイトル | Lazy Note");
+    });
+
+    it("タイトル未設定の記事は無題フォールバックを連結した document.title にできる", () => {
+      const postWithoutTitle: Post = { ...mockPost, title: "" };
+      render(
+        <MemoryRouter>
+          <PostDetailPage
+            post={postWithoutTitle}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(document.title).toBe("無題の記事 | Lazy Note");
+    });
+
+    it("description メタタグに記事の抜粋を出力できる", () => {
+      render(
+        <MemoryRouter>
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
+        </MemoryRouter>,
+      );
+
+      const metas = document.head.querySelectorAll('meta[name="description"]');
+      expect(metas).toHaveLength(1);
+      expect(metas[0]?.getAttribute("content")).toBe(
+        "これはテスト記事の内容です。追加のコンテンツ",
+      );
+    });
+
+    it("抜粋が空の記事では description メタタグを出力しない", () => {
+      const postWithoutExcerpt: Post = { ...mockPost, excerpt: "" };
+      render(
+        <MemoryRouter>
+          <PostDetailPage
+            post={postWithoutExcerpt}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(
+        document.head.querySelectorAll('meta[name="description"]'),
+      ).toHaveLength(0);
+    });
+
+    it("og:type を article にできる", () => {
+      render(
+        <MemoryRouter>
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(
+        document.head
+          .querySelector('meta[property="og:type"]')
+          ?.getAttribute("content"),
+      ).toBe("article");
+    });
+
+    it("ページ最上位で title を 1 つだけ描画する (複数 title を hoist しない)", () => {
+      // View Transition 共存検証: 1 ルート 1 タイトルの設計確認。
+      render(
+        <MemoryRouter>
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(document.head.querySelectorAll("title")).toHaveLength(1);
+    });
+  });
 });

--- a/src/lib/i18nLiterals.ts
+++ b/src/lib/i18nLiterals.ts
@@ -40,6 +40,23 @@
 export const UNTITLED_POST = "無題の記事" as const;
 
 /**
+ * サイト名。React 19 ネイティブ Document Metadata で各ページが描画する
+ * `<title>` のサフィックス (`... | Lazy Note`) や `og:site_name` に使用する。
+ *
+ * 横串集約の根拠 (CLAUDE.md「横串で散らばっている文言のみここに置く」):
+ * - `index.html` の静的 `<title>Lazy Note</title>` (初期フォールバック) と
+ *   HomePage / PostDetailPage / AnchorPage の per-page title サフィックスで
+ *   同一文言を参照するため、単一ファイル局所定数ではなく横串定数とする。
+ * - 各ページ固有の title 本体や description は単一ファイルで完結するため、
+ *   従来どおり各コンポーネント内の `as const` 定数に閉じる。
+ *
+ * テストファイルからは **import しない** (`UNTITLED_POST` と同方針: 期待値
+ * リテラルを共有すると同義反復になり、文言変更時の regression を検知
+ * できなくなるため)。
+ */
+export const SITE_NAME = "Lazy Note" as const;
+
+/**
  * 著者名未設定の記事を表示する際のフォールバック文言 (Issue #706 / PR #711 follow-up)。
  *
  * 参照元 (2 箇所):

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -10,6 +10,7 @@ import { PostDetailPage } from "../../components/pages/PostDetailPage";
 import { useAdjacentPosts } from "../../hooks/useAdjacentPosts";
 import { usePost } from "../../hooks/usePost";
 import type { Milestone } from "../../lib/anchors";
+import { SITE_NAME } from "../../lib/i18nLiterals";
 import { parseMilestones } from "../../lib/milestonesSchema";
 import {
   fadeInEnter,
@@ -66,6 +67,23 @@ const POST_NOT_FOUND_DESCRIPTION =
   "お探しの記事は削除されたか、URLが間違っている可能性があります。" as const;
 const POST_NOT_FOUND_ACTION_LABEL = "← 記事一覧に戻る" as const;
 
+/**
+ * 記事未検出時の `<title>` 文言 (React 19 ネイティブ metadata)。
+ *
+ * PostDetailPage が描画する `${記事タイトル} | Lazy Note` と同じサフィックス
+ * 体系で、未検出 EmptyState 経路でもブラウザタブ / 共有カードに何のページか
+ * 伝わるようにする。テンプレートリテラル 1 文字列で構築する (React 19 の
+ * `<title>` は単一テキスト子のみ許容)。
+ *
+ * **ロード前 (loading 中) はあえて `<title>` を描画しない**: SPA 内遷移では
+ * 直前ページの `<title>` がそのまま残り、初回ロード時は `index.html` の静的
+ * `<title>Lazy Note</title>` (初期フォールバック) が効く。loading 用の
+ * 専用タイトルを足すと一瞬チラつくため、解決後 (記事 or 未検出) に初めて
+ * `<title>` を確定させる方針とする。
+ */
+const POST_NOT_FOUND_DOCUMENT_TITLE =
+  `${POST_NOT_FOUND_TITLE} | ${SITE_NAME}` as const;
+
 const Post = () => {
   const { timestamp } = useParams<{ timestamp: string }>();
   const { post, loading, notFound } = usePost(timestamp);
@@ -73,15 +91,21 @@ const Post = () => {
 
   if (notFound || (!loading && !post)) {
     return (
-      <EmptyState
-        icon={FileQuestion}
-        title={POST_NOT_FOUND_TITLE}
-        description={POST_NOT_FOUND_DESCRIPTION}
-        action={{
-          label: POST_NOT_FOUND_ACTION_LABEL,
-          href: "/",
-        }}
-      />
+      <>
+        {/* React 19 ネイティブ Document Metadata。未検出時もタブ文言を確定
+            させる (1 ルート 1 タイトル。EmptyState は単独描画なので他の
+            <title> と共存しない)。 */}
+        <title>{POST_NOT_FOUND_DOCUMENT_TITLE}</title>
+        <EmptyState
+          icon={FileQuestion}
+          title={POST_NOT_FOUND_TITLE}
+          description={POST_NOT_FOUND_DESCRIPTION}
+          action={{
+            label: POST_NOT_FOUND_ACTION_LABEL,
+            href: "/",
+          }}
+        />
+      </>
     );
   }
 

--- a/src/pages/posts/__tests__/Post.test.tsx
+++ b/src/pages/posts/__tests__/Post.test.tsx
@@ -84,6 +84,27 @@ describe("Post", () => {
     expect(backLink).toHaveAttribute("href", "/");
   });
 
+  it("記事が見つからない場合は document.title を未検出フォールバックにできる", () => {
+    // React 19 ネイティブ metadata: 未検出 EmptyState 経路でも
+    // `記事が見つかりません | Lazy Note` をタブ文言に確定させる。
+    vi.mocked(usePost).mockReturnValue({
+      post: null,
+      loading: false,
+      notFound: true,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/posts/123"]}>
+        <Routes>
+          <Route path="/posts/:timestamp" element={<Post />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(document.title).toBe("記事が見つかりません | Lazy Note");
+  });
+
   it("記事が存在する場合はPostDetailPageが表示される", () => {
     vi.mocked(usePost).mockReturnValue({
       post: mockPost,


### PR DESCRIPTION
## 概要

`react` / `react-dom 19.2.6` のネイティブ Document Metadata を活用し、これまで全ページ共通だった `<title>` / `<meta>` をページ別に出力する（外部ライブラリ不要）。あわせてコードベースに 1 箇所だけ残っていた `React.FC` を除去する。

## 変更内容

- `src/components/pages/HomePage.tsx` / `PostDetailPage.tsx` / `AnchorPage.tsx`, `src/pages/posts/Post.tsx`: per-page の `<title>` / `<meta name="description">` / og:* を描画。title はテンプレートリテラル1文字列・1ルート1タイトルを厳守し、記事未検出・excerpt 空のフォールバックを実装
- `src/lib/i18nLiterals.ts`: 横串で参照する `SITE_NAME` を追加
- `src/components/common/TableOfContents.tsx`: `React.FC<Props>` を props 直接型注釈へ（`React.memo` 維持）
- 各ページのテストに title/meta の描画と「1ルート1タイトル」検証を追加

## 備考

- View Transition 共存は「Routes は常に1ルートのみマウント」を実機 probe で確証し、各テストで `querySelectorAll("title").length === 1` を担保
- `index.html` の静的 title は初期フォールバックとして温存
- `type-check` 全種 / `test:run`（1081 passed）green
