### PR TITLE
refactor: クリック系テストを fireEvent から userEvent に移行

### DIFF
--- a/src/components/atoms/__tests__/Button.test.tsx
+++ b/src/components/atoms/__tests__/Button.test.tsx
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { Button } from "../Button";
 
@@ -17,12 +18,13 @@ describe("Button", () => {
     ).toBeInTheDocument();
   });
 
-  it("クリックできる", () => {
+  it("クリックできる", async () => {
+    const user = userEvent.setup();
     const handleClick = vi.fn();
     render(<Button onClick={handleClick}>Click me</Button>);
 
     const button = screen.getByRole("button", { name: "Click me" });
-    fireEvent.click(button);
+    await user.click(button);
 
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
@@ -34,7 +36,8 @@ describe("Button", () => {
     expect(button).toBeDisabled();
   });
 
-  it("disabledの場合、クリックイベントが発火しない", () => {
+  it("disabledの場合、クリックイベントが発火しない", async () => {
+    const user = userEvent.setup();
     const handleClick = vi.fn();
     render(
       <Button onClick={handleClick} disabled>
@@ -43,7 +46,7 @@ describe("Button", () => {
     );
 
     const button = screen.getByRole("button", { name: "Disabled Button" });
-    fireEvent.click(button);
+    await user.click(button);
 
     expect(handleClick).not.toHaveBeenCalled();
   });

--- a/src/components/atoms/__tests__/Link.test.tsx
+++ b/src/components/atoms/__tests__/Link.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Link } from "../Link";
@@ -285,7 +286,8 @@ describe("Link", () => {
       }
     });
 
-    it("viewTransition=true でクリックすると startViewTransition 経由で navigate される", () => {
+    it("viewTransition=true でクリックすると startViewTransition 経由で navigate される", async () => {
+      const user = userEvent.setup();
       const startVTSpy = vi.fn((cb: () => void) => {
         cb();
       });
@@ -301,14 +303,15 @@ describe("Link", () => {
       );
 
       const link = screen.getByRole("link", { name: "VT Link" });
-      fireEvent.click(link);
+      await user.click(link);
 
       // startViewTransition が呼ばれていれば、preventDefault → vtNavigate のパスが
       // 機能している証拠となる。
       expect(startVTSpy).toHaveBeenCalledTimes(1);
     });
 
-    it("viewTransition=false ではクリック時に startViewTransition を呼ばない", () => {
+    it("viewTransition=false ではクリック時に startViewTransition を呼ばない", async () => {
+      const user = userEvent.setup();
       const startVTSpy = vi.fn();
       // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
       (document as any).startViewTransition = startVTSpy;
@@ -320,12 +323,13 @@ describe("Link", () => {
       );
 
       const link = screen.getByRole("link", { name: "No VT Link" });
-      fireEvent.click(link);
+      await user.click(link);
 
       expect(startVTSpy).not.toHaveBeenCalled();
     });
 
-    it("修飾キー併用クリック (Cmd) では preventDefault せずブラウザ既定挙動に委ねる", () => {
+    it("修飾キー併用クリック (Cmd) では preventDefault せずブラウザ既定挙動に委ねる", async () => {
+      const user = userEvent.setup();
       const startVTSpy = vi.fn();
       // biome-ignore lint/suspicious/noExplicitAny: テストファイルでのモックのため許可
       (document as any).startViewTransition = startVTSpy;
@@ -339,7 +343,11 @@ describe("Link", () => {
       );
 
       const link = screen.getByRole("link", { name: "Cmd Click" });
-      fireEvent.click(link, { metaKey: true });
+      // Meta キーを押下したまま左クリックする (Cmd+クリック)。user-event では
+      // keyboard で修飾キーを保持してから click することで metaKey 付き click を再現する。
+      await user.keyboard("{Meta>}");
+      await user.click(link);
+      await user.keyboard("{/Meta}");
 
       // 新規タブを開く意図なので VT は発火させない
       expect(startVTSpy).not.toHaveBeenCalled();

--- a/src/components/common/__tests__/ImageLightbox.test.tsx
+++ b/src/components/common/__tests__/ImageLightbox.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ImageLightbox } from "../ImageLightbox";
 

--- a/src/components/common/__tests__/TableOfContents.test.tsx
+++ b/src/components/common/__tests__/TableOfContents.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import type { TocItem } from "../../../lib/markdown";
 import { TableOfContents } from "../TableOfContents";

--- a/src/components/common/__tests__/ThemeToggle.test.tsx
+++ b/src/components/common/__tests__/ThemeToggle.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeToggle } from "../ThemeToggle";
@@ -72,23 +72,25 @@ describe("ThemeToggle", () => {
     );
   });
 
-  it("クリックでテーマがdarkからlightに切り替わる", () => {
+  it("クリックでテーマがdarkからlightに切り替わる", async () => {
+    const user = userEvent.setup();
     localStorage.setItem("theme", "dark");
     render(<ThemeToggle />);
 
     const toggle = screen.getByRole("switch");
-    fireEvent.click(toggle);
+    await user.click(toggle);
 
     expect(document.documentElement.dataset.theme).toBe("light");
   });
 
-  it("クリック2回でテーマがdarkに戻る", () => {
+  it("クリック2回でテーマがdarkに戻る", async () => {
+    const user = userEvent.setup();
     localStorage.setItem("theme", "dark");
     render(<ThemeToggle />);
 
     const toggle = screen.getByRole("switch");
-    fireEvent.click(toggle);
-    fireEvent.click(toggle);
+    await user.click(toggle);
+    await user.click(toggle);
 
     expect(document.documentElement.dataset.theme).toBe("dark");
   });
@@ -146,7 +148,8 @@ describe("ThemeToggle", () => {
       expect(paths.length).toBeGreaterThanOrEqual(1);
     });
 
-    it("クリックでアイコンが Sun と Moon の間で切り替わる", () => {
+    it("クリックでアイコンが Sun と Moon の間で切り替わる", async () => {
+      const user = userEvent.setup();
       localStorage.setItem("theme", "dark");
       const { rerender } = render(<ThemeToggle />);
 
@@ -155,7 +158,7 @@ describe("ThemeToggle", () => {
       expect(toggle.querySelectorAll("circle").length).toBe(0);
 
       // クリックで light に切替 → Sun の circle が出る
-      fireEvent.click(toggle);
+      await user.click(toggle);
       rerender(<ThemeToggle />);
       expect(
         screen.getByRole("switch").querySelectorAll("circle").length,


### PR DESCRIPTION
## 概要

`@testing-library/user-event 14.6.1` を活用し、クリック系テストを `fireEvent` から実ユーザー操作に忠実な `userEvent` へ移行する（focus 挙動の再現精度向上）。

## 変更内容

- `src/components/atoms/__tests__/Button.test.tsx` / `Link.test.tsx`, `src/components/common/__tests__/ThemeToggle.test.tsx`: `fireEvent.click` を `userEvent.setup()` + `await user.click()` に移行。Link の Cmd+クリックは `user.keyboard("{Meta>}")` で修飾キー保持して再現
- `src/components/common/__tests__/ImageLightbox.test.tsx` / `TableOfContents.test.tsx`: `userEvent` の import を named 形式に統一

## 備考

- 画像 onError を発火する `fireEvent.error(img)` は userEvent に対応物がないため意図的に維持（過剰移行を回避）
- `test:run`（1066 passed）green
