### PR TITLE
refactor: computeCoordinates の excludeHeavy を excludeTones へ拡張 (Issue #614)

### DIFF
--- a/src/components/common/Coordinate.tsx
+++ b/src/components/common/Coordinate.tsx
@@ -148,14 +148,16 @@ export const Coordinate = memo(
     //   `computeCoordinates` の責務に集約済み (Issue #532 / 案A)。
     //   表示層で `c.tone !== "heavy"` の filter を書くと、別の表示層
     //   (e.g. /anchor ページ = #493) で語彙が分散するリスクがあるため、
-    //   表示ポリシーをエンジン引数 (`excludeHeavy`) で表現する設計を採る。
+    //   表示ポリシーをエンジン引数 (`excludeTones`) で表現する設計を採る。
+    //   除外指定は Issue #614 で boolean フラグから集合指定 (`excludeTones`) へ
+    //   拡張されたが、本表示層の挙動 (heavy のみ除外) は不変。
     // - 戻り値は `readonly Coordinate[]` (現状単型) のため、`kind` の narrowing は
     //   ここでは不要。将来 `Coordinate | Elapsed` mixed union に拡張された場合は
     //   再度 narrowing を入れる (Issue #497 の discriminator 設計意図に対応)。
     const displayable: readonly CoordinateData[] = computeCoordinates(
       publishedAt,
       milestones,
-      { excludeHeavy: true },
+      { excludeTones: ["heavy"] },
     );
 
     if (displayable.length === 0) {

--- a/src/components/common/__tests__/Coordinate.allPosts.test.tsx
+++ b/src/components/common/__tests__/Coordinate.allPosts.test.tsx
@@ -66,7 +66,7 @@ interface CoordinateExpectation {
  *   import milestones from "../datasources/milestones.json";
  *   const id = "20260307120000"; // 追加した post.id
  *   const publishedAt = inferPublishedAt(id);
- *   const rows = computeCoordinates(publishedAt!, milestones as never, { excludeHeavy: true })
+ *   const rows = computeCoordinates(publishedAt!, milestones as never, { excludeTones: ["heavy"] })
  *     .map((c) => ({ label: c.label, daysSince: c.daysSince }));
  *   console.log(JSON.stringify({ postId: id, publishedAt, expectedRows: rows }, null, 2));
  *

--- a/src/components/common/__tests__/Coordinate.test.tsx
+++ b/src/components/common/__tests__/Coordinate.test.tsx
@@ -343,7 +343,7 @@ describe("Coordinate", () => {
     // 検出できない。境界 3 パターンを最小コストで axe 通過保証する。
     it("heavy 除外で表示件数が縮んだ状態でも axe a11y 違反が 0 件である", async () => {
       // 全節目が過去だが heavy (休職開始) は除外され、表示は neutral / light の
-      // 2 件に縮む構成。Coordinate 内部で `excludeHeavy: true` が効くため
+      // 2 件に縮む構成。Coordinate 内部で `excludeTones: ["heavy"]` が効くため
       // separator は 1 件のみ描画される (境界: 「heavy あり入力」 vs 「heavy なし出力」)
       const { container } = render(
         <Coordinate

--- a/src/lib/__tests__/anchors.test.ts
+++ b/src/lib/__tests__/anchors.test.ts
@@ -229,19 +229,21 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
   });
 
   /**
-   * Issue #532: 表示ポリシーをエンジン引数で表現する案 (案A) を採用したことで、
-   * `excludeHeavy` オプションの挙動を仕様としてここで固定する。
+   * Issue #532 / Issue #614: 表示ポリシーをエンジン引数で表現する案 (案A) を
+   * 採用し、当初 boolean の heavy 除外フラグだった除外指定を、将来の tone 追加に
+   * 備えて集合指定型 `excludeTones: readonly MilestoneTone[]` へ破壊的置換した
+   * (Issue #614)。`excludeTones` に含まれる tone を持つ節目を結果から除外する。
    *
    * 表示層 (`Coordinate.tsx`) で `c.tone !== "heavy"` を filter で書くと、
    * 別の表示層 (`/anchor` ページ = #493) で語彙が分散するリスクがあるため、
    * 「どの tone を除外するか」の責務は anchors モジュールに集約する。
    *
    * 既存呼び出し (AnchorPage.tsx / 既存テスト) は options 未指定で
-   * 「heavy を含めて返す」既定挙動が維持されること (= 後方互換) を
-   * 「options 未指定」「options.excludeHeavy: false」テストで固定する。
+   * 「全 tone を含めて返す」既定挙動が維持されること (= 後方互換) を
+   * 「options 未指定」「excludeTones: []」テストで固定する。
    */
-  describe("options.excludeHeavy: heavy 除外オプション (Issue #532)", () => {
-    it("options 未指定のとき heavy も含めて返す (既存挙動 = 後方互換)", () => {
+  describe("options.excludeTones: tone 除外オプション (Issue #532 / Issue #614)", () => {
+    it("options 未指定のとき全 tone を含めて返す (既存挙動 = 後方互換)", () => {
       const milestones: readonly Milestone[] = [
         { date: "2025-01-01", label: "中立", tone: "neutral" },
         { date: "2025-01-02", label: "軽め", tone: "light" },
@@ -256,7 +258,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       expect(result.map((c) => c.label)).toEqual(["中立", "軽め", "重い"]);
     });
 
-    it("options.excludeHeavy が false のとき heavy も含めて返す (明示指定)", () => {
+    it("excludeTones が空配列のとき全 tone を含めて返す (明示指定)", () => {
       const milestones: readonly Milestone[] = [
         { date: "2025-01-01", label: "中立", tone: "neutral" },
         { date: "2025-01-02", label: "軽め", tone: "light" },
@@ -265,14 +267,14 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       const result = computeCoordinates(
         "2025-02-01T12:00:00+09:00",
         milestones,
-        { excludeHeavy: false },
+        { excludeTones: [] },
       );
 
       expect(result).toHaveLength(3);
       expect(result.map((c) => c.label)).toEqual(["中立", "軽め", "重い"]);
     });
 
-    it("options.excludeHeavy が true のとき tone === 'heavy' を除外して返す", () => {
+    it("excludeTones に 'heavy' を指定すると tone === 'heavy' を除外して返す", () => {
       const milestones: readonly Milestone[] = [
         { date: "2025-01-01", label: "中立", tone: "neutral" },
         { date: "2025-01-02", label: "軽め", tone: "light" },
@@ -281,7 +283,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       const result = computeCoordinates(
         "2025-02-01T12:00:00+09:00",
         milestones,
-        { excludeHeavy: true },
+        { excludeTones: ["heavy"] },
       );
 
       expect(result).toHaveLength(2);
@@ -289,7 +291,24 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       expect(result.every((c) => c.tone !== "heavy")).toBe(true);
     });
 
-    it("excludeHeavy: true で全 milestone が heavy のときは空配列を返す", () => {
+    it("excludeTones に複数 tone を指定すると指定した全 tone を除外して返す (heavy / light 指定で neutral のみ残る)", () => {
+      const milestones: readonly Milestone[] = [
+        { date: "2025-01-01", label: "中立", tone: "neutral" },
+        { date: "2025-01-02", label: "軽め", tone: "light" },
+        { date: "2025-01-03", label: "重い", tone: "heavy" },
+      ];
+      const result = computeCoordinates(
+        "2025-02-01T12:00:00+09:00",
+        milestones,
+        { excludeTones: ["heavy", "light"] },
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result.map((c) => c.label)).toEqual(["中立"]);
+      expect(result.every((c) => c.tone === "neutral")).toBe(true);
+    });
+
+    it("excludeTones: ['heavy'] で全 milestone が heavy のときは空配列を返す", () => {
       const milestones: readonly Milestone[] = [
         { date: "2025-01-01", label: "重い1", tone: "heavy" },
         { date: "2025-01-02", label: "重い2", tone: "heavy" },
@@ -297,13 +316,13 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       const result = computeCoordinates(
         "2025-02-01T12:00:00+09:00",
         milestones,
-        { excludeHeavy: true },
+        { excludeTones: ["heavy"] },
       );
 
       expect(result).toEqual([]);
     });
 
-    it("excludeHeavy: true でも heavy 以外の入力順は保持される", () => {
+    it("excludeTones: ['heavy'] でも除外されない tone の入力順は保持される", () => {
       const milestones: readonly Milestone[] = [
         { date: "2025-01-05", label: "B", tone: "light" },
         { date: "2025-01-04", label: "X", tone: "heavy" },
@@ -313,13 +332,13 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       const result = computeCoordinates(
         "2025-02-01T12:00:00+09:00",
         milestones,
-        { excludeHeavy: true },
+        { excludeTones: ["heavy"] },
       );
 
       expect(result.map((c) => c.label)).toEqual(["B", "A", "C"]);
     });
 
-    it("excludeHeavy: true と未来除外は両立する (heavy かつ未来 / heavy かつ過去 / 未来 light / 過去 light)", () => {
+    it("excludeTones: ['heavy'] と未来除外は両立する (heavy かつ未来 / heavy かつ過去 / 未来 light / 過去 light)", () => {
       const milestones: readonly Milestone[] = [
         { date: "2025-01-01", label: "過去-light", tone: "light" },
         { date: "2025-01-02", label: "過去-heavy", tone: "heavy" },
@@ -329,7 +348,7 @@ describe("computeCoordinates: 層1=座標 (登録節目との差分日数)", () 
       const result = computeCoordinates(
         "2025-02-01T12:00:00+09:00",
         milestones,
-        { excludeHeavy: true },
+        { excludeTones: ["heavy"] },
       );
 
       expect(result).toHaveLength(1);

--- a/src/lib/anchors.ts
+++ b/src/lib/anchors.ts
@@ -253,36 +253,44 @@ export const todayInJst = (): string => {
 /**
  * `computeCoordinates` の動作オプション
  *
- * - `excludeHeavy`: true のとき、tone === "heavy" の節目を結果から **除外** する。
- *   未指定または false のときは heavy を含めて全 tone を返す (既存挙動)
+ * - `excludeTones`: 指定した tone を持つ節目を結果から **除外** する。
+ *   未指定または空配列のときは全 tone を返す (既存挙動)。
+ *   例: `["heavy"]` で heavy のみ除外 / `["heavy", "light"]` で neutral のみ残す
  *
- * 設計判断 (Issue #532):
- * - 「表示ポリシーをエンジン引数で表現する」案A を採用
+ * 設計判断 (Issue #532 → Issue #614):
+ * - 「表示ポリシーをエンジン引数で表現する」案A を採用 (Issue #532)
  * - 採用理由:
- *   1. **表示層ごとの再実装リスクを排除する**: heavy 除外を `Coordinate.tsx`
+ *   1. **表示層ごとの再実装リスクを排除する**: tone 除外を `Coordinate.tsx`
  *      側 (`c.tone !== "heavy"` の filter) で行うと、`/anchor` ページ (#493) など
  *      別の表示層で「heavy も含めて出したい」「heavy だけ除外したい」を分岐したい
  *      ときに `tone !== "heavy"` の語彙を表示層ごとに書き直すリスクがある
  *   2. **責務集約**: 「どの tone を除外するか」は表示ポリシーだが、`MilestoneTone`
  *      を知るのは anchors モジュールであり、表示層に enum 比較を漏らしたくない
- *   3. **API 互換性維持**: options は省略可能で、既存呼び出し
- *      (`AnchorPage.tsx` の heavy 含む呼び出し / 全テストケース) は無変更で動作する
+ *   3. **API 表面の単純化**: options は省略可能で、tone 指定なし (未指定 / 空配列)
+ *      の呼び出し (`AnchorPage.tsx` / 全 tone を出す経路) は素直に全件を返す
  * - 案B (ラッパー関数 `computeCoordinatesForDisplay` 追加) との比較: 同じ
  *   モジュールに似た名前の関数を2つ並べると「どちらを呼ぶべきか」の意思決定コストが
  *   表示層側に残る。options による単一関数化の方が API 表面が小さい
- * - 案C (現状維持) との比較: ドキュメントだけでは「呼び出し忘れ」「filter の語彙
- *   揺れ」を防げない (受け入れ基準は「いずれかを選択し判断根拠を明文化」なので
- *   案C も選択肢だが、構造的に再発防止できる案A を採用する)
+ *
+ * boolean → 集合指定への破壊的置換 (Issue #614):
+ * - 当初は「heavy を除外するか」を表す boolean フラグだったが、将来 tone が
+ *   増えたとき (例: `light` も状況により隠したい) に boolean フラグを tone ごとに
+ *   増やすと API が肥大化する。除外したい tone の **集合** を直接受ける
+ *   `excludeTones?: readonly MilestoneTone[]` へ拡張性のため置換した
+ * - `@deprecated` 二段移行 (旧 boolean フラグを当面残す案2) は採らない。
+ *   旧フラグの利用は内部の `Coordinate.tsx` 1 か所のみで外部公開 API では
+ *   なく、後方互換コストを払う意味がないため破壊的に置換する (「過剰抽象化を避ける」
+ *   方針と整合)
  */
 export interface ComputeCoordinatesOptions {
-  readonly excludeHeavy?: boolean;
+  readonly excludeTones?: readonly MilestoneTone[];
 }
 
 /**
  * 1 つの (milestone, publishedDate) ペアを評価し、Coordinate に変換する純粋関数。
  *
  * 戻り値が undefined の場合は以下のいずれかに該当する:
- *   - `excludeHeavy: true` で tone === "heavy" の節目だった
+ *   - `excludeTones` に含まれる tone の節目だった (Issue #614)
  *   - milestone.date の形式不正 (`toMilestoneCalendarDate` が null を返す)
  *   - publishedAt より後 (未来) の節目だった
  *
@@ -292,9 +300,9 @@ export interface ComputeCoordinatesOptions {
 const tryBuildCoordinate = (
   milestone: Milestone,
   publishedDate: Date,
-  excludeHeavy: boolean,
+  excludeTones: readonly MilestoneTone[],
 ): Coordinate | undefined => {
-  if (excludeHeavy && milestone.tone === "heavy") {
+  if (excludeTones.includes(milestone.tone)) {
     return undefined;
   }
   const milestoneDate = toMilestoneCalendarDate(milestone.date);
@@ -325,13 +333,13 @@ const tryBuildCoordinate = (
  * - 空配列が渡されたら空配列を返す
  * - Milestone.date の値範囲は検証せず、`Date.UTC` のロールオーバーを許容する
  *   (`toMilestoneCalendarDate` の JSDoc / テスト「Milestone.date 不正値の仕様」参照)
- * - `options.excludeHeavy` が true のとき、tone === "heavy" の節目を結果から
- *   除外する。未指定または false のときは heavy を含めて返す (Issue #532)
+ * - `options.excludeTones` に含まれる tone の節目を結果から除外する。未指定または
+ *   空配列のときは全 tone を含めて返す (Issue #532 → Issue #614 で集合指定型に拡張)
  *
  * Biome 厳格化耐性メモ (Issue #652 / PR #623 follow-up):
  * - 本関数は `maxAllowedComplexity:8` 厳格化条件下でも違反 0 になるよう、
  *   per-milestone の評価を `tryBuildCoordinate` ヘルパーへ抽出している。
- *   入力順保持 / 未来除外 / 形式不正除外 / excludeHeavy 除外の全仕様は
+ *   入力順保持 / 未来除外 / 形式不正除外 / excludeTones 除外の全仕様は
  *   既存 `anchors.test.ts` で固定済み。
  *
  * @param publishedAt - 記事の公開日時 (ISO 8601 文字列)
@@ -339,7 +347,7 @@ const tryBuildCoordinate = (
  * @param options - 表示ポリシーオプション (省略可能。詳細は
  *   `ComputeCoordinatesOptions` の JSDoc を参照)
  * @returns 各節目に対応する Coordinate の配列 (publishedAt より後の節目は除外。
- *   `excludeHeavy: true` 指定時はさらに heavy も除外)
+ *   `excludeTones` 指定時は該当 tone の節目もさらに除外)
  */
 export const computeCoordinates = (
   publishedAt: string,
@@ -347,11 +355,11 @@ export const computeCoordinates = (
   options?: ComputeCoordinatesOptions,
 ): readonly Coordinate[] => {
   const publishedDate = toJstCalendarDate(publishedAt);
-  const excludeHeavy = options?.excludeHeavy ?? false;
+  const excludeTones = options?.excludeTones ?? [];
 
   const coordinates: Coordinate[] = [];
   for (const milestone of milestones) {
-    const coordinate = tryBuildCoordinate(milestone, publishedDate, excludeHeavy);
+    const coordinate = tryBuildCoordinate(milestone, publishedDate, excludeTones);
     if (coordinate !== undefined) {
       coordinates.push(coordinate);
     }


### PR DESCRIPTION
## 概要

`computeCoordinates` の表示ポリシーオプションを `excludeHeavy?: boolean` から拡張性の高い `excludeTones?: readonly MilestoneTone[]` へ**破壊的置換**する (Issue #614 / #532 follow-up)。

Issue #614 は本来「`MilestoneTone` に新値が追加されたとき再評価する」deferral-record だが、トリガー（tone 追加）未充足の段階で**先行解決**する。変更は実質「boolean→集合指定」の型置換で抽象化コストがほぼゼロであり、boolean フラグを tone ごとに増やす (`excludeHeavy` / `excludeLight` …) よりも API 肥大化を事前に防ぐ正しい一般化方向と判断したため。これにより本 Issue は deferral → resolved とする。

Closes #614

## 変更内容

- `src/lib/anchors.ts`: `ComputeCoordinatesOptions.excludeHeavy?: boolean` を `excludeTones?: readonly MilestoneTone[]` へ置換。`tryBuildCoordinate` の除外判定を `excludeTones.includes(milestone.tone)` に変更し、`computeCoordinates` 本体は既定 `[]` を渡す。`@deprecated` 二段移行は不採用（利用は内部 `Coordinate.tsx` 1 か所のみで外部公開 API ではないため）。設計判断・系譜（#532 → #614）を JSDoc に明記
- `src/components/common/Coordinate.tsx`: 呼び出しを `{ excludeTones: ["heavy"] }` に変更（heavy 除外という表示挙動は不変）。周辺コメントも追従
- `src/lib/__tests__/anchors.test.ts`: describe を `excludeTones` 仕様へ書き換え。複数 tone 除外（heavy/light で neutral のみ残る）/ `excludeTones: []` が全件返す振る舞いをテスト追加。「未指定」「空配列」の後方互換 2 系統も固定
- `src/components/common/__tests__/Coordinate.test.tsx` / `Coordinate.allPosts.test.tsx`: コメント・JSDoc 内サンプルを `excludeTones` 表記へ追従

## 備考

- 後方互換: `AnchorPage.tsx` は options 無指定のままで全 tone 返却（挙動不変）。`Coordinate.tsx` は heavy のみ除外で従来挙動と一致。
- 検証: `pnpm lint` / `pnpm test:run`（1120 件）/ `pnpm exec tsc --noEmit` / `pnpm build` 全 pass。`excludeHeavy` 文字列残存 0 件。
- ローカルレビュー（Devil's Advocate / コードレビュー / セキュリティレビュー）で Blocking 指摘なし。
- Anchor 型チェックブロックは対象外（`Coordinate`/`Elapsed` を要素とする新フィールド追加はないため）。
