### PR TITLE
refactor: 戻りリンク等の矢印を aria-hidden 装飾に分離し横断統一 (Issue #708)

### DIFF
--- a/e2e/a11y/aria-structure.spec.ts
+++ b/e2e/a11y/aria-structure.spec.ts
@@ -28,7 +28,7 @@ import { expect, test } from "@playwright/test";
  * - landmark role の欠落・誤り (banner / main / contentinfo / navigation / region)
  * - 見出しレベルの逆転・変更 (h1 → h2 等)
  * - 固定見出し文言 ("Index" / "Anchor" / "節目一覧" / "各記事の座標") の消失
- * - ナビゲーションリンク ("← TOPに戻る") の消失
+ * - ナビゲーションリンク ("TOPに戻る") の消失
  */
 
 /**
@@ -103,13 +103,15 @@ test.describe("ARIA 構造: 記事詳細 (/posts/:timestamp)", () => {
     await page.waitForLoadState("networkidle");
 
     // 記事詳細の安定骨格:
-    // - 「ページナビゲーション」nav 内の "← TOPに戻る" リンク (固定文言 / / 遷移)
+    // - 「ページナビゲーション」nav 内の "TOPに戻る" リンク (固定文言 / / 遷移)。
+    //   矢印「←」は aria-hidden な装飾 span に分離済み (Issue #708) のため
+    //   accessibility tree から除外され、アクセシブル名は "TOPに戻る" になる。
     // - article 直下の記事タイトル h1 (文言は動的なので level のみ検査)
     // Markdown 本文の h2/h3 や段落・リンクは記事ごとに変わるため含めない。
     await expect(page.getByRole("main")).toMatchAriaSnapshot(`
       - main:
         - navigation "ページナビゲーション":
-          - link "← TOPに戻る":
+          - link "TOPに戻る":
             - /url: /
         - article:
           - heading [level=1]

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -25,6 +25,10 @@ interface EmptyStateProps {
      * 装飾矢印 + テキスト」を分離して渡せるよう `ReactNode` に広げた
      * (例: `<><span aria-hidden="true">←</span>記事一覧に戻る</>`)。
      * 既存の素の文字列ラベル渡しはそのまま後方互換で動作する。
+     *
+     * 用途制約: `label` には CTA の短いラベル相当のノードのみを渡す
+     * (装飾矢印 + テキスト等)。レイアウト目的の大きな要素ツリーは渡さない
+     * (`ReactNode` 化で任意ノードを受け入れる型の緩さをこの規約で補う)。
      */
     label: ReactNode;
     href: string;

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { css } from "../../../styled-system/css";
 import { center } from "../../../styled-system/patterns";
@@ -17,7 +18,15 @@ interface EmptyStateProps {
   title: string;
   description: string;
   action?: {
-    label: string;
+    /**
+     * CTA リンクのラベル。
+     *
+     * Issue #708: 当初は `string` のみだったが、呼び出し側で「aria-hidden な
+     * 装飾矢印 + テキスト」を分離して渡せるよう `ReactNode` に広げた
+     * (例: `<><span aria-hidden="true">←</span>記事一覧に戻る</>`)。
+     * 既存の素の文字列ラベル渡しはそのまま後方互換で動作する。
+     */
+    label: ReactNode;
     href: string;
   };
 }

--- a/src/components/common/PostNavigation.tsx
+++ b/src/components/common/PostNavigation.tsx
@@ -3,6 +3,19 @@ import { css } from "../../../styled-system/css";
 import type { PostSummary } from "../../lib/markdown";
 import { Link } from "../atoms/Link";
 
+// Issue #708: 前後ナビのラベルから矢印「←」「→」を分離し、JSX 側で
+// `<span aria-hidden="true">{矢印}</span>` の装飾要素として描画する。
+// 旧実装はラベルを JSX 直書きで `← 前の記事` / `次の記事 →` と連結していたが、
+// 再評価トリガー3 (同種の「矢印 + テキスト」ラベルが 3 箇所以上発生) の充足に
+// 伴い BackToTop / PostDetailPage と方針統一する。矢印を aria-hidden にする
+// ことで SR のアクセシブル名から外れ、構造的な i18n / RTL 対応の土台になる
+// (実際の `[dir=rtl]` 反転 CSS は RTL 要件発生時まで先送り = YAGNI)。
+// 矢印は純粋な glyph のため BackToTop に倣い `ICON` ではなく `ARROW` と命名する。
+const PREV_POST_ARROW = "←" as const;
+const PREV_POST_LABEL = "前の記事" as const;
+const NEXT_POST_ARROW = "→" as const;
+const NEXT_POST_LABEL = "次の記事" as const;
+
 interface PostNavigationProps {
   olderPost: PostSummary | null;
   newerPost: PostSummary | null;
@@ -75,7 +88,13 @@ export const PostNavigation = memo(
               variant="card"
               viewTransition={true}
             >
-              <span className={labelStyles}>← 前の記事</span>
+              <span className={labelStyles}>
+                {/* Issue #708: 矢印は aria-hidden な装飾要素として分離。
+                    labelStyles は display:block で gap が無いため、矢印と
+                    テキストの間隔は明示の半角スペース {" "} で従来の見た目を保つ。 */}
+                <span aria-hidden="true">{PREV_POST_ARROW}</span>{" "}
+                {PREV_POST_LABEL}
+              </span>
               <span className={titleStyles}>{olderPost.title}</span>
             </Link>
           )}
@@ -87,7 +106,13 @@ export const PostNavigation = memo(
               variant="card"
               viewTransition={true}
             >
-              <span className={labelStyles}>次の記事 →</span>
+              <span className={labelStyles}>
+                {/* Issue #708: 「次の記事」は末尾に矢印「→」を置く。
+                    aria-hidden で SR から隠し、明示の半角スペース {" "} で
+                    テキストと矢印の間隔を保つ。 */}
+                {NEXT_POST_LABEL}{" "}
+                <span aria-hidden="true">{NEXT_POST_ARROW}</span>
+              </span>
               <span className={titleStyles}>{newerPost.title}</span>
             </Link>
           )}

