### PR TITLE
chore: parsePostDateToEpoch に月日時分の値範囲検証を追加 (Issue #812)

### DIFF
--- a/src/lib/__tests__/postDate.test.ts
+++ b/src/lib/__tests__/postDate.test.ts
@@ -48,6 +48,57 @@ describe("parsePostDateToEpoch", () => {
   it("ドット区切りに対し undefined を返す", () => {
     expect(parsePostDateToEpoch("2026.03.10")).toBeUndefined();
   });
+
+  it("月が 13 (範囲外) の入力に対し undefined を返す", () => {
+    expect(parsePostDateToEpoch("2026/13/01")).toBeUndefined();
+  });
+
+  it("月が 00 (範囲外) の入力に対し undefined を返す", () => {
+    expect(parsePostDateToEpoch("2026/00/01")).toBeUndefined();
+  });
+
+  it("日が 40 (範囲外) の入力に対し undefined を返す", () => {
+    expect(parsePostDateToEpoch("2026/01/40")).toBeUndefined();
+  });
+
+  it("日が 00 (範囲外) の入力に対し undefined を返す", () => {
+    expect(parsePostDateToEpoch("2026/01/00")).toBeUndefined();
+  });
+
+  it("時が 24 (範囲外) の入力に対し undefined を返す", () => {
+    expect(parsePostDateToEpoch("2026/01/01 24:00")).toBeUndefined();
+  });
+
+  it("分が 60 (範囲外) の入力に対し undefined を返す", () => {
+    expect(parsePostDateToEpoch("2026/01/01 12:60")).toBeUndefined();
+  });
+
+  it("月日時分が全て上限境界 (12/31 23:59) の入力に対し有効な epoch を返す", () => {
+    expect(parsePostDateToEpoch("2026/12/31 23:59")).toBe(
+      expectedJstEpoch(2026, 12, 31, 23, 59),
+    );
+  });
+
+  it("月日が下限境界 (01/01) の入力に対し有効な epoch を返す", () => {
+    expect(parsePostDateToEpoch("2026/01/01")).toBe(
+      expectedJstEpoch(2026, 1, 1, 0, 0),
+    );
+  });
+
+  it("時分が下限境界 (00:00) の入力に対し有効な epoch を返す", () => {
+    expect(parsePostDateToEpoch("2026/06/15 00:00")).toBe(
+      expectedJstEpoch(2026, 6, 15, 0, 0),
+    );
+  });
+
+  it("月に対し過大な日 (04/31) はロールオーバーに委ね有効な epoch を返す", () => {
+    // 日の検証は単純な 1-31 範囲のみで、月ごとの日数や閏年は判定しない (意図的な
+    // 現状維持)。4 月は 30 日までだが 31 は 1-31 範囲を通過し、Date.UTC により
+    // 翌月 1 日へロールオーバーする。
+    expect(parsePostDateToEpoch("2026/04/31")).toBe(
+      expectedJstEpoch(2026, 5, 1, 0, 0),
+    );
+  });
 });
 
 describe("isUpdatedAfterCreated", () => {
@@ -96,5 +147,13 @@ describe("isUpdatedAfterCreated", () => {
     // 同日加筆を「更新あり」として扱う挙動は意図的 (openQuestion #2 の決定)。
     // createdAt が日付のみ (= 00:00 とみなす) のため、同日でも時刻が後なら更新扱い。
     expect(isUpdatedAfterCreated("2026/03/10", "2026/03/10 09:30")).toBe(true);
+  });
+
+  it("updatedAt が範囲外値 (13 月) なら false を返す", () => {
+    // 比較層として、範囲外 updatedAt はパース不能 (undefined) 扱いになり、
+    // 隣接日時へのロールオーバー化けを起こさず false に落ちる。
+    expect(isUpdatedAfterCreated("2026/03/10 09:30", "2026/13/11 10:00")).toBe(
+      false,
+    );
   });
 });

--- a/src/lib/postDate.ts
+++ b/src/lib/postDate.ts
@@ -27,8 +27,9 @@ const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
  *   fixture `"2024-01-15"` との互換のため。運用データは全てスラッシュ)
  * - 時刻部 `(?:[ T]HH:MM)?` は省略可能 (省略時は 00:00 とみなす)。日付と時刻の
  *   区切りは半角スペースまたは `T` を許容する
- * - 各フィールドは桁数のみを検証し、月日時分の値範囲 (1-12 月等) は検証しない。
- *   範囲外値は `Date.UTC` のロールオーバーに委ねる (シンプルさ優先)
+ * - 本正規表現は **桁数のみ**を検証する。月日時分の値範囲 (1-12 月等) の検証は
+ *   `parsePostDateToEpoch` 側で行う (Issue #812 で追加。正規表現の受理形式自体は
+ *   変更せず、パース後に範囲チェックする方針)
  * - 1 つの値の中で区切りが混在するケース (`2026/03-10` 等) は実運用で発生しない
  *   ため受理する場合があるが、ドット区切り `2026.03.10` は桁の前後に許可文字が
  *   無いため確実に不一致 (`undefined`) になる
