### PR TITLE
chore: actions/checkout を SHA ピンに変更（v6.0.3）

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0

--- a/.github/workflows/panda-hash-regression.yml
+++ b/.github/workflows/panda-hash-regression.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0

--- a/.github/workflows/precommit-guard-tests.yml
+++ b/.github/workflows/precommit-guard-tests.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Assert .githooks files exist and are executable
         # Issue #592 (Counterpoint 31): git native hook の同梱を CI で保証する。

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0


### PR DESCRIPTION
## 概要

全ワークフローファイルの `actions/checkout` をタグ指定からコミット SHA ピンに変更する。

## 変更内容

- `v6.0.2` タグ指定だった 7 ファイルを `df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3` に変更
  - `.github/workflows/ci.yml`
  - `.github/workflows/test.yml`
  - `.github/workflows/playwright.yml`
  - `.github/workflows/deploy.yml`
  - `.github/workflows/a11y.yml`
  - `.github/workflows/panda-hash-regression.yml`
  - `.github/workflows/precommit-guard-tests.yml`
- `reviewdog.yaml` は既に同 SHA でピン済みのため変更なし

## 備考

SHA `df4cb1c069e1874edd31b4311f1884172cec0e10` は `actions/checkout` v6.0.3 の注釈タグが指すコミット（GitHub API で確認済み）。

タグはポインタを書き換えられる（タグの移動・削除）リスクがあるため、コミット SHA への固定 pin によりサプライチェーン攻撃耐性を向上させる。全ワークフローで SHA が統一され、`reviewdog.yaml` との整合性も取れた状態になる。