### PR TITLE
chore: dompurify を 3.4.7 に更新 (GHSA 脆弱性対応)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^2.2.10",
-    "dompurify": "^3.4.5",
+    "dompurify": "^3.4.7",
     "marked": "^18.0.4",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^2.2.10
         version: 2.2.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       dompurify:
-        specifier: ^3.4.5
-        version: 3.4.5
+        specifier: ^3.4.7
+        version: 3.4.7
       marked:
         specifier: ^18.0.4
         version: 18.0.4
@@ -1156,8 +1156,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.5:
-    resolution: {integrity: sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==}
+  dompurify@3.4.7:
+    resolution: {integrity: sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3358,7 +3358,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.5:
+  dompurify@3.4.7:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
## 概要

`dompurify` を 3.4.5 から 3.4.7 に更新する。3.4.5 は GitHub Advisory 3 件（GHSA-hpcv-96wg-7vj8 / GHSA-r47g-fvhr-h676 → 3.4.6、GHSA-76mc-f452-cxcm → 3.4.7）の脆弱範囲に含まれるため、衛生上の先行 bump を行う。

## 変更内容

- `package.json`: `dompurify` を `^3.4.5` から `^3.4.7` に更新
- `pnpm-lock.yaml`: dompurify 3.4.7 に解決し直し（integrity 含む、変更は dompurify に限定）

## 備考

- 本コードの `sanitizePostHtml`（`src/lib/sanitize.ts`）は `IN_PLACE` / `addHook` を使わないため、上記 advisory の exploit 経路には該当しない（exploit 不可）。3.4.7 は sanitize 出力をより厳格化するのみで挙動退行なし
- `sanitize.test.ts`（XSS 網羅 23 件）含め `test:run` green