@@ -37,11 +38,31 @@ const POST_DATE_PATTERN =
   /^(\d{4})[/-](\d{2})[/-](\d{2})(?:[ T](\d{2}):(\d{2}))?$/;
 
 /**
+ * 値が指定範囲 (両端含む) の内側かどうかを判定する純粋関数。
+ *
+ * @param value 判定対象の数値
+ * @param min 下限 (この値を含む)
+ * @param max 上限 (この値を含む)
+ * @returns `min <= value <= max` なら `true`
+ */
+const isInRange = (value: number, min: number, max: number): boolean =>
+  value >= min && value <= max;
+
+/**
  * 投稿日時文字列を JST (+09:00) 固定で epoch(ms) に正規化する純粋関数。
+ *
+ * - 桁数マッチ (`POST_DATE_PATTERN`) 後、月日時分の値範囲を検証する (Issue #812)。
+ *   月 1-12 / 日 1-31 / 時 0-23 / 分 0-59 のいずれかが範囲外なら `undefined` を返す。
+ *   これにより `2026/13/40` や `24:00` 等の範囲外値が `Date.UTC` のロールオーバーで
+ *   隣接日時へ化けるのを防ぐ
+ * - 日の検証は **単純な 1-31 範囲のみ**で、月ごとの日数や閏年は判定しない (意図的な
+ *   現状維持・YAGNI)。そのため `2026/04/31` (4 月は 30 日まで) や `2026/02/30` の
+ *   ような「月に対し過大な日」は範囲検証を通過し、従来どおり `Date.UTC` の
+ *   ロールオーバーに委ねられる (翌月へ繰り上がる)
  *
  * @param value `YYYY/MM/DD HH:MM` / `YYYY-MM-DD HH:MM` 形式の文字列
  *   (時刻は省略可能で、省略時は 00:00 とみなす)
- * @returns 正規化した epoch(ms)。形式不一致の場合は `undefined`
+ * @returns 正規化した epoch(ms)。形式不一致または値範囲外の場合は `undefined`
  */
 export const parsePostDateToEpoch = (value: string): number | undefined => {
   const matched = POST_DATE_PATTERN.exec(value);
@@ -55,6 +76,16 @@ export const parsePostDateToEpoch = (value: string): number | undefined => {
   // 時刻省略時は 00:00 とみなす
   const hour = matched[4] === undefined ? 0 : Number(matched[4]);
   const minute = matched[5] === undefined ? 0 : Number(matched[5]);
+
+  // 月日時分の値範囲を検証する (日は 1-31 範囲のみ。月過大日はロールオーバーに委ねる)
+  if (
+    !isInRange(month, 1, 12) ||
+    !isInRange(day, 1, 31) ||
+    !isInRange(hour, 0, 23) ||
+    !isInRange(minute, 0, 59)
+  ) {
+    return undefined;
+  }
 
   // JST 壁時計時刻 → epoch は UTC 換算で 9 時間引く (JST は UTC+9 のため)
   return Date.UTC(year, month - 1, day, hour, minute) - JST_OFFSET_MS;


### PR DESCRIPTION
## 概要

比較専用パース層 `src/lib/postDate.ts` の `parsePostDateToEpoch` に**月日時分の値範囲検証**を追加する (Issue #812)。現状は桁数のみ検証し、範囲外値を `Date.UTC` のロールオーバーに委ねるため、`2026/13/40`（13月40日）や `24:00`・`12:60` が「パース成功」して隣接日時へ化けていた。これを防ぎ、比較層 (`isUpdatedAfterCreated`) を「不正データは更新扱いにしない」フェイルセーフ方向へ改善する。

Issue #812 の残りの観点（秒/TZ サフィックス対応・1値内区切り混在の厳密化・日の月ごと上限/閏年検証）は YAGNI のため本 PR のスコープ外とし、失わないよう follow-up Issue #836 へ分離した。

Closes #812

## 変更内容

- `src/lib/postDate.ts`: 桁数マッチ (`POST_DATE_PATTERN`) 成功後、月 1-12 / 日 1-31 / 時 0-23 / 分 0-59 を検証し、いずれか範囲外なら `undefined` を返す。可読性のため両端含む判定 `isInRange(value, min, max)` を小ヘルパーへ切り出し（日本語 JSDoc 付き）。正規表現の受理形式（桁数・区切り `/`・`-`）は**一切変更せず**、パース後段で範囲チェックする方針。`parsePostDateToEpoch` / `POST_DATE_PATTERN` の JSDoc を実態に更新し、「日は 1-31 範囲のみ・月過大日（`2026/04/31` 等）はロールオーバーに委ねる」残存仕様を明記
- `src/lib/__tests__/postDate.test.ts`: 範囲外値（13月/00月/40日/00日/24時/60分）が `undefined` になる振る舞い、上限境界 `12/31 23:59`・下限境界 `01/01`/`00:00` の正常系、月過大日 `04/31` のロールオーバー、`isUpdatedAfterCreated` 経由で範囲外 `updatedAt` が `false` に落ちる比較層挙動をテストとして追加

## 備考

- 後方互換: 範囲内の既存データ（記事 17 件の投稿日時・ISO 互換 fixture・時刻省略・区切り `/`/`-`）は従来どおり同一 epoch を返す。範囲検証は正常範囲内の値に一切影響しない。
- 検証: `pnpm lint` / `pnpm test:run`（1130 件）/ `pnpm exec tsc --noEmit` / `pnpm build` 全 pass。
- ローカルレビュー（Devil's Advocate / コードレビュー / セキュリティレビュー）で Blocking 指摘なし。
- Anchor 型チェックブロックは対象外（`Coordinate`/`Elapsed` を要素とする新フィールド追加はないため）。
