### PR TITLE
fix: 新記事追加に伴うテストfixtureの実データ同期

### DIFF
--- a/e2e/a11y/aria-structure.spec.ts
+++ b/e2e/a11y/aria-structure.spec.ts
@@ -36,7 +36,7 @@ import { expect, test } from "@playwright/test";
  * (最新記事) と同一 timestamp を採用し、e2e 全体で代表記事を揃える。
  */
 const HOME_PATH = "/";
-const POST_PATH = "/posts/20260624143000";
+const POST_PATH = "/posts/20260728134449";
 const ANCHOR_PATH = "/anchor";
 
 test.describe("ARIA 構造: ホーム (/)", () => {

--- a/e2e/a11y/violations.spec.ts
+++ b/e2e/a11y/violations.spec.ts
@@ -24,7 +24,7 @@ import { expect, test } from "@playwright/test";
  */
 const TARGETS = [
   { name: "home", path: "/" },
-  { name: "post-detail-latest", path: "/posts/20260624143000" },
+  { name: "post-detail-latest", path: "/posts/20260728134449" },
   { name: "post-detail-secondary", path: "/posts/20260307120000" },
   // /anchor は Footer の「サイトの読み方」入口でナビ統合された読者導線
   // (Issue #839)。読者面のためデフォルトで heavy を抑制した状態の DOM を

--- a/src/components/common/__tests__/Coordinate.allPosts.test.tsx
+++ b/src/components/common/__tests__/Coordinate.allPosts.test.tsx
@@ -205,6 +205,14 @@ const expectations: readonly CoordinateExpectation[] = [
       { label: "社会復帰", daysSince: 292 },
     ],
   },
+  {
+    postId: "20260728134449",
+    publishedAt: "2026-07-28T13:44:49+09:00",
+    expectedRows: [
+      { label: "サイト開設", daysSince: 336 },
+      { label: "社会復帰", daysSince: 326 },
+    ],
+  },
 ];
 
 // datasources/*.md のファイル名を動的列挙する。

--- a/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
+++ b/src/components/pages/__tests__/AnchorPage.allPosts.test.tsx
@@ -251,6 +251,15 @@ const expectations: readonly PostCoordinatesExpectation[] = [
       { label: "社会復帰", tone: "light", daysSince: 292 },
     ],
   },
