### PR TITLE
chore: axe-core のバージョンを 4.11.4 に統一

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  axe-core: 4.11.4
   fast-uri@<=3.1.0: '>=3.1.1'
   fast-uri@<=3.1.1: '>=3.1.2'
   hono@<4.12.16: '>=4.12.16'
@@ -963,14 +964,6 @@ packages:
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
-
-  axe-core@3.5.6:
-    resolution: {integrity: sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==}
-    engines: {node: '>=4'}
-
-  axe-core@4.10.2:
-    resolution: {integrity: sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==}
-    engines: {node: '>=4'}
 
   axe-core@4.11.4:
     resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
@@ -3044,7 +3037,7 @@ snapshots:
   '@types/jest-axe@3.5.9':
     dependencies:
       '@types/jest': 30.0.0
-      axe-core: 3.5.6
+      axe-core: 4.11.4
 
   '@types/jest@30.0.0':
     dependencies:
@@ -3200,10 +3193,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   astral-regex@2.0.0: {}
-
-  axe-core@3.5.6: {}
-
-  axe-core@4.10.2: {}
 
   axe-core@4.11.4: {}
 
@@ -3633,7 +3622,7 @@ snapshots:
 
   jest-axe@10.0.0:
     dependencies:
-      axe-core: 4.10.2
+      axe-core: 4.11.4
       chalk: 4.1.2
       jest-matcher-utils: 29.2.2
       lodash.merge: 4.6.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ allowBuilds:
   esbuild: true
 
 overrides:
+  axe-core: 4.11.4
   "fast-uri@<=3.1.0": ">=3.1.1"
   "fast-uri@<=3.1.1": ">=3.1.2"
   "hono@<4.12.16": ">=4.12.16"


### PR DESCRIPTION
## 概要

a11y 検査の axe-core バージョン不整合を解消する。jest-axe(axe-core 4.10.2) と @axe-core/playwright(axe-core 4.11.4) でルールセットが食い違っていたため、単一バージョンに統一する。

## 変更内容

- `pnpm-workspace.yaml`: `overrides` に `axe-core: 4.11.4` を追加
- `pnpm-lock.yaml`: override 反映により 3.5.6 / 4.10.2 / 4.11.4 の三分裂を 4.11.4 に集約（dedup）

## 備考

- axe-core は dev/test 専用の transitive 依存でランタイム非搭載
- jest-axe ユニットテスト 4 件（Coordinate / AnchorPage / AnchorPage.allPosts / PostDetailPage）は 4.11.4 で violation 0
- `@types/jest-axe` は最新が 3.5.9（jest-axe 10 対応版なし）のため現状維持
