### PR TITLE
update: dependabot の GHA cooldown を 3 日へ短縮

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,5 +38,5 @@ updates:
       time: "05:00"
       timezone: "Asia/Tokyo"
     cooldown:
-      default-days: 7
+      default-days: 3
     open-pull-requests-limit: 10


### PR DESCRIPTION
## 概要

dependabot が管理する GitHub Actions のバージョン更新 cooldown を 1 週間（7 日）から 3 日へ短縮する。

## 変更内容

- `.github/dependabot.yml`: `github-actions` エコシステムの `cooldown.default-days` を `7` から `3` に変更

## 備考

GHA バージョン更新 PR がより早く反映されるようになる。npm エコシステム側の設定は変更していない。