### PR TITLE
feat: PostDetailPage に updatedAt を配線しコンテンツ規約を文書化 (#810)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,36 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `styled-system/` - Panda CSS自動生成ファイル（編集不要）
 - `datasources/` - Markdownファイル等のデータソース
 
+#### datasources の記事フォーマット（Issue #810）
+
+`datasources/` に置く記事 Markdown は、以下の節構成で書く。各セクションの値はリスト形式（`- 値`）で記述する。`datasources/_TEMPLATE.md` は本リポジトリに存在せず、**本ブロックが記事フォーマット規約の単一ソース**である。
+
+```markdown
+# 記事タイトル
+
+## 投稿日時
+
+- 2026/06/06 12:00
+
+## 筆者名
+
+- amkkr
+
+## 本文
+
+ここから本文（Markdown 記法が使える）。
+
+## 更新日時
+
+- 2026/06/10 09:30
+```
+
+- **`## 投稿日時` / `## 筆者名` / `## 本文`** は必須セクション。`## 更新日時` は**任意**セクションで、加筆したときだけ書く。
+- **日時の推奨書式は `YYYY/MM/DD HH:MM`**（`## 投稿日時` と**同形式**）。区切りは `/` を推奨する（パーサは互換目的で `-` も受理するが運用は `/` に統一する）。
+- **`## 更新日時` は `createdAt`（投稿日時）より新しいときのみ**、記事詳細ページの header に `更新: <日時>` 行として表示される。無い / 空 / パース不能 / `createdAt` 以下のいずれかのときは表示されない（新旧判定は `src/lib/postDate.ts` の `isUpdatedAfterCreated` に委譲、表示は `MetaInfo`（#809）→ `PostDetailPage`（#810）の配線による）。
+- **一覧（IndexPage）には更新表示を出さない**: 一覧用の `PostSummary` 型に `updatedAt` フィールドが無く、`Post` 型のみが持つ構造（型レベル保証）。二重経路 drift を防ぐため一覧経路には露出しない。
+- **`data-meta-field` は当面 `updated` 値のみを吐く**（Tripwire テスト用の構造属性）。投稿日時 / 筆者名 / 読了時間など他項目への `data-meta-field` 付与は別 Issue で扱う。
+
 > **既存 Issue / PR の用語解釈ガイド（Issue #542）**: 過去の Issue や PR の AC / 説明文に「ファイルベースルーティング」「vite-plugin-pages」と記載されているものは、いずれも本プロジェクトの実態である「`src/pages/` 配下にページコンポーネントを置き、`src/main.tsx` の `<Routes>` に手動登録する慣行」を指すものとして読み替えること。`vite-plugin-pages` 等の自動ルート生成方式の導入検討は #562 を参照。
 
 #### 自動ルート生成方式（vite-plugin-pages 等）の導入検討結果（Issue #562, 2026-05-16）

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -238,6 +238,7 @@ export const PostDetailPage = ({
 
               <MetaInfo
                 createdAt={post.createdAt}
+                updatedAt={post.updatedAt}
                 author={post.author}
                 variant="header"
               />

--- a/src/components/pages/__tests__/PostDetailPage.test.tsx
+++ b/src/components/pages/__tests__/PostDetailPage.test.tsx
@@ -620,6 +620,81 @@ describe("PostDetailPage", () => {
     });
   });
 
+  // ==========================================================================
+  // 加筆日時 (更新日時) 表示 (Issue #810 / epic #806)
+  //
+  // header 内の MetaInfo に post.updatedAt を配線し、createdAt より厳密に
+  // 新しいときだけ「更新: <日時>」行を data-meta-field="updated" で吐く。
+  // 表示判定ロジック自体は MetaInfo (#809) / isUpdatedAfterCreated (#808) の
+  // 責務だが、PostDetailPage がそれを header に正しく配線できているかを検証する。
+  // ==========================================================================
+  describe("加筆日時 (更新日時) 表示", () => {
+    it("updatedAt が createdAt より新しいとき header に更新行を表示できる", () => {
+      // createdAt は時刻付きスラッシュ形式、updatedAt は明確に後の日時にして
+      // 日付のみ vs 時刻ありの境界に依存しない明快な大小関係で検証する。
+      const postWithUpdatedAt: Post = {
+        ...mockPost,
+        createdAt: "2024/01/15 12:00",
+        updatedAt: "2024/03/10 09:30",
+      };
+
+      const { container } = render(
+        <MemoryRouter>
+          <PostDetailPage
+            post={postWithUpdatedAt}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
+        </MemoryRouter>,
+      );
+
+      const updatedRow = container.querySelector('[data-meta-field="updated"]');
+      expect(updatedRow).not.toBeNull();
+      // 「更新:」ラベルと更新日時が同じ行のテキストに含まれることを保証する。
+      expect(updatedRow?.textContent).toContain("更新:");
+      expect(updatedRow?.textContent).toContain("2024/03/10 09:30");
+    });
+
+    it("updatedAt を持たない記事では header に更新行を表示しない", () => {
+      // 既存 mockPost は updatedAt 未設定 (後方互換)。更新行は出ない。
+      const { container } = render(
+        <MemoryRouter>
+          <PostDetailPage
+            post={mockPost}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(container.querySelector('[data-meta-field="updated"]')).toBeNull();
+    });
+
+    it("更新行を含む PostDetailPage 全体で axe a11y 違反が 0 件である", async () => {
+      const postWithUpdatedAt: Post = {
+        ...mockPost,
+        createdAt: "2024/01/15 12:00",
+        updatedAt: "2024/03/10 09:30",
+      };
+
+      const { container } = render(
+        <MemoryRouter>
+          <PostDetailPage
+            post={postWithUpdatedAt}
+            olderPost={null}
+            newerPost={null}
+            milestones={[]}
+          />
+        </MemoryRouter>,
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
   describe("Document Metadata (React 19 ネイティブ metadata)", () => {
     it("記事タイトルとサイト名を連結した document.title にできる", () => {
       render(


### PR DESCRIPTION
## 概要

エピック #806 の最後のサブIssue（I4）。記事詳細 `PostDetailPage` の header 内 `MetaInfo` に `updatedAt={post.updatedAt}` を配線し、加筆日時表示をページに統合する。あわせて `## 更新日時` セクションのコンテンツ運用規約を CLAUDE.md に文書化する。これで `datasources` の `## 更新日時`（任意）→ `parseMarkdown`（#807）→ `Post.updatedAt` → 比較（#808）→ `MetaInfo` 表示（#809）→ header 配線（本PR）の E2E が成立する。

## 変更内容

- `src/components/pages/PostDetailPage.tsx`: header 内 `<MetaInfo>` に `updatedAt={post.updatedAt}` を1行追加（配線のみ。`Coordinate` / `publishedAt` 逆算ロジックは不変）。
- `src/components/pages/__tests__/PostDetailPage.test.tsx`:「加筆日時 (更新日時) 表示」describe を追加。
  - 表示ケース（createdAt 時刻付きスラッシュ・updatedAt 明確に後）で header に `更新: 2024/03/10 09:30` が出る
  - 後方互換ケース（updatedAt 無し）で更新行が出ない
  - 更新行を含む PostDetailPage 全体の axe 違反 0 件
- `CLAUDE.md`: ディレクトリ構造節に「datasources の記事フォーマット（Issue #810）」を1ブロック追記（完全な節構成例 / 推奨書式 `YYYY/MM/DD HH:MM` / 更新日時は任意 / 表示条件 / 一覧非露出の型レベル保証 / `data-meta-field` は当面 `updated` のみ / `_TEMPLATE.md` 不在で本ブロックが単一ソース）。

## 備考

- IndexPage（一覧）に更新表示が出ないのは `PostSummary` 型に `updatedAt` が無い**型レベル保証**による（FeaturedCard / BentoCard は `updatedAt` を渡さない）。
- `anchors.ts` / `anchors.test.ts` 無変更で「updatedAt を露出しない」テストは green を維持。
- コミットは「対応内容ごと」に配線と docs で分割。
- ローカルレビュー（DA / code-review / security-review）実施済み。指摘なし・脆弱性なし。
- `pnpm test:run`（1110件）/ `pnpm lint` / 型チェック いずれも pass。

Closes #810
Refs #806

<details>
<summary>Anchor 型を扱う PR のみチェック (Issue #556)</summary>

本 PR は Anchor 型（`Coordinate` / `Elapsed`）を扱わないため対象外。

</details>
