### PR TITLE
feat: parseMarkdown に updatedAt 抽出を追加し Post 型に露出 (#807)

### DIFF
--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -75,7 +75,7 @@ describe("markdown.ts", () => {
       expect(result.author).toBe("");
     });
 
-    it("更新日時セクションがあるとupdatedAtに加筆日時が入る", () => {
+    it("更新日時セクションがあるとupdatedAtにその値が入る", () => {
       const content = `# テストタイトル
 
 ## 投稿日時

--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -75,6 +75,63 @@ describe("markdown.ts", () => {
       expect(result.author).toBe("");
     });
 
+    it("更新日時セクションがあるとupdatedAtに加筆日時が入る", () => {
+      const content = `# テストタイトル
+
+## 投稿日時
+- 2024-01-01 10:00
+
+## 筆者名
+- テスト太郎
+
+## 更新日時
+- 2026/03/10 09:30
+
+## 本文
+本文です。`;
+
+      const result = parseMarkdown(content, "20240101100000");
+
+      expect(result.updatedAt).toBe("2026/03/10 09:30");
+    });
+
+    it("更新日時セクションがない場合はupdatedAtが空文字になる", () => {
+      const content = `# テストタイトル
+
+## 投稿日時
+- 2024-01-01 10:00
+
+## 筆者名
+- テスト太郎
+
+## 本文
+本文です。`;
+
+      const result = parseMarkdown(content, "20240101100000");
+
+      expect(result.updatedAt).toBe("");
+    });
+
+    it("更新日時がリスト形式でない場合はupdatedAtが空文字になる", () => {
+      const content = `# テストタイトル
+
+## 投稿日時
+- 2024-01-01 10:00
+
+## 筆者名
+- テスト太郎
+
+## 更新日時
+2026/03/10 09:30
+
+## 本文
+本文です。`;
+
+      const result = parseMarkdown(content, "20240101100000");
+
+      expect(result.updatedAt).toBe("");
+    });
+
     it("本文がない場合は空文字を返す", () => {
       const content = `# テストタイトル
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -121,6 +121,12 @@ export interface Post extends PostSummary {
   content: string;
   rawContent: string;
   toc: TocItem[];
+  /**
+   * 任意の加筆日時。`## 更新日時` セクションから抽出する。
+   * 一覧用の PostSummary には流さず、記事詳細ページ専用とする
+   * (二重経路 drift を防ぐため一覧経路には露出しない)。
+   */
+  updatedAt?: string;
 }
 
 export const parseMarkdown = (content: string, timestamp: string): Post => {
@@ -128,6 +134,7 @@ export const parseMarkdown = (content: string, timestamp: string): Post => {
 
   const title = extractTitle(lines);
   const createdAt = extractSectionContent(lines, "投稿日時");
+  const updatedAt = extractSectionContent(lines, "更新日時");
   const author = extractSectionContent(lines, "筆者名");
   const bodyContent = extractBodyContent(lines);
 
@@ -143,6 +150,7 @@ export const parseMarkdown = (content: string, timestamp: string): Post => {
     id: timestamp,
     title,
     createdAt,
+    updatedAt,
     content: parsedContent,
     author,
     rawContent: content,


### PR DESCRIPTION
## 概要

記事 Markdown の任意セクション `## 更新日時` から加筆日時を抽出し、記事詳細専用の `Post` 型に `updatedAt?: string` として露出する。エピック #806 の I1（抽出と型露出のみ）。

一覧経路（`PostSummary` / `extractSummaryFromContent`）には型としても値としても流さず、二重経路 drift を構造的に防ぐ。比較ロジック（#808）・表示（#809）はこの PR の範囲外。

## 変更内容

- `src/lib/markdown.ts`: `Post extends PostSummary` に `updatedAt?: string` を追加（記事詳細ページ専用である旨を JSDoc に明記）。`parseMarkdown` 内で `createdAt` 抽出の直後に既存 `extractSectionContent(lines, "更新日時")` を再利用して抽出し、戻り値に含める。新規パーサ関数は追加しない。
- `src/lib/__tests__/markdown.test.ts`: 更新日時セクションの有無・リスト形式可否に応じた `updatedAt` の振る舞いを検証する3テストを追加。
- `src/lib/markdownParser.ts`（`PostSummary` / `extractSummaryFromContent`）・`src/lib/anchors.ts` は不変。

## 備考

- 既存16記事は `## 更新日時` を持たないため `updatedAt: ""` となり後方互換（全件で従来どおり表示）。
- `anchors.ts` / `anchors.test.ts` 無変更で「status / tags / updatedAt を露出しない」テストは green を維持。
- ローカルレビュー（Devil's Advocate / code-review / security-review）実施済み。指摘は DA の minor（テスト名の用語統一）のみで対応済み、blocker/major・脆弱性なし。
- `pnpm test:run`（1084件）/ `pnpm lint` / 型チェック いずれも pass。

Closes #807
Refs #806

<details>
<summary>Anchor 型を扱う PR のみチェック (Issue #556)</summary>

本 PR は Anchor 型（`Coordinate` / `Elapsed`）を扱わないため対象外。

</details>