+  {
+    postId: "20260728134449",
+    publishedAt: "2026-07-28T13:44:49+09:00",
+    expectedRows: [
+      { label: "休職開始", tone: "heavy", daysSince: 357 },
+      { label: "サイト開設", tone: "neutral", daysSince: 336 },
+      { label: "社会復帰", tone: "light", daysSince: 326 },
+    ],
+  },
 ];
 
 /**

--- a/src/lib/__tests__/anchors.test.ts
+++ b/src/lib/__tests__/anchors.test.ts
@@ -822,16 +822,16 @@ describe("Issue #489 AC: 実データ統合 (milestones.json × 全記事)", () 
     return isoList;
   };
 
-  it("datasources/*.md が 18 件存在する (AC 前提条件)", () => {
+  it("datasources/*.md が 19 件存在する (AC 前提条件)", () => {
     const publishedAts = collectPostPublishedAts();
-    expect(publishedAts.length).toBe(18);
+    expect(publishedAts.length).toBe(19);
   });
 
   it("milestones.json は 1 件以上の節目を持つ (AC 前提条件)", () => {
     expect(milestones.length).toBeGreaterThan(0);
   });
 
-  it("全 18 記事に対して computeCoordinates が例外を投げず配列を返す", () => {
+  it("全記事に対して computeCoordinates が例外を投げず配列を返す", () => {
     const publishedAts = collectPostPublishedAts();
     for (const publishedAt of publishedAts) {
       const result = computeCoordinates(publishedAt, milestones);
@@ -839,7 +839,7 @@ describe("Issue #489 AC: 実データ統合 (milestones.json × 全記事)", () 
     }
   });
 
-  it("全 18 記事の Coordinate 配列に undefined / null 要素が混入しない", () => {
+  it("全記事の Coordinate 配列に undefined / null 要素が混入しない", () => {
     const publishedAts = collectPostPublishedAts();
     for (const publishedAt of publishedAts) {
       const result = computeCoordinates(publishedAt, milestones);
@@ -850,7 +850,7 @@ describe("Issue #489 AC: 実データ統合 (milestones.json × 全記事)", () 
     }
   });
 
-  it("全 18 記事の Coordinate.daysSince が NaN にならず 0 以上の整数になる", () => {
+  it("全記事の Coordinate.daysSince が NaN にならず 0 以上の整数になる", () => {
     const publishedAts = collectPostPublishedAts();
     for (const publishedAt of publishedAts) {
       const result = computeCoordinates(publishedAt, milestones);
@@ -862,7 +862,7 @@ describe("Issue #489 AC: 実データ統合 (milestones.json × 全記事)", () 
     }
   });
 
-  it("全 18 記事の Coordinate.tone が MilestoneTone の値域に収まる", () => {
+  it("全記事の Coordinate.tone が MilestoneTone の値域に収まる", () => {
     const allowedTones: readonly string[] = ["neutral", "light", "heavy"];
     const publishedAts = collectPostPublishedAts();
     for (const publishedAt of publishedAts) {
@@ -873,7 +873,7 @@ describe("Issue #489 AC: 実データ統合 (milestones.json × 全記事)", () 
     }
   });
 
-  it("全 18 記事の Coordinate.kind が discriminator 'coordinate' になる", () => {
+  it("全記事の Coordinate.kind が discriminator 'coordinate' になる", () => {
     const publishedAts = collectPostPublishedAts();
     for (const publishedAt of publishedAts) {
       const result = computeCoordinates(publishedAt, milestones);

--- a/src/lib/__tests__/resurface.test.ts
+++ b/src/lib/__tests__/resurface.test.ts
@@ -293,11 +293,11 @@ describe("selectResurfaced: 既存の全記事の実データに対する分岐"
       .sort((a, b) => b.id.localeCompare(a.id));
   };
 
-  it("today=2026-08-22 では最新記事 (2026-06-24) から 59 日経過のため沈黙トリガーが発火する", () => {
+  it("today=2026-08-28 では最新記事 (2026-07-28) から 31 日経過のため沈黙トリガーが発火する", () => {
     const posts = loadRealPostSummaries();
     expect(posts.length).toBeGreaterThanOrEqual(16);
 
-    const result = selectResurfaced(posts, [], "2026-08-22");
+    const result = selectResurfaced(posts, [], "2026-08-28");
 
     expect(result).not.toBeNull();
     expect(result?.reason.kind).toBe("silence");
@@ -314,15 +314,15 @@ describe("selectResurfaced: 既存の全記事の実データに対する分岐"
     expect(result).toBeNull();
   });
 
-  it("today=2026-08-26 (沈黙 & 1年前 2025-08-26 に記事あり) では沈黙が暦の節目より優先される", () => {
+  it("today=2026-08-27 (沈黙 & 1年前 2025-08-27 に記事あり) では沈黙が暦の節目より優先される", () => {
     const posts = loadRealPostSummaries();
-    // 最新の 2026-06-24 から today までの日数を確認
-    // 2026-06-24 から 2026-08-26 は 63 日経過 → 沈黙トリガー (>=30) が先に発火
-    // ※ 1年前 (2025-08-26 = 最古記事) の同月同日記事も存在するが、沈黙が優先される
-    const result = selectResurfaced(posts, [], "2026-08-26");
+    // 最新の 2026-07-28 から today までの日数を確認
+    // 2026-07-28 から 2026-08-27 は 30 日経過 → 沈黙トリガー (>=30) が先に発火
+    // ※ 1年前 (2025-08-27) の同月同日記事も存在するが、沈黙が優先される
+    const result = selectResurfaced(posts, [], "2026-08-27");
 
     expect(result).not.toBeNull();
-    // 沈黙が優先される (lastPostDaysAgo > 30)
+    // 沈黙が優先される (lastPostDaysAgo >= 30)
     expect(result?.reason.kind).toBe("silence");
   });
 });
@@ -441,7 +441,7 @@ describe("selectResurfaced: options.excludeIds (View Transition 名前衝突回�
     expect(result?.post.id).toBe("20240401120000");
   });
 
-  it("実データ (全記事) で today=2026-08-22、最古記事 id を excludeIds に渡すと別記事 or null になる", () => {
+  it("実データ (全記事) で today=2026-08-28、最古記事 id を excludeIds に渡すと別記事 or null になる", () => {
     // datasources から実データ全記事を読む。最古は 20250826031705。
     // 既定では沈黙トリガーで最古 (20250826031705) が選定される (1年前候補が無いため)。
     // この id を excludeIds に渡すと、フォールバックの最古が無くなるので
@@ -454,10 +454,10 @@ describe("selectResurfaced: options.excludeIds (View Transition 名前衝突回�
       .map((file) => makePost(file.replace(".md", "")))
       .sort((a, b) => b.id.localeCompare(a.id));
 
-    const defaultResult = selectResurfaced(posts, [], "2026-08-22");
+    const defaultResult = selectResurfaced(posts, [], "2026-08-28");
     expect(defaultResult?.post.id).toBe("20250826031705");
 
-    const excludedResult = selectResurfaced(posts, [], "2026-08-22", {
+    const excludedResult = selectResurfaced(posts, [], "2026-08-28", {
       excludeIds: ["20250826031705"],
     });
     expect(excludedResult).not.toBeNull();


### PR DESCRIPTION
## 概要

PR #878 で記事 `datasources/20260728134449.md`（19件目、「また夏が来て、そろそろ1年」）を追加した際、記事集合をハードコードしている複数のテストで実データとの同期作業が漏れており、CI ([run 30365649049](https://github.com/amkkr/lazy-note/actions/runs/30365649049/job/90296082322)) が6件のテストで失敗していました。本PRはそのfixture同期作業のみを行うものです（実装コードの変更なし）。

## 変更内容

- `src/lib/__tests__/anchors.test.ts`: `datasources/*.md` の件数アサーションを18→19件に更新。件数依存の describe/it 名 (「全18記事」) は今後のdriftを防ぐため件数非依存表現 (「全記事」) に書き換え
- `src/components/common/__tests__/Coordinate.allPosts.test.tsx`: 新記事 `20260728134449` の `expectedRows`（heavy除外、サイト開設336日/社会復帰326日）を `computeCoordinates` を実行して検算しfixtureに追記
- `src/components/pages/__tests__/AnchorPage.allPosts.test.tsx`: 新記事 `20260728134449` の `expectedRows`（heavy含む全節目: 休職開始357日/サイト開設336日/社会復帰326日）を検算しfixtureに追記
- `src/lib/__tests__/resurface.test.ts`: 新しい最新記事 (2026-07-28) を基準に `today` 値を再導出し、沈黙トリガー発火/暦の節目との優先順位/excludeIdsフォールバックの検証意図を保ったまま実データに追従させた
- `e2e/a11y/violations.spec.ts`, `e2e/a11y/aria-structure.spec.ts`: 代表記事 (`post-detail-latest` / `POST_PATH`) を新記事 `20260728134449` に更新

## 備考

- `pnpm test:run`（1172件）/ `pnpm lint` / `pnpm run type-check` / `pnpm run build` すべて成功を確認済み。
- 新記事 `datasources/20260728134449.md` は `## 投稿日時` セクション (`2026/07/28 22:44`) とファイル名タイムスタンプ (`2026-07-28 13:44:49`) の時刻が9時間ずれている（直近数記事は一致していた）。日次粒度の `daysSince` 計算には影響しないため本PRのスコープ外としたが、記事メタデータ側の入力ミスの可能性があるため別途確認を推奨。

<details>
<summary>Anchor 型を扱う PR のみチェック (Issue #556)</summary>

本PRはテストfixtureの値更新のみで、`Coordinate` / `Elapsed` 型宣言や `IgnitionInput` の変更は含まないため対象外。

</details>