### PR TITLE
chore: tsconfig の lib から DOM.Iterable を削除

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
## 概要

`typescript 6.0.3` で `lib.dom.iterable.d.ts` の内容が `lib.dom.d.ts` に統合されたため、冗長になった `DOM.Iterable` の明示を削除する。

## 変更内容

- `tsconfig.json`: `lib` を `["ES2020", "DOM", "DOM.Iterable"]` から `["ES2020", "DOM"]` に変更（`extends` 経由で api/scripts/test の全 tsconfig に波及）

## 備考

- 削除後に NodeList の for...of 等で型エラーが出ないことを全 tsconfig で確認（プロダクションコードに DOM コレクション反復は存在しない）
- `type-check` 全種 / `build:ci` / `check:build-ci-sync` green
- `verbatimModuleSyntax` / `isolatedDeclarations` は bundler/private SPA に不適のため不採用