--- a/src/components/common/__tests__/EmptyState.test.tsx
+++ b/src/components/common/__tests__/EmptyState.test.tsx
@@ -57,6 +57,30 @@ describe("EmptyState", () => {
     expect(actionLink).toHaveAttribute("href", "/posts/new");
   });
 
+  it("action.label に ReactNode (装飾矢印 + テキスト) を渡して描画できる", () => {
+    // Issue #708: action.label の型を ReactNode に広げ、呼び出し側で
+    // 「aria-hidden な装飾矢印 + テキスト」を分離して渡せることを保証する。
+    const action = {
+      label: (
+        <>
+          <span aria-hidden="true">←</span>記事一覧に戻る
+        </>
+      ),
+      href: "/",
+    };
+
+    render(<EmptyState {...defaultProps} action={action} />);
+
+    // 矢印を除いたテキストがリンクのアクセシブル名になる。
+    const actionLink = screen.getByRole("link", { name: "記事一覧に戻る" });
+    expect(actionLink).toHaveAttribute("href", "/");
+    // 装飾矢印は aria-hidden で SR から隠される (#709 方式 b-1)。
+    // EmptyState の装飾アイコン SVG も aria-hidden を持つため、リンク内に
+    // スコープして矢印 span のみを取得する。
+    const decorativeArrow = actionLink.querySelector('[aria-hidden="true"]');
+    expect(decorativeArrow?.textContent).toBe("←");
+  });
+
   it("アクションボタンが設定されていない場合、表示されない", () => {
     render(<EmptyState {...defaultProps} />);
 

--- a/src/components/common/__tests__/PostNavigation.test.tsx
+++ b/src/components/common/__tests__/PostNavigation.test.tsx
@@ -31,14 +31,22 @@ describe("PostNavigation", () => {
     const olderPost = createMockPost("20240101100000", "古い記事タイトル");
     const newerPost = createMockPost("20240103100000", "新しい記事タイトル");
 
-    renderInRouter(
+    const { container } = renderInRouter(
       <PostNavigation olderPost={olderPost} newerPost={newerPost} />,
     );
 
-    expect(screen.getByText("← 前の記事")).toBeInTheDocument();
+    // Issue #708: 矢印「←」「→」は aria-hidden な装飾 span に分離したため、
+    // ラベルテキストは矢印を含まない「前の記事」「次の記事」になる。
+    expect(screen.getByText("前の記事")).toBeInTheDocument();
     expect(screen.getByText("古い記事タイトル")).toBeInTheDocument();
-    expect(screen.getByText("次の記事 →")).toBeInTheDocument();
+    expect(screen.getByText("次の記事")).toBeInTheDocument();
     expect(screen.getByText("新しい記事タイトル")).toBeInTheDocument();
+
+    // 装飾矢印は aria-hidden で SR から隠される (#709 方式 b-1)。
+    const arrows = container.querySelectorAll('span[aria-hidden="true"]');
+    const arrowTexts = Array.from(arrows).map((el) => el.textContent);
+    expect(arrowTexts).toContain("←");
+    expect(arrowTexts).toContain("→");
 
     const links = screen.getAllByRole("link");
     expect(links[0]).toHaveAttribute("href", "/posts/20240101100000");
@@ -48,21 +56,37 @@ describe("PostNavigation", () => {
   it("古い記事のみの場合に新しい記事リンクが非表示になる", () => {
     const olderPost = createMockPost("20240101100000", "古い記事タイトル");
 
-    renderInRouter(<PostNavigation olderPost={olderPost} newerPost={null} />);
+    const { container } = renderInRouter(
+      <PostNavigation olderPost={olderPost} newerPost={null} />,
+    );
 
-    expect(screen.getByText("← 前の記事")).toBeInTheDocument();
+    expect(screen.getByText("前の記事")).toBeInTheDocument();
     expect(screen.getByText("古い記事タイトル")).toBeInTheDocument();
-    expect(screen.queryByText("次の記事 →")).not.toBeInTheDocument();
+    expect(screen.queryByText("次の記事")).not.toBeInTheDocument();
+
+    // 「前の記事」側の装飾矢印「←」のみが描画され、「→」は出ない。
+    const arrows = container.querySelectorAll('span[aria-hidden="true"]');
+    const arrowTexts = Array.from(arrows).map((el) => el.textContent);
+    expect(arrowTexts).toContain("←");
+    expect(arrowTexts).not.toContain("→");
   });
 
   it("新しい記事のみの場合に古い記事リンクが非表示になる", () => {
     const newerPost = createMockPost("20240103100000", "新しい記事タイトル");
 
-    renderInRouter(<PostNavigation olderPost={null} newerPost={newerPost} />);
+    const { container } = renderInRouter(
+      <PostNavigation olderPost={null} newerPost={newerPost} />,
+    );
 
-    expect(screen.queryByText("← 前の記事")).not.toBeInTheDocument();
-    expect(screen.getByText("次の記事 →")).toBeInTheDocument();
+    expect(screen.queryByText("前の記事")).not.toBeInTheDocument();
+    expect(screen.getByText("次の記事")).toBeInTheDocument();
     expect(screen.getByText("新しい記事タイトル")).toBeInTheDocument();
+
+    // 「次の記事」側の装飾矢印「→」のみが描画され、「←」は出ない。
+    const arrows = container.querySelectorAll('span[aria-hidden="true"]');
+    const arrowTexts = Array.from(arrows).map((el) => el.textContent);
+    expect(arrowTexts).toContain("→");
+    expect(arrowTexts).not.toContain("←");
   });
 
   it("両方nullの場合にコンポーネントが非表示になる", () => {

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -19,15 +19,19 @@ import { TableOfContents } from "../common/TableOfContents";
 // 文言調整の影響範囲をファイル内 1 箇所に局所化する。
 // (i18n フレームワークは導入しない方針 — 単純な template リテラルに留める)
 //
-// 矢印「←」はテキストの一部として 1 定数に連結したまま保持する。理由:
-// - 現状 JSX は `<Link>← TOPに戻る</Link>` の単一テキストノードで構成されており、
-//   矢印を別 span で装飾扱いしていない (= aria-hidden で SR から隠す構造ではない)。
-// - 連結のまま 1 定数化する方が JSX 側の変更を最小化でき、テンプレート文字列
-//   としての可読性も保たれる。
-// - 将来矢印をアイコンコンポーネント化する等の構造変更が入る場合は、その時点で
-//   再度分離を検討する (現時点では YAGNI)。
+// Issue #708: 矢印「←」をテキストから分離し、JSX 側で
+// `<span aria-hidden="true">{矢印}</span>` の装飾要素として描画する。
+// 連結 1 定数 (`"← TOPに戻る"`) から分離した理由:
+// - 再評価トリガー3 (同種の「矢印 + テキスト」ラベルが 3 箇所以上発生) が
+//   充足したため横断的に方針統一する (BackToTop / PostNavigation / Post と揃える)。
+// - 矢印を aria-hidden にすることで SR のアクセシブル名から外れる a11y 改善。
+// - 矢印を構造的に分離することが将来の i18n / RTL 対応の土台になる
+//   (実際の `[dir=rtl]` 反転 CSS は RTL 要件発生時まで先送り = YAGNI)。
+// 矢印は SVG / アイコンフォントではなく純粋な glyph のため BackToTop に倣い
+// `ICON` ではなく `ARROW` と命名する。
 const POST_DETAIL_NAV_ARIA_LABEL = "ページナビゲーション" as const;
-const POST_DETAIL_BACK_TO_TOP_LABEL = "← TOPに戻る" as const;
+const POST_DETAIL_BACK_TO_TOP_ARROW = "←" as const;
+const POST_DETAIL_BACK_TO_TOP_TEXT = "TOPに戻る" as const;
 
 /**
  * `/posts/:timestamp` ルートの `<title>` を組み立てる純粋関数
@@ -171,7 +175,12 @@ export const PostDetailPage = ({
           })}
         >
           <Link to="/" variant="navigation">
-            {POST_DETAIL_BACK_TO_TOP_LABEL}
+            {/* Issue #708: 矢印は aria-hidden な装飾要素として分離し、
+                アクセシブル名はテキスト「TOPに戻る」のみにする。
+                navigation variant は inline-flex + gap:sm のため矢印と
+                テキストの間隔は gap が担う (旧連結定数の半角スペース相当)。 */}
+            <span aria-hidden="true">{POST_DETAIL_BACK_TO_TOP_ARROW}</span>
+            {POST_DETAIL_BACK_TO_TOP_TEXT}
           </Link>
         </div>
       </nav>

--- a/src/components/pages/PostDetailPage.tsx
+++ b/src/components/pages/PostDetailPage.tsx
@@ -29,6 +29,15 @@ import { TableOfContents } from "../common/TableOfContents";
 //   (実際の `[dir=rtl]` 反転 CSS は RTL 要件発生時まで先送り = YAGNI)。
 // 矢印は SVG / アイコンフォントではなく純粋な glyph のため BackToTop に倣い
 // `ICON` ではなく `ARROW` と命名する。
+//
+// 「統一」したのは処理パターン (矢印を aria-hidden 分離する扱い) であって、
+// コードの共通化 (共有コンポーネント化 / 定数集約) はしない。根拠: (a) 矢印
+// `←`/`→`/`↑` は aria-hidden の装飾文字であり、装飾文字を i18nLiterals.ts へ
+// 集約しない先例がある (IndexRow.tsx の `INDEX_ROW_META_SEPARATOR = "—"` は
+// ローカル定数 / i18nLiterals.ts の「単一ファイル完結はファイル内局所定数」方針)。
+// (b) CLAUDE.md「過度に抽象化しない」+ 参照実装 BackToTop も矢印をローカル定数の
+// まま持つ。この根拠は本ファイル 1 箇所のみに記す (他 3 ファイルは #708 横断統一の
+// 記載から辿れるため重複させない)。
 const POST_DETAIL_NAV_ARIA_LABEL = "ページナビゲーション" as const;
 const POST_DETAIL_BACK_TO_TOP_ARROW = "←" as const;
 const POST_DETAIL_BACK_TO_TOP_TEXT = "TOPに戻る" as const;
@@ -178,7 +187,7 @@ export const PostDetailPage = ({
             {/* Issue #708: 矢印は aria-hidden な装飾要素として分離し、
                 アクセシブル名はテキスト「TOPに戻る」のみにする。
                 navigation variant は inline-flex + gap:sm のため矢印と
-                テキストの間隔は gap が担う (旧連結定数の半角スペース相当)。 */}
+                テキストの間隔は gap token が担う (旧連結時の半角スペースの代替)。 */}
             <span aria-hidden="true">{POST_DETAIL_BACK_TO_TOP_ARROW}</span>
             {POST_DETAIL_BACK_TO_TOP_TEXT}
           </Link>

--- a/src/components/pages/__tests__/PostDetailPage.test.tsx
+++ b/src/components/pages/__tests__/PostDetailPage.test.tsx
@@ -90,6 +90,48 @@ describe("PostDetailPage", () => {
     expect(backLink).toHaveAttribute("href", "/");
   });
 
+  it("戻りリンクのアクセシブル名から装飾矢印が除外される", () => {
+    // Issue #708: 矢印「←」を aria-hidden な装飾 span に分離したため、
+    // リンクのアクセシブル名は矢印を含まない「TOPに戻る」になる。
+    render(
+      <MemoryRouter>
+        <PostDetailPage
+          post={mockPost}
+          olderPost={null}
+          newerPost={null}
+          milestones={[]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "TOPに戻る" }),
+    ).toBeInTheDocument();
+    // 矢印付きの名前ではアクセシブル名として一致しないことも保証する。
+    expect(
+      screen.queryByRole("link", { name: "← TOPに戻る" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("戻りリンクの矢印が aria-hidden の装飾要素になる", () => {
+    // Issue #708 / #709 方式 b-1: 装飾矢印は HTML 文字列として保持しつつ
+    // aria-hidden で SR から隠す。リンク内にスコープして矢印 span を取得する。
+    render(
+      <MemoryRouter>
+        <PostDetailPage
+          post={mockPost}
+          olderPost={null}
+          newerPost={null}
+          milestones={[]}
+        />
+      </MemoryRouter>,
+    );
+
+    const backLink = screen.getByRole("link", { name: "TOPに戻る" });
+    const decorativeArrow = backLink.querySelector('[aria-hidden="true"]');
+    expect(decorativeArrow?.textContent).toBe("←");
+  });
+
   it("タイトルがない記事は「無題の記事」と表示される", () => {
     const postWithoutTitle: Post = {
       ...mockPost,

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -65,7 +65,17 @@ const MILESTONES: readonly Milestone[] = parseMilestones(milestonesData);
 const POST_NOT_FOUND_TITLE = "記事が見つかりません" as const;
 const POST_NOT_FOUND_DESCRIPTION =
   "お探しの記事は削除されたか、URLが間違っている可能性があります。" as const;
-const POST_NOT_FOUND_ACTION_LABEL = "← 記事一覧に戻る" as const;
+
+// Issue #708: 戻りリンクの矢印「←」をテキストから分離し、EmptyState の
+// action.label (ReactNode 化済み) に「aria-hidden な装飾矢印 + テキスト」を
+// 渡す。連結 1 定数 (`"← 記事一覧に戻る"`) から分離した理由は再評価トリガー3
+// (同種の「矢印 + テキスト」ラベルが 3 箇所以上発生) の充足に伴う横断統一で、
+// BackToTop / PostDetailPage / PostNavigation と方針を揃える。矢印を
+// aria-hidden にすることで SR のアクセシブル名から外れ、i18n / RTL 対応の
+// 構造的土台になる (実際の `[dir=rtl]` 反転 CSS は RTL 要件発生時まで先送り)。
+// 矢印は純粋な glyph のため BackToTop に倣い `ICON` ではなく `ARROW` と命名する。
+const POST_NOT_FOUND_ACTION_ARROW = "←" as const;
+const POST_NOT_FOUND_ACTION_TEXT = "記事一覧に戻る" as const;
 
 /**
  * 記事未検出時の `<title>` 文言 (React 19 ネイティブ metadata)。
@@ -101,7 +111,16 @@ const Post = () => {
           title={POST_NOT_FOUND_TITLE}
           description={POST_NOT_FOUND_DESCRIPTION}
           action={{
-            label: POST_NOT_FOUND_ACTION_LABEL,
+            // Issue #708: 矢印を aria-hidden な装飾要素として分離し、
+            // アクセシブル名はテキスト「記事一覧に戻る」のみにする。EmptyState の
+            // CTA Link は inline-flex + gap:2 のため矢印とテキストの間隔は gap が
+            // 担う (旧連結定数の半角スペース相当)。
+            label: (
+              <>
+                <span aria-hidden="true">{POST_NOT_FOUND_ACTION_ARROW}</span>
+                {POST_NOT_FOUND_ACTION_TEXT}
+              </>
+            ),
             href: "/",
           }}
         />

--- a/src/pages/posts/Post.tsx
+++ b/src/pages/posts/Post.tsx
@@ -113,8 +113,8 @@ const Post = () => {
           action={{
             // Issue #708: 矢印を aria-hidden な装飾要素として分離し、
             // アクセシブル名はテキスト「記事一覧に戻る」のみにする。EmptyState の
-            // CTA Link は inline-flex + gap:2 のため矢印とテキストの間隔は gap が
-            // 担う (旧連結定数の半角スペース相当)。
+            // CTA Link は inline-flex + gap:2 のため矢印とテキストの間隔は gap token
+            // が担う (旧連結時の半角スペースの代替)。
             label: (
               <>
                 <span aria-hidden="true">{POST_NOT_FOUND_ACTION_ARROW}</span>

--- a/src/pages/posts/__tests__/Post.test.tsx
+++ b/src/pages/posts/__tests__/Post.test.tsx
@@ -79,9 +79,38 @@ describe("Post", () => {
       ),
     ).toBeInTheDocument();
 
-    const backLink = screen.getByRole("link", { name: "← 記事一覧に戻る" });
+    // Issue #708: 矢印「←」を aria-hidden な装飾 span に分離したため、
+    // リンクのアクセシブル名は矢印を含まない「記事一覧に戻る」になる。
+    const backLink = screen.getByRole("link", { name: "記事一覧に戻る" });
     expect(backLink).toBeInTheDocument();
     expect(backLink).toHaveAttribute("href", "/");
+    // 矢印付きの名前ではアクセシブル名として一致しないことも保証する。
+    expect(
+      screen.queryByRole("link", { name: "← 記事一覧に戻る" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("記事未検出リンクの矢印が aria-hidden の装飾要素になる", () => {
+    // Issue #708 / #709 方式 b-1: 装飾矢印は HTML 文字列として保持しつつ
+    // aria-hidden で SR から隠す。リンク内にスコープして矢印 span を取得する。
+    vi.mocked(usePost).mockReturnValue({
+      post: null,
+      loading: false,
+      notFound: true,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/posts/123"]}>
+        <Routes>
+          <Route path="/posts/:timestamp" element={<Post />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const backLink = screen.getByRole("link", { name: "記事一覧に戻る" });
+    const decorativeArrow = backLink.querySelector('[aria-hidden="true"]');
+    expect(decorativeArrow?.textContent).toBe("←");
   });
 
   it("記事が見つからない場合は document.title を未検出フォールバックにできる", () => {


### PR DESCRIPTION
## 概要

記事詳細ページの戻りリンク「← TOPに戻る」など、コードベースに散在する「矢印 + テキスト」連結ラベルを、装飾矢印を `aria-hidden` な独立要素に分離する方式へ横断的に統一する。

Issue #708 の再評価トリガー3「同種の『矢印 + テキスト』ラベルがコードベース内に 3 箇所以上発生」が充足した（実際に 4 箇所: `BackToTop` / `PostDetailPage` / `PostNavigation` / `Post` 未検出）ことを受けた対応。既に矢印 `↑` を `aria-hidden` 分離済みの `BackToTop` を参照実装とし、Issue #709 の aria-hidden 装飾アサーション方針に整合させる。

効果:

- **a11y 改善**: 装飾矢印がスクリーンリーダーのアクセシブル名から外れる（例: 戻りリンクの名前が「← TOPに戻る」→「TOPに戻る」）。
- **i18n / RTL 対応の構造的土台**: 矢印を構造的に分離する。実際の `[dir=rtl]` 反転 CSS は RTL 要件発生時まで先送り（YAGNI、#819 で追跡）。
- **パターン統一**: 4 箇所を同一方式（矢印 = `aria-hidden` 装飾 / 可視テキスト = アクセシブル名）に揃える。

closes #708

## 変更内容

- `src/components/pages/PostDetailPage.tsx`: 戻りリンクの連結定数 `"← TOPに戻る"` を矢印定数 / テキスト定数に分離し、矢印を `<span aria-hidden="true">` で描画（間隔は navigation variant の `gap` が担う）。
- `src/components/common/PostNavigation.tsx`: 前後ナビの `← 前の記事` / `次の記事 →` をローカル `as const` 定数に外出しし、矢印を `aria-hidden` 分離（`display:block` のため間隔は明示の半角スペースで維持）。
- `src/pages/posts/Post.tsx`: 記事未検出 CTA `"← 記事一覧に戻る"` を分離し、矢印を `aria-hidden` 装飾として `EmptyState` に渡す。
- `src/components/common/EmptyState.tsx`: `action.label` の型を `string` → `ReactNode` に拡張（後方互換。用途を「CTA の短いラベル相当のノードのみ」に制約する JSDoc を付与）。
- `e2e/a11y/aria-structure.spec.ts`: 矢印が `aria-hidden` 化されアクセシブル名が「TOPに戻る」になったため、`toMatchAriaSnapshot` の期待値と関連コメントを更新。
- 各テスト: アクセシブル名から矢印が除外されること・矢印が `aria-hidden` 装飾であること（Issue #709 方式 b-1）の検証を追加 / 更新。

検証: `pnpm build`（lint + Vitest 1115 件 + 型チェック 3 種 + Panda + tsc + Vite）全 pass。Playwright e2e（`e2e/a11y/aria-structure.spec.ts`）も実ブラウザで 6 件 pass。

## 備考

- **非共通化の設計判断**: 矢印 `←`/`→`/`↑` は `aria-hidden` の装飾文字のため、共有コンポーネント化や `i18nLiterals.ts` への集約はせず各コンポーネントのローカル定数に留めた。装飾文字を集約しない先例（`IndexRow.tsx` の `INDEX_ROW_META_SEPARATOR = "—"`）および「過度に抽象化しない」方針に整合する（詳細は `PostDetailPage.tsx` のコメントに記載）。
- **RTL 反転 CSS は本 PR のスコープ外**（YAGNI）。i18n フレームワーク導入 / RTL 要件が発生したタイミングで対応する follow-up Issue #819 を起票済み。

<details>
<summary>Anchor 型を扱う PR のみチェック (Issue #556)</summary>

本 PR は `Coordinate` / `Elapsed` 等の Anchor 型を新規追加・変更しないため対象外。

</details>
