### PR TITLE
feat: MetaInfo に updatedAt 行を data-meta-field 付きで条件付き追加 (#809)

### DIFF
--- a/src/components/common/MetaInfo.tsx
+++ b/src/components/common/MetaInfo.tsx
@@ -1,12 +1,20 @@
 import { memo } from "react";
 import { css } from "../../../styled-system/css";
 import { AUTHOR_FALLBACK, DATE_FALLBACK } from "../../lib/i18nLiterals";
+import { isUpdatedAfterCreated } from "../../lib/postDate";
 import { Calendar, Clock, PenLine } from "../atoms/icons";
 
 interface MetaInfoProps {
   createdAt?: string;
   author?: string;
   readingTimeMinutes?: number;
+  /**
+   * 加筆日時の表示文字列 (`YYYY/MM/DD HH:MM` 等)。
+   *
+   * Issue #809: `createdAt` より厳密に新しい場合のみ「更新: <日時>」行を
+   * 追加する。新旧判定は #808 の `isUpdatedAfterCreated` に委譲する。
+   */
+  updatedAt?: string;
   variant?: "card" | "header" | "featured" | "bento";
 }
 
@@ -18,6 +26,11 @@ interface MetaInfoProps {
 // `Resurface.tsx` の `RESURFACE_REASON_LABEL_*_TEMPLATE` に倣う。
 const READING_TIME_LABEL_TEMPLATE = (minutes: number): string =>
   `${minutes}分で読了`;
+
+// Issue #809: 加筆日時の表示文言テンプレート。`READING_TIME_LABEL_TEMPLATE` と
+// 同方針で、単一ファイル内で完結する文言のため `i18nLiterals.ts` への横串集約は
+// せず、ファイル内ローカル定数に留める (Issue #721 / #534 / #630 方針)。
+const UPDATED_AT_LABEL_TEMPLATE = (value: string): string => `更新: ${value}`;
 
 // スタイルをコンポーネント外に定数として定義
 const containerStyles = css({
@@ -195,6 +208,7 @@ export const MetaInfo = memo(
     createdAt,
     author,
     readingTimeMinutes,
+    updatedAt,
     variant = "card",
   }: MetaInfoProps) => {
     const styles = variantStyleSets[variant];
@@ -218,6 +232,25 @@ export const MetaInfo = memo(
           <div className={itemClassName} data-token-bg={styles.itemBg}>
             <Clock aria-hidden="true" size={styles.iconSize} />
             <span>{READING_TIME_LABEL_TEMPLATE(readingTimeMinutes)}</span>
+          </div>
+        )}
+        {/*
+          Issue #809: updatedAt が createdAt より厳密に新しいときだけ加筆日時行を
+          追加する。新旧判定は #808 の `isUpdatedAfterCreated` に委譲する。
+          空文字 (`updatedAt=""`) のとき React が空テキストノードを残さないよう
+          `!!updatedAt` で真偽値化してから条件評価する。
+          専用アイコンが無いため `Clock` を再利用する (読了時間と同じアイコンに
+          なるが、行の構造的識別子は `data-meta-field="updated"` を唯一とし、
+          アイコンは行の識別には使わない)。
+        */}
+        {!!updatedAt && isUpdatedAfterCreated(createdAt ?? "", updatedAt) && (
+          <div
+            className={itemClassName}
+            data-token-bg={styles.itemBg}
+            data-meta-field="updated"
+          >
+            <Clock aria-hidden="true" size={styles.iconSize} />
+            <span>{UPDATED_AT_LABEL_TEMPLATE(updatedAt)}</span>
           </div>
         )}
       </div>

--- a/src/components/common/__tests__/MetaInfo.test.tsx
+++ b/src/components/common/__tests__/MetaInfo.test.tsx
@@ -163,6 +163,10 @@ describe("MetaInfo", () => {
   // Issue #809: updatedAt が createdAt より新しいときだけ「更新: <日時>」行を
   // 追加する。行の種別は `data-meta-field="updated"` で観測可能にする。
   // 更新判定は #808 の `isUpdatedAfterCreated` を使う。
+  //
+  // 行の構造的識別子は `data-meta-field="updated"` を唯一とする。Clock アイコンは
+  // 読了時間行と共用するため行の識別には使わない (アイコンに依存せず data-meta-field
+  // 単独で更新行を一意に特定できることを明示)。
   // ===================================================================
   it("updatedAt が createdAt より新しいとき更新日時行を data-meta-field 付きで表示できる", () => {
     const { container } = render(

--- a/src/components/common/__tests__/MetaInfo.test.tsx
+++ b/src/components/common/__tests__/MetaInfo.test.tsx
@@ -158,4 +158,133 @@ describe("MetaInfo", () => {
     const bentoSvgs = bentoContainer.querySelectorAll('svg[width="12"]');
     expect(bentoSvgs.length).toBeGreaterThanOrEqual(2);
   });
+
+  // ===================================================================
+  // Issue #809: updatedAt が createdAt より新しいときだけ「更新: <日時>」行を
+  // 追加する。行の種別は `data-meta-field="updated"` で観測可能にする。
+  // 更新判定は #808 の `isUpdatedAfterCreated` を使う。
+  // ===================================================================
+  it("updatedAt が createdAt より新しいとき更新日時行を data-meta-field 付きで表示できる", () => {
+    const { container } = render(
+      <MetaInfo
+        createdAt="2024/01/15 12:00"
+        author="山田太郎"
+        updatedAt="2024/03/10 09:30"
+      />,
+    );
+
+    const updatedRow = container.querySelector('[data-meta-field="updated"]');
+    expect(updatedRow).not.toBeNull();
+    // 行の textContent に「更新:」と日時が含まれることを確認する
+    // (装飾アイコン svg は aria-hidden なので textContent には現れない)。
+    expect(updatedRow?.textContent).toContain("更新:");
+    expect(updatedRow?.textContent).toContain("2024/03/10 09:30");
+  });
+
+  it("updatedAt 未指定のとき更新日時行が描画されない", () => {
+    const { container } = render(
+      <MetaInfo createdAt="2024/01/15 12:00" author="山田太郎" />,
+    );
+
+    expect(container.querySelector('[data-meta-field="updated"]')).toBeNull();
+  });
+
+  it("updatedAt が空文字のとき更新日時行が描画されない", () => {
+    const { container } = render(
+      <MetaInfo createdAt="2024/01/15 12:00" author="山田太郎" updatedAt="" />,
+    );
+
+    expect(container.querySelector('[data-meta-field="updated"]')).toBeNull();
+  });
+
+  it("updatedAt が createdAt と同一のとき更新日時行が描画されない", () => {
+    const { container } = render(
+      <MetaInfo
+        createdAt="2024/01/15 12:00"
+        author="山田太郎"
+        updatedAt="2024/01/15 12:00"
+      />,
+    );
+
+    expect(container.querySelector('[data-meta-field="updated"]')).toBeNull();
+  });
+
+  it("updatedAt が createdAt より前のとき更新日時行が描画されない", () => {
+    const { container } = render(
+      <MetaInfo
+        createdAt="2024/03/10 09:30"
+        author="山田太郎"
+        updatedAt="2024/01/15 12:00"
+      />,
+    );
+
+    expect(container.querySelector('[data-meta-field="updated"]')).toBeNull();
+  });
+
+  it("header variant で更新日時行が bg.muted token を持つ", () => {
+    const { container } = render(
+      <MetaInfo
+        createdAt="2024/01/15 12:00"
+        author="山田太郎"
+        updatedAt="2024/03/10 09:30"
+        variant="header"
+      />,
+    );
+
+    const updatedRow = container.querySelector('[data-meta-field="updated"]');
+    expect(updatedRow).toHaveAttribute("data-token-bg", "bg.muted");
+  });
+
+  it("featured variant で更新日時行のアイコンが 12px に縮小される", () => {
+    const { container } = render(
+      <MetaInfo
+        createdAt="2024/01/15 12:00"
+        author="山田太郎"
+        updatedAt="2024/03/10 09:30"
+        variant="featured"
+      />,
+    );
+
+    const updatedRow = container.querySelector('[data-meta-field="updated"]');
+    const icon = updatedRow?.querySelector("svg");
+    expect(icon).toHaveAttribute("width", "12");
+    expect(icon).toHaveAttribute("height", "12");
+  });
+
+  it("bento variant で更新日時行のアイコンが 12px に縮小される", () => {
+    const { container } = render(
+      <MetaInfo
+        createdAt="2024/01/15 12:00"
+        author="山田太郎"
+        updatedAt="2024/03/10 09:30"
+        variant="bento"
+      />,
+    );
+
+    const updatedRow = container.querySelector('[data-meta-field="updated"]');
+    const icon = updatedRow?.querySelector("svg");
+    expect(icon).toHaveAttribute("width", "12");
+    expect(icon).toHaveAttribute("height", "12");
+  });
+
+  it("更新日時行のアイコンのみ aria-hidden で更新テキストは SR 読み上げ対象になる", () => {
+    const { container } = render(
+      <MetaInfo
+        createdAt="2024/01/15 12:00"
+        author="山田太郎"
+        updatedAt="2024/03/10 09:30"
+      />,
+    );
+
+    const updatedRow = container.querySelector('[data-meta-field="updated"]');
+    // 装飾アイコンの検証は属性ベースで行う (Issue #709)。行内の svg が
+    // aria-hidden を持つことを確認する。
+    const icon = updatedRow?.querySelector("svg");
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+    // 「更新:」テキストを保持する span は aria-hidden を持たない
+    // (SR 読み上げ対象である)。
+    const textSpan = updatedRow?.querySelector("span");
+    expect(textSpan).not.toHaveAttribute("aria-hidden");
+    expect(textSpan?.textContent).toContain("更新:");
+  });
 });


### PR DESCRIPTION
## 概要

`MetaInfo` に、`updatedAt` が `createdAt` より厳密に新しい場合のみ `更新: <日時>` 行を1行追加する。エピック #806 の I3。新旧判定は #808 の `isUpdatedAfterCreated` に委譲し、行の種別を `data-meta-field="updated"` で Tripwire 観測可能にする。

## 変更内容

- `src/components/common/MetaInfo.tsx`:
  - `MetaInfoProps` に `updatedAt?: string` を追加。
  - ファイル内ローカル定数 `UPDATED_AT_LABEL_TEMPLATE`（`READING_TIME_LABEL_TEMPLATE` と同方針、`i18nLiterals` 非集約 / Issue #721 / #534 / #630）。
  - `readingTimeMinutes` 行の直後に、`!!updatedAt && isUpdatedAfterCreated(createdAt ?? "", updatedAt)` が真のときだけ更新行を描画。`data-token-bg={styles.itemBg}` / `data-meta-field="updated"` を付与し、全 variant で `itemClassName` / `iconSize` を他項目と共通化。
  - 専用アイコンが無いため `Clock` を再利用。行の構造的識別子は `data-meta-field="updated"` を唯一とし、アイコンは識別に使わない旨をコメント明記。
- `src/components/common/__tests__/MetaInfo.test.tsx`: 表示/非表示（未指定・空文字・同一・より前）、header の `bg.muted`、featured/bento の 12px アイコン、`Clock` のみ aria-hidden で `更新:` テキストは SR 読み上げ対象、を `data-meta-field` ベースで検証（9件追加）。

## 備考

- `updatedAt` は optional で既存呼び出し側（FeaturedCard / BentoCard / PostDetailPage）は未渡し → 後方互換（既存テスト無修正で pass）。
- 色 token に依存せず `data-meta-field` + `更新:` テキストの二重で WCAG 1.4.1 を担保。aria-hidden 装飾要素の検証は属性ベース（Issue #709）。
- `data-meta-field` の data-* 規約章への位置づけ整備・既存3項目への非付与の負回帰テストは follow-up #814 に記録。
- ローカルレビュー（DA / code-review / security-review）実施済み。DA minor（テストコメント明記）対応、blocker/major・脆弱性なし。
- `pnpm test:run`（1107件）/ `pnpm lint` / 型チェック いずれも pass。

Closes #809
Refs #806

<details>
<summary>Anchor 型を扱う PR のみチェック (Issue #556)</summary>

本 PR は Anchor 型（`Coordinate` / `Elapsed`）を扱わないため対象外。

</details>
