### PR TITLE
feat: 加筆日時の比較専用パース関数 postDate.ts を追加 (#808)

### DIFF
--- a/src/lib/__tests__/postDate.test.ts
+++ b/src/lib/__tests__/postDate.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { isUpdatedAfterCreated, parsePostDateToEpoch } from "../postDate";
+
+/**
+ * JST 壁時計時刻 (年月日時分) から期待 epoch(ms) を算出するテスト用ヘルパー。
+ * - 本体実装と同一ロジック (UTC 換算で 9 時間引く) を独立に書くことで、
+ *   実装側の計算式を二重チェックする意図。
+ */
+const expectedJstEpoch = (
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+): number => Date.UTC(year, month - 1, day, hour, minute) - 9 * 60 * 60 * 1000;
+
+describe("parsePostDateToEpoch", () => {
+  it("スラッシュ区切りとダッシュ区切りの同一日時が等しい epoch を返す", () => {
+    const slash = parsePostDateToEpoch("2026/03/10 09:30");
+    const dash = parsePostDateToEpoch("2026-03-10 09:30");
+
+    expect(slash).toBe(expectedJstEpoch(2026, 3, 10, 9, 30));
+    expect(slash).toBe(dash);
+  });
+
+  it("時刻省略時は同日 00:00 (JST) の epoch を返す", () => {
+    const epoch = parsePostDateToEpoch("2026/03/10");
+
+    expect(epoch).toBe(expectedJstEpoch(2026, 3, 10, 0, 0));
+  });
+
+  it("空文字に対し undefined を返す", () => {
+    expect(parsePostDateToEpoch("")).toBeUndefined();
+  });
+
+  it("数字を含まない文字列に対し undefined を返す", () => {
+    expect(parsePostDateToEpoch("abc")).toBeUndefined();
+  });
+
+  it("ドット区切りに対し undefined を返す", () => {
+    expect(parsePostDateToEpoch("2026.03.10")).toBeUndefined();
+  });
+});
+
+describe("isUpdatedAfterCreated", () => {
+  it("updatedAt が createdAt より後なら true を返す", () => {
+    expect(isUpdatedAfterCreated("2026/03/10 09:30", "2026/03/11 10:00")).toBe(
+      true,
+    );
+  });
+
+  it("updatedAt が createdAt と同一なら false を返す", () => {
+    expect(isUpdatedAfterCreated("2026/03/10 09:30", "2026/03/10 09:30")).toBe(
+      false,
+    );
+  });
+
+  it("updatedAt が createdAt より前なら false を返す", () => {
+    expect(isUpdatedAfterCreated("2026/03/11 10:00", "2026/03/10 09:30")).toBe(
+      false,
+    );
+  });
+
+  it("createdAt の書式が不正なら false を返す", () => {
+    expect(isUpdatedAfterCreated("2026.03.10", "2026/03/11 10:00")).toBe(false);
+  });
+
+  it("updatedAt の書式が不正なら false を返す", () => {
+    expect(isUpdatedAfterCreated("2026/03/10 09:30", "abc")).toBe(false);
+  });
+
+  it("区切りが混在 (createdAt が -, updatedAt が /) でも epoch 比較で正しく判定する", () => {
+    // 合成ケース: 運用データは全てスラッシュだが、ダッシュ受理 (fixture 互換) と
+    // スラッシュ受理が同一 epoch に正規化されることを 1 ケースで確認する目的の
+    // 意図的な区切り混在テスト。
+    expect(isUpdatedAfterCreated("2026-03-10 09:30", "2026/03/11 10:00")).toBe(
+      true,
+    );
+  });
+
+  it("日跨ぎ境界 (23:59 → 翌日 00:00) で true を返す", () => {
+    expect(isUpdatedAfterCreated("2026/03/10 23:59", "2026/03/11 00:00")).toBe(
+      true,
+    );
+  });
+
+  it("同日加筆境界 (日付のみ 00:00 → 同日 09:30) で true を返す", () => {
+    // 同日加筆を「更新あり」として扱う挙動は意図的 (openQuestion #2 の決定)。
+    // createdAt が日付のみ (= 00:00 とみなす) のため、同日でも時刻が後なら更新扱い。
+    expect(isUpdatedAfterCreated("2026/03/10", "2026/03/10 09:30")).toBe(true);
+  });
+});

--- a/src/lib/__tests__/postDate.test.ts
+++ b/src/lib/__tests__/postDate.test.ts
@@ -29,6 +29,14 @@ describe("parsePostDateToEpoch", () => {
     expect(epoch).toBe(expectedJstEpoch(2026, 3, 10, 0, 0));
   });
 
+  it("ISO 8601 (+09:00) リテラルと同一の epoch を返す", () => {
+    // 本体・expectedJstEpoch ヘルパーと同じ式のコピーに依存しない独立検証。
+    // JS の Date が解釈する ISO 8601 (オフセット明示) の epoch と一致することを確認する。
+    const epoch = parsePostDateToEpoch("2026/03/10 09:30");
+
+    expect(epoch).toBe(new Date("2026-03-10T09:30:00+09:00").getTime());
+  });
+
   it("空文字に対し undefined を返す", () => {
     expect(parsePostDateToEpoch("")).toBeUndefined();
   });

--- a/src/lib/postDate.ts
+++ b/src/lib/postDate.ts
@@ -1,0 +1,86 @@
+/**
+ * 加筆日時の比較専用パース層 (Issue #808)
+ *
+ * - `createdAt` / `updatedAt` の **表示文字列**はそのまま使い、本モジュールは
+ *   「updatedAt が createdAt より厳密に新しいか」の **大小判定**のみを担う
+ * - 文字列の辞書順比較は書式不統一 (区切り `/` と `-` の混在 / 時刻有無) で
+ *   破綻するため、書式緩めのパースで一度 JST epoch(ms) に正規化してから比較する
+ * - 純粋関数のみで構成し、`Date.now()` / 引数なし `new Date()` には依存しない
+ *   (現在時刻に依存しない = 同一入力で常に同一出力)
+ * - `anchors.ts` の export (`JST_OFFSET_MS` 等) は import しない。責務分離のため
+ *   JST オフセット定数は本モジュール内にローカルに持つ
+ */
+
+/**
+ * JST (+09:00) のオフセット (ミリ秒)。
+ *
+ * - JST の壁時計時刻を UTC epoch へ変換する際、UTC 換算で 9 時間引くために使う
+ *   (JST は UTC+9 のため、同じ壁時計時刻でも UTC より 9 時間早い瞬間を指す)
+ * - `anchors.ts` にも同名定数があるが、責務分離のため本モジュールに独立して持つ
+ */
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/**
+ * `YYYY/MM/DD HH:MM` / `YYYY-MM-DD HH:MM` を受理する正規表現。
+ *
+ * - 区切りは `/` と `-` の両方を許容する (ダッシュは PostDetailPage の既存
+ *   fixture `"2024-01-15"` との互換のため。運用データは全てスラッシュ)
+ * - 時刻部 `(?:[ T]HH:MM)?` は省略可能 (省略時は 00:00 とみなす)。日付と時刻の
+ *   区切りは半角スペースまたは `T` を許容する
+ * - 各フィールドは桁数のみを検証し、月日時分の値範囲 (1-12 月等) は検証しない。
+ *   範囲外値は `Date.UTC` のロールオーバーに委ねる (シンプルさ優先)
+ * - 1 つの値の中で区切りが混在するケース (`2026/03-10` 等) は実運用で発生しない
+ *   ため受理する場合があるが、ドット区切り `2026.03.10` は桁の前後に許可文字が
+ *   無いため確実に不一致 (`undefined`) になる
+ */
+const POST_DATE_PATTERN =
+  /^(\d{4})[/-](\d{2})[/-](\d{2})(?:[ T](\d{2}):(\d{2}))?$/;
+
+/**
+ * 投稿日時文字列を JST (+09:00) 固定で epoch(ms) に正規化する純粋関数。
+ *
+ * @param value `YYYY/MM/DD HH:MM` / `YYYY-MM-DD HH:MM` 形式の文字列
+ *   (時刻は省略可能で、省略時は 00:00 とみなす)
+ * @returns 正規化した epoch(ms)。形式不一致の場合は `undefined`
+ */
+export const parsePostDateToEpoch = (value: string): number | undefined => {
+  const matched = POST_DATE_PATTERN.exec(value);
+  if (matched === null) {
+    return undefined;
+  }
+
+  const year = Number(matched[1]);
+  const month = Number(matched[2]);
+  const day = Number(matched[3]);
+  // 時刻省略時は 00:00 とみなす
+  const hour = matched[4] === undefined ? 0 : Number(matched[4]);
+  const minute = matched[5] === undefined ? 0 : Number(matched[5]);
+
+  // JST 壁時計時刻 → epoch は UTC 換算で 9 時間引く (JST は UTC+9 のため)
+  return Date.UTC(year, month - 1, day, hour, minute) - JST_OFFSET_MS;
+};
+
+/**
+ * `updatedAt` が `createdAt` より厳密に新しいかを判定する純粋関数。
+ *
+ * - 両者とも `parsePostDateToEpoch` でパース成功し、かつ
+ *   `updated epoch > created epoch` のときだけ `true`
+ * - いずれかが形式不正 (`undefined`)、または `updated <= created` のときは `false`
+ *
+ * @param createdAt 作成日時の表示文字列
+ * @param updatedAt 更新日時の表示文字列
+ * @returns updatedAt が createdAt より厳密に新しければ `true`
+ */
+export const isUpdatedAfterCreated = (
+  createdAt: string,
+  updatedAt: string,
+): boolean => {
+  const createdEpoch = parsePostDateToEpoch(createdAt);
+  const updatedEpoch = parsePostDateToEpoch(updatedAt);
+
+  if (createdEpoch === undefined || updatedEpoch === undefined) {
+    return false;
+  }
+
+  return updatedEpoch > createdEpoch;
+};


### PR DESCRIPTION
## 概要

`updatedAt` が `createdAt` より厳密に新しいかを判定する比較専用の純粋関数群 `src/lib/postDate.ts` を新設する。エピック #806 の I2。表示文字列はそのまま使い、大小判定だけを書式緩めのパースで JST epoch(ms) に正規化して行う（文字列辞書順比較の罠と書式不統一を回避）。**本リポジトリ初の日時パース層**。外部依存ゼロ。

## 変更内容

- `src/lib/postDate.ts`（新規）:
  - `parsePostDateToEpoch(value): number | undefined` — `YYYY/MM/DD HH:MM` / `YYYY-MM-DD HH:MM` を受理（時刻省略時 00:00）。JST(+09:00) 固定で epoch(ms) に正規化（`Date.UTC(...) - 9h`）。形式不一致は `undefined`。
  - `isUpdatedAfterCreated(createdAt, updatedAt): boolean` — 両者パース成功かつ `updated > created`（厳密）のときだけ true。いずれか不正 / `updated <= created` なら false。
  - `JST_OFFSET_MS` はローカル定義。**`anchors.ts` の export は import しない**（責務分離・anchors 非汚染）。`Date.now()` / 引数なし `new Date()` 不使用（純粋関数）。
- `src/lib/__tests__/postDate.test.ts`（新規）: 等値・日付のみ・不正形式・大小・区切り混在・日跨ぎ境界・同日加筆境界を網羅（計14件）。期待 epoch は ISO 8601(+09:00) リテラルでも独立検証。

## 備考

- ダッシュ区切り受理は `PostDetailPage` 既存 fixture `"2024-01-15"` 互換のため（運用データは全てスラッシュ）。
- 月日時分の値範囲は検証せず `Date.UTC` のロールオーバーに委ねる設計（比較専用としてシンプルさ優先）。この点と秒/TZ付き入力の非対応は follow-up #812 に記録済み。
- ローカルレビュー（Devil's Advocate / code-review / security-review）実施済み。DA nit（テスト期待値の独立検証）を対応、blocker/major・脆弱性なし。
- `pnpm test:run`（1098件）/ `pnpm lint` / 型チェック いずれも pass。

Closes #808
Refs #806

<details>
<summary>Anchor 型を扱う PR のみチェック (Issue #556)</summary>

本 PR は Anchor 型（`Coordinate` / `Elapsed`）を扱わないため対象外。

</details>
